### PR TITLE
fix: implement safe retrieval of component classes from registry

### DIFF
--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -51,9 +51,9 @@ from django_components.dependencies import (
     cache_component_css_vars,
     cache_component_js,
     cache_component_js_vars,
+    comp_hash_mapping,
     postprocess_component_html,
     set_component_attrs_for_js_and_css,
-    comp_hash_mapping,
 )
 from django_components.node import BaseNode
 from django_components.perfutil.component import component_post_render
@@ -72,7 +72,7 @@ from django_components.slots import (
 )
 from django_components.template import cached_template
 from django_components.util.django_monkeypatch import is_template_cls_patched
-from django_components.util.misc import hash_comp_cls, gen_id
+from django_components.util.misc import gen_id, hash_comp_cls
 from django_components.util.template_tag import TagAttr
 from django_components.util.validation import validate_typed_dict, validate_typed_tuple
 

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -1,4 +1,3 @@
-import inspect
 import types
 from collections import deque
 from contextlib import contextmanager
@@ -54,6 +53,7 @@ from django_components.dependencies import (
     cache_component_js_vars,
     postprocess_component_html,
     set_component_attrs_for_js_and_css,
+    comp_hash_mapping,
 )
 from django_components.node import BaseNode
 from django_components.perfutil.component import component_post_render
@@ -72,7 +72,7 @@ from django_components.slots import (
 )
 from django_components.template import cached_template
 from django_components.util.django_monkeypatch import is_template_cls_patched
-from django_components.util.misc import gen_id
+from django_components.util.misc import hash_comp_cls, gen_id
 from django_components.util.template_tag import TagAttr
 from django_components.util.validation import validate_typed_dict, validate_typed_tuple
 
@@ -499,7 +499,7 @@ class Component(
     However, there's a few differences from Django's Media class:
 
     1. Our Media class accepts various formats for the JS and CSS files: either a single file, a list,
-       or (CSS-only) a dictonary (See [`ComponentMediaInput`](../api#django_components.ComponentMediaInput)).
+       or (CSS-only) a dictionary (See [`ComponentMediaInput`](../api#django_components.ComponentMediaInput)).
     2. Individual JS / CSS files can be any of `str`, `bytes`, `Path`,
        [`SafeString`](https://dev.to/doridoro/django-safestring-afj), or a function
        (See [`ComponentMediaInputPath`](../api#django_components.ComponentMediaInputPath)).
@@ -556,7 +556,7 @@ class Component(
     # MISC
     # #####################################
 
-    _class_hash: ClassVar[int]
+    _class_hash: ClassVar[str]
 
     def __init__(
         self,
@@ -587,7 +587,8 @@ class Component(
         self._types: Optional[Union[Tuple[Any, Any, Any, Any, Any, Any], Literal[False]]] = None
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
-        cls._class_hash = hash(inspect.getfile(cls) + cls.__name__)
+        cls._class_hash = hash_comp_cls(cls)
+        comp_hash_mapping[cls._class_hash] = cls
 
     @property
     def name(self) -> str:
@@ -627,7 +628,7 @@ class Component(
     @property
     def input(self) -> RenderInput[ArgsType, KwargsType, SlotsType]:
         """
-        Input holds the data (like arg, kwargs, slots) that were passsed to
+        Input holds the data (like arg, kwargs, slots) that were passed to
         the current execution of the `render` method.
         """
         if not len(self._render_stack):

--- a/src/django_components/dependencies.py
+++ b/src/django_components/dependencies.py
@@ -1013,7 +1013,9 @@ def cached_script_view(
     if req.method != "GET":
         return HttpResponseNotAllowed(["GET"])
 
-    comp_cls = comp_hash_mapping[comp_cls_hash]
+    comp_cls = comp_hash_mapping.get(comp_cls_hash)
+    if comp_cls is None:
+        return HttpResponseNotFound()
 
     script = get_script_content(script_type, comp_cls, input_hash)
     if script is None:

--- a/src/django_components/dependencies.py
+++ b/src/django_components/dependencies.py
@@ -342,6 +342,7 @@ def _insert_component_comment(
     output = mark_safe(COMPONENT_DEPS_COMMENT.format(data=data) + content)
     return output
 
+
 # Anything and everything that needs to be done with a Component's HTML
 # script in order to support running JS and CSS per-instance.
 def postprocess_component_html(

--- a/src/django_components/util/misc.py
+++ b/src/django_components/util/misc.py
@@ -1,7 +1,6 @@
-from hashlib import md5
 import re
-from typing import Any, Callable, List, Optional, Type, TypeVar, TYPE_CHECKING
-
+from hashlib import md5
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Type, TypeVar
 
 from django_components.util.nanoid import generate
 

--- a/src/django_components/util/misc.py
+++ b/src/django_components/util/misc.py
@@ -1,7 +1,13 @@
+from functools import lru_cache
+from hashlib import md5
 import re
-from typing import Any, Callable, List, Optional, Type, TypeVar
+from typing import Any, Callable, List, Optional, Type, TypeVar, TYPE_CHECKING
+
 
 from django_components.util.nanoid import generate
+
+if TYPE_CHECKING:
+    from django_components.component import Component
 
 T = TypeVar("T")
 
@@ -71,3 +77,10 @@ def get_last_index(lst: List, key: Callable[[Any], bool]) -> Optional[int]:
 
 def is_nonempty_str(txt: Optional[str]) -> bool:
     return txt is not None and bool(txt.strip())
+
+
+@lru_cache(None)
+def hash_comp_cls(comp_cls: Type["Component"]) -> str:
+    full_name = get_import_path(comp_cls)
+    comp_cls_hash = md5(full_name.encode()).hexdigest()[0:6]
+    return comp_cls.__name__ + "_" + comp_cls_hash

--- a/src/django_components/util/misc.py
+++ b/src/django_components/util/misc.py
@@ -79,7 +79,6 @@ def is_nonempty_str(txt: Optional[str]) -> bool:
     return txt is not None and bool(txt.strip())
 
 
-@lru_cache(None)
 def hash_comp_cls(comp_cls: Type["Component"]) -> str:
     full_name = get_import_path(comp_cls)
     comp_cls_hash = md5(full_name.encode()).hexdigest()[0:6]

--- a/src/django_components/util/misc.py
+++ b/src/django_components/util/misc.py
@@ -1,4 +1,3 @@
-from functools import lru_cache
 from hashlib import md5
 import re
 from typing import Any, Callable, List, Optional, Type, TypeVar, TYPE_CHECKING


### PR DESCRIPTION
To illustrate a possible fix of #930

EDIT:

I think this is decent by now.

I'm not sure how I could write a test for this, at least not in a way which would provoke the error from the issue above without a disproportionate amount of work, but all tests pass and many of them rely on this logic working.