### PR TITLE
refactor: fix component recursion

### DIFF
--- a/sampleproject/components/recursive.py
+++ b/sampleproject/components/recursive.py
@@ -1,0 +1,31 @@
+from typing import Any, Dict
+
+from django_components import Component, register, types
+
+
+@register("recursive")
+class Recursive(Component):
+    def get(self, request):
+        import time
+        time_before = time.time()
+        output = self.render_to_response(
+            kwargs={
+                "depth": 0,
+            },
+        )
+        time_after = time.time()
+        print("TIME: ", time_after - time_before)
+        return output
+
+    def get_context_data(self, depth: int = 0) -> Dict[str, Any]:
+        return {"depth": depth + 1}
+
+    template: types.django_html = """
+        <div id="recursive">
+            depth: {{ depth }}
+            <hr/>
+            {% if depth <= 100 %}
+                {% component "recursive" depth=depth / %}
+            {% endif %}
+        </div>
+    """

--- a/sampleproject/components/urls.py
+++ b/sampleproject/components/urls.py
@@ -2,6 +2,7 @@ from components.calendar.calendar import Calendar, CalendarRelative
 from components.fragment import FragAlpine, FragJs, FragmentBaseAlpine, FragmentBaseHtmx, FragmentBaseJs
 from components.greeting import Greeting
 from components.nested.calendar.calendar import CalendarNested
+from components.recursive import Recursive
 from django.urls import path
 
 urlpatterns = [
@@ -9,6 +10,7 @@ urlpatterns = [
     path("calendar/", Calendar.as_view(), name="calendar"),
     path("calendar-relative/", CalendarRelative.as_view(), name="calendar-relative"),
     path("calendar-nested/", CalendarNested.as_view(), name="calendar-nested"),
+    path("recursive/", Recursive.as_view(), name="recursive"),
     path("fragment/base/alpine", FragmentBaseAlpine.as_view()),
     path("fragment/base/htmx", FragmentBaseHtmx.as_view()),
     path("fragment/base/js", FragmentBaseJs.as_view()),

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -27,10 +27,10 @@ from typing import (
 from django.core.exceptions import ImproperlyConfigured
 from django.forms.widgets import Media as MediaCls
 from django.http import HttpRequest, HttpResponse
-from django.template.base import NodeList, Parser, Template, TextNode, Token
+from django.template.base import NodeList, Origin, Parser, Template, TextNode, Token
 from django.template.context import Context, RequestContext
 from django.template.loader import get_template
-from django.template.loader_tags import BLOCK_CONTEXT_KEY
+from django.template.loader_tags import BLOCK_CONTEXT_KEY, BlockContext
 from django.test.signals import template_rendered
 from django.utils.html import conditional_escape
 from django.views import View
@@ -39,26 +39,24 @@ from django_components.app_settings import ContextBehavior
 from django_components.component_media import ComponentMediaInput, ComponentMediaMeta
 from django_components.component_registry import ComponentRegistry
 from django_components.component_registry import registry as registry_
-from django_components.context import (
-    _COMPONENT_SLOT_CTX_CONTEXT_KEY,
-    _REGISTRY_CONTEXT_KEY,
-    _ROOT_CTX_CONTEXT_KEY,
-    get_injected_context_var,
-    make_isolated_context_copy,
-)
+from django_components.context import _COMPONENT_CONTEXT_KEY, make_isolated_context_copy
 from django_components.dependencies import (
     RenderType,
     cache_component_css,
     cache_component_css_vars,
     cache_component_js,
     cache_component_js_vars,
-    postprocess_component_html,
+    insert_component_dependencies_comment,
+)
+from django_components.dependencies import render_dependencies as _render_dependencies
+from django_components.dependencies import (
     set_component_attrs_for_js_and_css,
 )
 from django_components.node import BaseNode
-from django_components.perfutil.component import component_post_render
+from django_components.perfutil.component import ComponentRenderer, component_context_cache, component_post_render
+from django_components.perfutil.provide import register_provide_reference, unregister_provide_reference
+from django_components.provide import get_injected_context_var
 from django_components.slots import (
-    ComponentSlotContext,
     Slot,
     SlotContent,
     SlotFunc,
@@ -71,8 +69,11 @@ from django_components.slots import (
     resolve_fills,
 )
 from django_components.template import cached_template
+from django_components.util.context import snapshot_context
 from django_components.util.django_monkeypatch import is_template_cls_patched
-from django_components.util.misc import gen_id
+from django_components.util.exception import component_error_message
+from django_components.util.logger import trace_component_msg
+from django_components.util.misc import gen_id, get_import_path
 from django_components.util.template_tag import TagAttr
 from django_components.util.validation import validate_typed_dict, validate_typed_tuple
 
@@ -99,7 +100,6 @@ CssDataType = TypeVar("CssDataType", bound=Mapping[str, Any])
 
 @dataclass(frozen=True)
 class RenderInput(Generic[ArgsType, KwargsType, SlotsType]):
-    id: str
     context: Context
     args: ArgsType
     kwargs: KwargsType
@@ -109,7 +109,8 @@ class RenderInput(Generic[ArgsType, KwargsType, SlotsType]):
 
 
 @dataclass()
-class RenderStackItem(Generic[ArgsType, KwargsType, SlotsType]):
+class MetadataItem(Generic[ArgsType, KwargsType, SlotsType]):
+    render_id: str
     input: RenderInput[ArgsType, KwargsType, SlotsType]
     is_filled: Optional[SlotIsFilled]
 
@@ -216,6 +217,21 @@ class ComponentView(View, metaclass=ComponentViewMeta):
     def __init__(self, component: "Component", **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.component = component
+
+
+# Internal data that are made available within the component's template
+@dataclass
+class ComponentContext:
+    component_name: str
+    component_id: str
+    component_class: Type["Component"]
+    component_path: List[str]
+    template_name: Optional[str]
+    is_dynamic_component: bool
+    default_slot: Optional[str]
+    fills: Dict[SlotName, Slot]
+    outer_context: Optional[Context]
+    registry: ComponentRegistry
 
 
 class Component(
@@ -580,14 +596,20 @@ class Component(
         self.as_view = types.MethodType(self.__class__.as_view.__func__, self)  # type: ignore
 
         self.registered_name: Optional[str] = registered_name
-        self.outer_context: Context = outer_context or Context()
+        self.outer_context: Optional[Context] = outer_context
         self.registry = registry or registry_
-        self._render_stack: Deque[RenderStackItem[ArgsType, KwargsType, SlotsType]] = deque()
+        self._metadata_stack: Deque[MetadataItem[ArgsType, KwargsType, SlotsType]] = deque()
         # None == uninitialized, False == No types, Tuple == types
         self._types: Optional[Union[Tuple[Any, Any, Any, Any, Any, Any], Literal[False]]] = None
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         cls._class_hash = hash(inspect.getfile(cls) + cls.__name__)
+
+    @contextmanager
+    def _with_metadata(self, item: MetadataItem) -> Generator[None, None, None]:
+        self._metadata_stack.append(item)
+        yield
+        self._metadata_stack.pop()
 
     @property
     def name(self) -> str:
@@ -622,7 +644,13 @@ class Component(
         # Rendering 'ab3c4d'
         ```
         """
-        return self.input.id
+        if not len(self._metadata_stack):
+            raise RuntimeError(
+                f"{self.name}: Tried to access Component's `id` attribute " "while outside of rendering execution"
+            )
+
+        ctx = self._metadata_stack[-1]
+        return ctx.render_id
 
     @property
     def input(self) -> RenderInput[ArgsType, KwargsType, SlotsType]:
@@ -630,12 +658,12 @@ class Component(
         Input holds the data (like arg, kwargs, slots) that were passsed to
         the current execution of the `render` method.
         """
-        if not len(self._render_stack):
+        if not len(self._metadata_stack):
             raise RuntimeError(f"{self.name}: Tried to access Component input while outside of rendering execution")
 
         # NOTE: Input is managed as a stack, so if `render` is called within another `render`,
         # the propertes below will return only the inner-most state.
-        return self._render_stack[-1].input
+        return self._metadata_stack[-1].input
 
     @property
     def is_filled(self) -> SlotIsFilled:
@@ -645,13 +673,13 @@ class Component(
         This attribute is available for use only within the template as `{{ component_vars.is_filled.slot_name }}`,
         and within `on_render_before` and `on_render_after` hooks.
         """
-        if not len(self._render_stack):
+        if not len(self._metadata_stack):
             raise RuntimeError(
                 f"{self.name}: Tried to access Component's `is_filled` attribute "
                 "while outside of rendering execution"
             )
 
-        ctx = self._render_stack[-1]
+        ctx = self._metadata_stack[-1]
         if ctx.is_filled is None:
             raise RuntimeError(
                 f"{self.name}: Tried to access Component's `is_filled` attribute " "before slots were resolved"
@@ -665,7 +693,7 @@ class Component(
     #
     #       This is important to keep in mind, because the implication is that we should
     #       treat Templates AND their nodelists as IMMUTABLE.
-    def _get_template(self, context: Context) -> Template:
+    def _get_template(self, context: Context, component_id: str) -> Template:
         template_name = self.get_template_name(context)
         # TODO_REMOVE_IN_V1 - Remove `self.get_template_string` in v1
         template_getter = getattr(self, "get_template_string", self.get_template)
@@ -699,9 +727,11 @@ class Component(
         if template_body is not None:
             # We got template string, so we convert it to Template
             if isinstance(template_body, str):
+                trace_component_msg("COMP_LOAD", component_name=self.name, component_id=component_id, slot_name=None)
                 template: Template = cached_template(
                     template_string=template_body,
-                    name=self.template_file,
+                    name=self.template_file or self.name,
+                    origin=Origin(name=self.template_file or get_import_path(self.__class__)),
                 )
             else:
                 template = template_body
@@ -928,36 +958,14 @@ class Component(
         render_dependencies: bool = True,
         request: Optional[HttpRequest] = None,
     ) -> str:
-        try:
-            return self._render_impl(
-                context, args, kwargs, slots, escape_slots_content, type, render_dependencies, request
-            )
-        except Exception as err:
-            # Nicely format the error message to include the component path.
-            # E.g.
-            # ```
-            # KeyError: "An error occured while rendering components ProjectPage > ProjectLayoutTabbed >
-            # Layout > RenderContextProvider > Base > TabItem:
-            # Component 'TabItem' tried to inject a variable '_tab' before it was provided.
-            # ```
-
-            if not hasattr(err, "_components"):
-                err._components = []  # type: ignore[attr-defined]
-
-            components = getattr(err, "_components", [])
-
-            # Access the exception's message, see https://stackoverflow.com/a/75549200/9788634
-            if not components:
-                orig_msg = err.args[0]
-            else:
-                orig_msg = err.args[0].split("\n", 1)[1]
-
-            components.insert(0, self.name)
-            comp_path = " > ".join(components)
-            prefix = f"An error occured while rendering components {comp_path}:\n"
-
-            err.args = (prefix + orig_msg,)  # tuple of one
-            raise err
+        # Modify the error to display full component path (incl. slots)
+        with component_error_message([self.name]):
+            try:
+                return self._render_impl(
+                    context, args, kwargs, slots, escape_slots_content, type, render_dependencies, request
+                )
+            except Exception as err:
+                raise err from None
 
     def _render_impl(
         self,
@@ -989,28 +997,83 @@ class Component(
 
         # Required for compatibility with Django's {% extends %} tag
         # See https://github.com/django-components/django-components/pull/859
-        context.render_context.push({BLOCK_CONTEXT_KEY: context.render_context.get(BLOCK_CONTEXT_KEY, {})})
+        context.render_context.push({BLOCK_CONTEXT_KEY: context.render_context.get(BLOCK_CONTEXT_KEY, BlockContext())})
 
         # By adding the current input to the stack, we temporarily allow users
         # to access the provided context, slots, etc. Also required so users can
         # call `self.inject()` from within `get_context_data()`.
+        #
+        # This is handled as a stack, as users can potentially call `component.render()`
+        # from within component hooks. Thus, then they do so, `component.id` will be the ID
+        # of the deepest-most call to `component.render()`.
         render_id = gen_id()
-        self._render_stack.append(
-            RenderStackItem(
-                input=RenderInput(
-                    id=render_id,
-                    context=context,
-                    slots=slots,
-                    args=args,
-                    kwargs=kwargs,
-                    type=type,
-                    render_dependencies=render_dependencies,
-                ),
-                is_filled=None,
+        metadata = MetadataItem(
+            render_id=render_id,
+            input=RenderInput(
+                context=context,
+                slots=slots,
+                args=args,
+                kwargs=kwargs,
+                type=type,
+                render_dependencies=render_dependencies,
             ),
+            is_filled=None,
         )
 
-        context_data = self.get_context_data(*args, **kwargs)
+        # If any slot fills were defined within the template, we want to scope them
+        # to the CSS of the parent component. Thus we keep track of the parent component.
+        if context.get(_COMPONENT_CONTEXT_KEY, None):
+            parent_id = cast(str, context[_COMPONENT_CONTEXT_KEY])
+            parent_comp_ctx = component_context_cache[parent_id]
+            component_path = [*parent_comp_ctx.component_path, self.name]
+        else:
+            parent_id = None
+            component_path = [self.name]
+
+        trace_component_msg(
+            "COMP_PREP_START",
+            component_name=self.name,
+            component_id=render_id,
+            slot_name=None,
+            component_path=component_path,
+            extra=f"Received {len(args)} args, {len(kwargs)} kwargs, {len(slots)} slots",
+        )
+
+        # Register the component to provide
+        register_provide_reference(context, render_id)
+
+        # This is data that will be accessible (internally) from within the component's template
+        component_ctx = ComponentContext(
+            component_class=self.__class__,
+            component_name=self.name,
+            component_id=render_id,
+            component_path=component_path,
+            # Template name is set only once we've resolved the component's Template instance.
+            template_name=None,
+            fills=slots_untyped,
+            is_dynamic_component=getattr(self, "_is_dynamic_component", False),
+            # This field will be modified from within `SlotNodes.render()`:
+            # - The `default_slot` will be set to the first slot that has the `default` attribute set.
+            #   If multiple slots have the `default` attribute set, yet have different name, then
+            #   we will raise an error.
+            default_slot=None,
+            outer_context=snapshot_context(self.outer_context) if self.outer_context is not None else None,
+            registry=self.registry,
+        )
+
+        # Instead of passing the ComponentContext directly through the Context, the entry on the Context
+        # contains only a key to retrieve the ComponentContext from `component_context_cache`.
+        #
+        # This way, the flow is easier to debug. Because otherwise, if you try to print out
+        # or inspect the Context object, your screen is filled with the deeply nested ComponentContext objects.
+        component_context_cache[render_id] = component_ctx
+
+        # Allow to access component input and metadata like component ID from within these hook
+        with self._with_metadata(metadata):
+            context_data = self.get_context_data(*args, **kwargs)
+            # TODO - enable JS and CSS vars
+            # js_data = self.get_js_data(*args, **kwargs)
+            # css_data = self.get_css_data(*args, **kwargs)
         self._validate_outputs(data=context_data)
 
         # Process Component's JS and CSS
@@ -1022,40 +1085,19 @@ class Component(
         cache_component_css(self.__class__)
         css_input_hash = cache_component_css_vars(self.__class__, css_data) if css_data else None
 
-        with _prepare_template(self, context, context_data) as template:
+        with _prepare_template(self, context, context_data, metadata) as template:
+            component_ctx.template_name = template.name
+
             # For users, we expose boolean variables that they may check
             # to see if given slot was filled, e.g.:
             # `{% if variable > 8 and component_vars.is_filled.header %}`
             is_filled = SlotIsFilled(slots_untyped)
-            self._render_stack[-1].is_filled = is_filled
-
-            # If any slot fills were defined within the template, we want to scope them
-            # to the CSS of the parent component. Thus we keep track of the parent component.
-            if context.get(_COMPONENT_SLOT_CTX_CONTEXT_KEY, None):
-                parent_comp_ctx: ComponentSlotContext = context[_COMPONENT_SLOT_CTX_CONTEXT_KEY]
-                parent_id = parent_comp_ctx.component_id
-            else:
-                parent_id = None
-
-            component_slot_ctx = ComponentSlotContext(
-                component_name=self.name,
-                component_id=render_id,
-                template_name=template.name,
-                fills=slots_untyped,
-                is_dynamic_component=getattr(self, "_is_dynamic_component", False),
-                # This field will be modified from within `SlotNodes.render()`:
-                # - The `default_slot` will be set to the first slot that has the `default` attribute set.
-                #   If multiple slots have the `default` attribute set, yet have different name, then
-                #   we will raise an error.
-                default_slot=None,
-            )
+            metadata.is_filled = is_filled
 
             with context.update(
                 {
                     # Private context fields
-                    _ROOT_CTX_CONTEXT_KEY: self.outer_context,
-                    _COMPONENT_SLOT_CTX_CONTEXT_KEY: component_slot_ctx,
-                    _REGISTRY_CONTEXT_KEY: self.registry,
+                    _COMPONENT_CONTEXT_KEY: render_id,
                     # NOTE: Public API for variables accessible from within a component's template
                     # See https://github.com/django-components/django-components/issues/280#issuecomment-2081180940
                     "component_vars": ComponentVars(
@@ -1063,60 +1105,153 @@ class Component(
                     ),
                 }
             ):
-                self.on_render_before(context, template)
+                # Make a "snapshot" of the context as it was at the time of the render call.
+                #
+                # Previously, we recursively called `Template.render()` as this point, but due to recursion
+                # this was limiting the number of nested components to only about 60 levels deep.
+                #
+                # Now, we make a flat copy, so that the context copy is static and doesn't change even if
+                # we leave the `with context.update` blocks.
+                #
+                # This makes it possible to render nested components with a queue, avoiding recursion limits.
+                context_snapshot = snapshot_context(context)
+
+        # Cleanup
+        context.render_context.pop()
+
+        # Instead of rendering component at the time we come across the `{% component %}` tag
+        # in the template, we defer rendering in order to scalably handle deeply nested components.
+        #
+        # See `_gen_component_renderer()` for more details.
+        deferred_render = self._gen_component_renderer(
+            render_id=render_id,
+            template=template,
+            context=context_snapshot,
+            metadata=metadata,
+            component_path=component_path,
+            css_input_hash=css_input_hash,
+            js_input_hash=js_input_hash,
+            css_scope_id=None,  # TODO - Implement CSS scoping
+        )
+
+        # Remove component from caches
+        def on_component_rendered(component_id: str) -> None:
+            del component_context_cache[component_id]  # type: ignore[arg-type]
+            unregister_provide_reference(component_id)  # type: ignore[arg-type]
+
+        def on_html_rendered(html: str) -> str:
+            if render_dependencies:
+                html = _render_dependencies(html, type)
+            return html
+
+        trace_component_msg(
+            "COMP_PREP_END",
+            component_name=self.name,
+            component_id=render_id,
+            slot_name=None,
+            component_path=component_path,
+        )
+
+        return component_post_render(
+            renderer=deferred_render,
+            render_id=render_id,
+            component_name=self.name,
+            parent_id=parent_id,
+            on_component_rendered=on_component_rendered,
+            on_html_rendered=on_html_rendered,
+        )
+
+    # Creates a renderer function that will be called only once, when the component is to be rendered.
+    #
+    # By encapsulating components' output as render function, we can render components top-down,
+    # starting from root component, and moving down.
+    #
+    # This way, when it comes to rendering a particular component, we have already rendered its parent,
+    # and we KNOW if there were any HTML attributes that were passed from parent to children.
+    #
+    # Thus, the returned renderer function accepts the extra HTML attributes that were passed from parent,
+    # and returns the updated HTML content.
+    #
+    # Because the HTML attributes are all boolean (e.g. `data-djc-id-a1b3c4`), they are passed as a list.
+    #
+    # This whole setup makes it possible for multiple components to resolve to the same HTML element.
+    # E.g. if CompA renders CompB, and CompB renders a <div>, then the <div> element will have
+    # IDs of both CompA and CompB.
+    # ```html
+    # <div djc-id-a1b3cf djc-id-f3d3cf>...</div>
+    # ```
+    #
+    # ---
+    #
+    # After the component is rendered, we post-process the output:
+    # - Add the HTML attributes to work with JS and CSS variables
+    # - Resolve component's JS / CSS into <script> and <link> (if render_dependencies=True)
+    def _gen_component_renderer(
+        self,
+        render_id: str,
+        template: Template,
+        context: Context,
+        metadata: MetadataItem,
+        component_path: List[str],
+        css_input_hash: Optional[str],
+        js_input_hash: Optional[str],
+        css_scope_id: Optional[str],
+    ) -> ComponentRenderer:
+        component = self
+        component_name = self.name
+        component_cls = self.__class__
+
+        def renderer(root_attributes: Optional[List[str]] = None) -> Tuple[str, Dict[str, List[str]]]:
+            trace_component_msg(
+                "COMP_RENDER_START",
+                component_name=component_name,
+                component_id=render_id,
+                slot_name=None,
+                component_path=component_path,
+            )
+
+            # Allow to access component input and metadata like component ID from within `on_render` hook
+            with component._with_metadata(metadata):
+                component.on_render_before(context, template)
 
                 # Emit signal that the template is about to be rendered
-                template_rendered.send(sender=self, template=self, context=context)
+                template_rendered.send(sender=template, template=template, context=context)
                 # Get the component's HTML
                 html_content = template.render(context)
 
                 # Allow to optionally override/modify the rendered content
-                new_output = self.on_render_after(context, template, html_content)
+                new_output = component.on_render_after(context, template, html_content)
                 html_content = new_output if new_output is not None else html_content
-
-        # After rendering is done, remove the current state from the stack, which means
-        # properties like `self.context` will no longer return the current state.
-        self._render_stack.pop()
-        context.render_context.pop()
-
-        # Internal component HTML post-processing:
-        # - Add the HTML attributes to work with JS and CSS variables
-        # - Resolve component's JS / CSS into <script> and <link> (if render_dependencies=True)
-        #
-        # However, to ensure that we run an HTML parser only once over the HTML content,
-        # we have to wrap it in this callback. This callback runs only once we know whether
-        # there are any extra HTML attributes that should be applied to this component's root elements.
-        #
-        # This makes it possible for multiple components to resolve to the same HTML element.
-        # E.g. if CompA renders CompB, and CompB renders a <div>, then the <div> element will have
-        # IDs of both CompA and CompB.
-        # ```html
-        # <div djc-id-a1b3cf djc-id-f3d3cf>...</div>
-        # ```
-        def post_processor(root_attributes: Optional[List[str]] = None) -> Tuple[str, Dict[str, List[str]]]:
-            nonlocal html_content
 
             updated_html, child_components = set_component_attrs_for_js_and_css(
                 html_content=html_content,
                 component_id=render_id,
                 css_input_hash=css_input_hash,
-                css_scope_id=None,  # TODO - Implement
+                css_scope_id=css_scope_id,
                 root_attributes=root_attributes,
             )
 
-            updated_html = postprocess_component_html(
-                component_cls=self.__class__,
+            # Mark the generated HTML so that we will know which JS and CSS
+            # scripts are associated with it.
+            updated_html = insert_component_dependencies_comment(
+                updated_html,
+                component_cls=component_cls,
                 component_id=render_id,
-                html_content=updated_html,
-                css_input_hash=css_input_hash,
                 js_input_hash=js_input_hash,
-                type=type,
-                render_dependencies=render_dependencies,
+                css_input_hash=css_input_hash,
+            )
+
+            trace_component_msg(
+                "COMP_RENDER_END",
+                component_name=component_name,
+                component_id=render_id,
+                slot_name=None,
+                component_path=component_path,
             )
 
             return updated_html, child_components
 
-        return component_post_render(post_processor, render_id, parent_id)
+        return renderer
 
     def _normalize_slot_fills(
         self,
@@ -1128,12 +1263,41 @@ class Component(
 
         # NOTE: `gen_escaped_content_func` is defined as a separate function, instead of being inlined within
         #       the forloop, because the value the forloop variable points to changes with each loop iteration.
-        def gen_escaped_content_func(content: SlotFunc) -> Slot:
-            def content_fn(ctx: Context, slot_data: Dict, slot_ref: SlotRef) -> SlotResult:
-                rendered = content(ctx, slot_data, slot_ref)
-                return conditional_escape(rendered) if escape_content else rendered
+        def gen_escaped_content_func(content: SlotFunc, slot_name: str) -> Slot:
+            # Case: Already Slot, already escaped, and names tracing names assigned, so nothing to do.
+            if isinstance(content, Slot) and content.escaped and content.slot_name and content.component_name:
+                return content
 
-            slot = Slot(content_func=cast(SlotFunc, content_fn))
+            # Otherwise, we create a new instance of Slot, whether `content` was already Slot or not.
+            # This is so that user can potentially define a single `Slot` and use it in multiple components.
+            if not isinstance(content, Slot) or not content.escaped:
+
+                def content_fn(ctx: Context, slot_data: Dict, slot_ref: SlotRef) -> SlotResult:
+                    rendered = content(ctx, slot_data, slot_ref)
+                    return conditional_escape(rendered) if escape_content else rendered
+
+                content_func = cast(SlotFunc, content_fn)
+            else:
+                content_func = content.content_func
+
+            # Populate potentially missing fields so we can trace the component and slot
+            if isinstance(content, Slot):
+                used_component_name = content.component_name or self.name
+                used_slot_name = content.slot_name or slot_name
+                used_nodelist = content.nodelist
+            else:
+                used_component_name = self.name
+                used_slot_name = slot_name
+                used_nodelist = None
+
+            slot = Slot(
+                content_func=content_func,
+                component_name=used_component_name,
+                slot_name=used_slot_name,
+                nodelist=used_nodelist,
+                escaped=True,
+            )
+
             return slot
 
         for slot_name, content in fills.items():
@@ -1141,13 +1305,14 @@ class Component(
                 continue
             elif not callable(content):
                 slot = _nodelist_to_slot_render_func(
-                    slot_name,
-                    NodeList([TextNode(conditional_escape(content) if escape_content else content)]),
+                    component_name=self.name,
+                    slot_name=slot_name,
+                    nodelist=NodeList([TextNode(conditional_escape(content) if escape_content else content)]),
                     data_var=None,
                     default_var=None,
                 )
             else:
-                slot = gen_escaped_content_func(content)
+                slot = gen_escaped_content_func(content, slot_name)
 
             norm_fills[slot_name] = slot
 
@@ -1459,13 +1624,15 @@ def _prepare_template(
     component: Component,
     context: Context,
     context_data: Any,
+    metadata: MetadataItem,
 ) -> Generator[Template, Any, None]:
     with context.update(context_data):
         # Associate the newly-created Context with a Template, otherwise we get
         # an error when we try to use `{% include %}` tag inside the template?
         # See https://github.com/django-components/django-components/issues/580
         # And https://github.com/django-components/django-components/issues/634
-        template = component._get_template(context)
+        with component._with_metadata(metadata):
+            template = component._get_template(context, component_id=metadata.render_id)
 
         if not is_template_cls_patched(template):
             raise RuntimeError(

--- a/src/django_components/components/dynamic.py
+++ b/src/django_components/components/dynamic.py
@@ -120,7 +120,7 @@ class DynamicComponent(Component):
 
     # NOTE: The inner component is rendered in `on_render_before`, so that the `Context` object
     # is already configured as if the inner component was rendered inside the template.
-    # E.g. the `_COMPONENT_SLOT_CTX_CONTEXT_KEY` is set, which means that the child component
+    # E.g. the `_COMPONENT_CONTEXT_KEY` is set, which means that the child component
     # will know that it's a child of this component.
     def on_render_before(self, context: Context, template: Template) -> Context:
         comp_class = context["comp_class"]

--- a/src/django_components/context.py
+++ b/src/django_components/context.py
@@ -2,34 +2,29 @@
 This file centralizes various ways we use Django's Context class
 pass data across components, nodes, slots, and contexts.
 
-You can think of the Context as our storage system.
+Compared to `django_components/util/context.py`, this file contains the "business" logic
+and the list of all internal keys that we define on the `Context` object.
 """
 
-from collections import namedtuple
-from typing import Any, Dict, Optional
+from django.template import Context
 
-from django.template import Context, TemplateSyntaxError
+from django_components.util.misc import get_last_index
 
-from django_components.util.misc import find_last_index
-
-_COMPONENT_SLOT_CTX_CONTEXT_KEY = "_DJANGO_COMPONENTS_COMPONENT_SLOT_CTX"
-_ROOT_CTX_CONTEXT_KEY = "_DJANGO_COMPONENTS_ROOT_CTX"
-_REGISTRY_CONTEXT_KEY = "_DJANGO_COMPONENTS_REGISTRY"
-_INJECT_CONTEXT_KEY_PREFIX = "_DJANGO_COMPONENTS_INJECT__"
+_COMPONENT_CONTEXT_KEY = "_DJC_COMPONENT_CTX"
+_INJECT_CONTEXT_KEY_PREFIX = "_DJC_INJECT__"
 
 
 def make_isolated_context_copy(context: Context) -> Context:
     context_copy = context.new()
-    copy_forloop_context(context, context_copy)
+    _copy_forloop_context(context, context_copy)
 
     # Required for compatibility with Django's {% extends %} tag
     # See https://github.com/django-components/django-components/pull/859
     context_copy.render_context = context.render_context
 
     # Pass through our internal keys
-    context_copy[_REGISTRY_CONTEXT_KEY] = context.get(_REGISTRY_CONTEXT_KEY, None)
-    if _ROOT_CTX_CONTEXT_KEY in context:
-        context_copy[_ROOT_CTX_CONTEXT_KEY] = context[_ROOT_CTX_CONTEXT_KEY]
+    if _COMPONENT_CONTEXT_KEY in context:
+        context_copy[_COMPONENT_CONTEXT_KEY] = context[_COMPONENT_CONTEXT_KEY]
 
     # Make inject/provide to work in isolated mode
     context_keys = context.flatten().keys()
@@ -40,76 +35,14 @@ def make_isolated_context_copy(context: Context) -> Context:
     return context_copy
 
 
-def copy_forloop_context(from_context: Context, to_context: Context) -> None:
+def _copy_forloop_context(from_context: Context, to_context: Context) -> None:
     """Forward the info about the current loop"""
-    # Note that the ForNode (which implements for loop behavior) does not
+    # Note that the ForNode (which implements `{% for %}`) does not
     # only add the `forloop` key, but also keys corresponding to the loop elements
     # So if the loop syntax is `{% for my_val in my_lists %}`, then ForNode also
     # sets a `my_val` key.
     # For this reason, instead of copying individual keys, we copy the whole stack layer
     # set by ForNode.
     if "forloop" in from_context:
-        forloop_dict_index = find_last_index(from_context.dicts, lambda d: "forloop" in d)
+        forloop_dict_index = get_last_index(from_context.dicts, lambda d: "forloop" in d) or -1
         to_context.update(from_context.dicts[forloop_dict_index])
-
-
-def get_injected_context_var(
-    component_name: str,
-    context: Context,
-    key: str,
-    default: Optional[Any] = None,
-) -> Any:
-    """
-    Retrieve a 'provided' field. The field MUST have been previously 'provided'
-    by the component's ancestors using the `{% provide %}` template tag.
-    """
-    # NOTE: For simplicity, we keep the provided values directly on the context.
-    # This plays nicely with Django's Context, which behaves like a stack, so "newer"
-    # values overshadow the "older" ones.
-    internal_key = _INJECT_CONTEXT_KEY_PREFIX + key
-
-    # Return provided value if found
-    if internal_key in context:
-        return context[internal_key]
-
-    # If a default was given, return that
-    if default is not None:
-        return default
-
-    # Otherwise raise error
-    raise KeyError(
-        f"Component '{component_name}' tried to inject a variable '{key}' before it was provided."
-        f" To fix this, make sure that at least one ancestor of component '{component_name}' has"
-        f" the variable '{key}' in their 'provide' attribute."
-    )
-
-
-def set_provided_context_var(
-    context: Context,
-    key: str,
-    provided_kwargs: Dict[str, Any],
-) -> None:
-    """
-    'Provide' given data under given key. In other words, this data can be retrieved
-    using `self.inject(key)` inside of `get_context_data()` method of components that
-    are nested inside the `{% provide %}` tag.
-    """
-    # NOTE: We raise TemplateSyntaxError since this func should be called only from
-    # within template.
-    if not key:
-        raise TemplateSyntaxError(
-            "Provide tag received an empty string. Key must be non-empty and a valid identifier."
-        )
-    if not key.isidentifier():
-        raise TemplateSyntaxError(
-            "Provide tag received a non-identifier string. Key must be non-empty and a valid identifier."
-        )
-
-    # We turn the kwargs into a NamedTuple so that the object that's "provided"
-    # is immutable. This ensures that the data returned from `inject` will always
-    # have all the keys that were passed to the `provide` tag.
-    tpl_cls = namedtuple("DepInject", provided_kwargs.keys())  # type: ignore[misc]
-    payload = tpl_cls(**provided_kwargs)
-
-    internal_key = _INJECT_CONTEXT_KEY_PREFIX + key
-    context[internal_key] = payload

--- a/src/django_components/node.py
+++ b/src/django_components/node.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, cast
 from django.template import Context, Library
 from django.template.base import Node, NodeList, Parser, Token
 
-from django_components.util.logger import trace_msg
+from django_components.util.logger import trace_node_msg
 from django_components.util.misc import gen_id
 from django_components.util.template_tag import (
     TagAttr,
@@ -89,7 +89,7 @@ class NodeMeta(type):
 
         @functools.wraps(orig_render)
         def wrapper_render(self: "BaseNode", context: Context) -> str:
-            trace_msg("RENDR", self.tag, self.node_id)
+            trace_node_msg("RENDER", self.tag, self.node_id)
 
             resolved_params = resolve_params(self.tag, self.params, context)
 
@@ -196,7 +196,7 @@ class NodeMeta(type):
             ] + resolved_params_without_invalid_kwargs
             output = apply_params_in_original_order(orig_render, resolved_params_with_context, invalid_kwargs)
 
-            trace_msg("RENDR", self.tag, self.node_id, msg="...Done!")
+            trace_node_msg("RENDER", self.tag, self.node_id, msg="...Done!")
             return output
 
         # Wrap cls.render() so we resolve the args and kwargs and pass them to the
@@ -357,7 +357,7 @@ class BaseNode(Node, metaclass=NodeMeta):
         tag_id = gen_id()
         tag = parse_template_tag(cls.tag, cls.end_tag, cls.allowed_flags, parser, token)
 
-        trace_msg("PARSE", cls.tag, tag_id)
+        trace_node_msg("PARSE", cls.tag, tag_id)
 
         body = tag.parse_body()
         node = cls(
@@ -368,7 +368,7 @@ class BaseNode(Node, metaclass=NodeMeta):
             **kwargs,
         )
 
-        trace_msg("PARSE", cls.tag, tag_id, "...Done!")
+        trace_node_msg("PARSE", cls.tag, tag_id, "...Done!")
         return node
 
     @classmethod

--- a/src/django_components/perfutil/provide.py
+++ b/src/django_components/perfutil/provide.py
@@ -1,0 +1,155 @@
+"""
+This module contains optimizations for the `{% provide %}` feature.
+"""
+
+from contextlib import contextmanager
+from typing import Dict, Generator, NamedTuple, Set
+
+from django.template import Context
+
+from django_components.context import _INJECT_CONTEXT_KEY_PREFIX
+
+# Originally, when `{% provide %}` was used, the provided data was passed down
+# through the Context object.
+#
+# However, this was hard to debug if the provided data was large (e.g. a long
+# list of items).
+#
+# Instead, similarly to how the component internal data is passed through
+# the Context object, there's now a level of indirection - the Context now stores
+# only a key that points to the provided data.
+#
+# So when we inspect a Context layers, we may see something like this:
+#
+# ```py
+# [
+#     {"False": False, "None": None, "True": True}, # All Contexts contain this
+#     {"custom_key": "custom_value"},               # Data passed to Context()
+#     {"_DJC_INJECT__my_provide": "a1b3c3"},        # Data provided by {% provide %}
+#                                                   # containing only the key to "my_provide"
+# ]
+# ```
+#
+# Since the provided data is represented only as a key, we have to store the ACTUAL
+# data somewhere. Thus, we store it in a separate dictionary.
+#
+# So when one calls `Component.inject(key)`, we use the key to look up the actual data
+# in the dictionary and return that.
+#
+# This approach has several benefits:
+# - Debugging: One needs to only follow the IDs to trace the flow of data.
+# - Debugging: All provided data is stored in a separate dictionary, so it's easy to
+#   see what data is provided.
+# - Perf: The Context object is copied each time we call `Component.render()`, to have a "snapshot"
+#   of the context, in order to defer the rendering. Passing around only the key instead
+#   of actual value avoids potentially copying the provided data. This also keeps the source of truth
+#   unambiguous.
+# - Tests: It's easier to test the provided data, as we can just modify the dictionary directly.
+#
+# However, there is a price to pay for this:
+# - Manual memory management - Because the data is stored in a separate dictionary, we now need to
+#   keep track of when to delete the entries.
+#
+# The challenge with this manual memory management is that:
+# 1. Component rendering is deferred, so components are rendered AFTER we finish `Template.render()`.
+# 2. For the deferred rendering, we copy the Context object.
+#
+# This means that:
+# 1. We can't rely on simply reaching the end of `Template.render()` to delete the provided data.
+# 2. We can't rely on the Context object being deleted to delete the provided data.
+#
+# So we need to manually delete the provided data when we know it's no longer needed.
+#
+# Thus, the strategy is to count references to the provided data:
+# 1. When `{% provide %}` is used, it adds a key to the context.
+# 2. When we come across `{% component %}` that is within the `{% provide %}` tags,
+#    the component will see the provide's key and the component will register itself as a "child" of
+#    the `{% provide %}` tag at `Component.render()`.
+# 3. Once the component's deferred rendering takes place and finishes, the component makes a call
+#    to unregister itself from any "subscribed" provided data.
+# 4. While unsubscribing, if we see that there are no more children subscribed to the provided data,
+#    we can finally delete the provided data from the cache.
+#
+# However, this leaves open the edge case of when `{% provide %}` contains NO components.
+# In such case, we check if there are any subscribed components after rendering the contents
+# of `{% provide %}`. If there are NONE, we delete the provided data.
+
+
+# Similarly to ComponentContext instances, we store the actual Provided data
+# outside of the Context object, to make it easier to debug the data flow.
+provide_cache: Dict[str, NamedTuple] = {}
+
+# Keep track of how many components are referencing each provided data.
+provide_references: Dict[str, Set[str]] = {}
+
+# Keep track of all the listeners that are referencing any provided data.
+all_reference_ids: Set[str] = set()
+
+
+@contextmanager
+def managed_provide_cache(provide_id: str) -> Generator[None, None, None]:
+    all_reference_ids_before = all_reference_ids.copy()
+
+    def cache_cleanup() -> None:
+        # Lastly, remove provided data from the cache that was generated during this run,
+        # IF there are no more references to it.
+        if provide_id in provide_references and not provide_references[provide_id]:
+            provide_references.pop(provide_id)
+            provide_cache.pop(provide_id)
+
+        # Case: `{% provide %}` contained no components in its body.
+        # The provided data was not referenced by any components, but it's still in the cache.
+        elif provide_id not in provide_references and provide_id in provide_cache:
+            provide_cache.pop(provide_id)
+
+    try:
+        yield
+    except Exception as e:
+        # In case of an error in `Component.render()`, there may be some
+        # references left hanging, so we remove them.
+        new_reference_ids = all_reference_ids - all_reference_ids_before
+        for reference_id in new_reference_ids:
+            unregister_provide_reference(reference_id)
+
+        # Cleanup
+        cache_cleanup()
+        # Forward the error
+        raise e from None
+
+    # Cleanup
+    cache_cleanup()
+
+
+def register_provide_reference(context: Context, reference_id: str) -> None:
+    # No `{% provide %}` among the ancestors, nothing to register to
+    if not provide_cache:
+        return
+
+    all_reference_ids.add(reference_id)
+
+    for key, provide_id in context.flatten().items():
+        if not key.startswith(_INJECT_CONTEXT_KEY_PREFIX):
+            continue
+
+        if provide_id not in provide_references:
+            provide_references[provide_id] = set()
+        provide_references[provide_id].add(reference_id)
+
+
+def unregister_provide_reference(reference_id: str) -> None:
+    # No registered references, nothing to unregister
+    if reference_id not in all_reference_ids:
+        return
+
+    all_reference_ids.remove(reference_id)
+
+    for provide_id in list(provide_references.keys()):
+        if reference_id not in provide_references[provide_id]:
+            continue
+
+        provide_references[provide_id].remove(reference_id)
+
+        # There are no more references to the provided data, so we can delete it.
+        if not provide_references[provide_id]:
+            provide_cache.pop(provide_id)
+            provide_references.pop(provide_id)

--- a/src/django_components/util/context.py
+++ b/src/django_components/util/context.py
@@ -1,0 +1,99 @@
+import copy
+
+from django.template import Context
+from django.template.loader_tags import BlockContext
+
+
+class CopiedDict(dict):
+    """Dict subclass to identify dictionaries that have been copied with `snapshot_context`"""
+
+    pass
+
+
+def snapshot_context(context: Context) -> Context:
+    """
+    Make a copy of the Context object, so that it can be used as a snapshot.
+
+    Snapshot here means that the copied Context can leave any scopes that the original
+    Context is part of, and the copy will NOT be modified:
+
+    ```py
+    ctx = Context({ ... })
+    with ctx.render_context.push({}):
+        with ctx.update({"a": 1}):
+            snapshot = snapshot_context(ctx)
+
+    assert snapshot["a"] == 1  # OK
+    assert ctx["a"] == 1       # ERROR
+    ```
+
+    This function aims to make a shallow copy, but needs to make deeper copies
+    for certain features like forloops or support for `{% block %}` / `{% extends %}`.
+    """
+    # Using `copy()` should also copy flags like `autoescape`, `use_l10n`, etc.
+    context_copy = copy.copy(context)
+
+    # Context is a list of dicts, where the dicts can be thought of as "layers" - when a new
+    # layer is added, the keys defined on the latest layer overshadow the previous layers.
+    #
+    # For some special cases, like when we're inside forloops, we need to make deep copies
+    # of the objects created by the forloop, so all forloop metadata (index, first, last, etc.)
+    # is preserved for all (potentially nested) forloops.
+    #
+    # For non-forloop layers, we just make shallow copies.
+    dicts_with_copied_forloops = []
+    for ctx_dict in context.dicts:
+        # This layer is already copied
+        if isinstance(ctx_dict, CopiedDict):
+            dicts_with_copied_forloops.append(ctx_dict)
+            continue
+
+        ctx_dict = CopiedDict(ctx_dict)
+        if "forloop" in ctx_dict:
+            ctx_dict["forloop"] = ctx_dict["forloop"].copy()
+
+            # Recursively copy the state of potentially nested forloops
+            curr_forloop = ctx_dict["forloop"]
+            while curr_forloop is not None:
+                curr_forloop["parentloop"] = curr_forloop["parentloop"].copy()
+                if "parentloop" in curr_forloop["parentloop"]:
+                    curr_forloop = curr_forloop["parentloop"]
+                else:
+                    break
+
+        dicts_with_copied_forloops.append(ctx_dict)
+
+    context_copy.dicts = dicts_with_copied_forloops
+
+    # Make a copy of RenderContext
+    render_ctx_copies = []
+    for d in context.render_context.dicts:
+        # This layer is already copied
+        if isinstance(d, CopiedDict):
+            render_ctx_copies.append(d)
+            continue
+
+        # This holds info on what `{% block %}` blocks are defined
+        d_copy = CopiedDict(d)
+        if "block_context" in d:
+            d_copy["block_context"] = _copy_block_context(d["block_context"])
+
+        # "extends_context" is a list of Origin objects
+        if "extends_context" in d:
+            d_copy["extends_context"] = d["extends_context"].copy()
+
+        d_copy["_djc_snapshot"] = True
+        render_ctx_copies.append(d_copy)
+
+    context_copy.render_context.dicts = render_ctx_copies
+    return context_copy
+
+
+def _copy_block_context(block_context: BlockContext) -> BlockContext:
+    """Make a shallow copy of BlockContext"""
+    block_context_copy = block_context.__class__()
+    for key, val in block_context.blocks.items():
+        # Individual dict values should be lists of Nodes. We don't
+        # need to modify the Nodes, but we need to make a copy of the lists.
+        block_context_copy.blocks[key] = val.copy()
+    return block_context_copy

--- a/src/django_components/util/exception.py
+++ b/src/django_components/util/exception.py
@@ -1,0 +1,61 @@
+from contextlib import contextmanager
+from typing import Generator, List
+
+
+@contextmanager
+def component_error_message(component_path: List[str]) -> Generator[None, None, None]:
+    """
+    If an error occurs within the context, format the error message to include
+    the component path. E.g.
+    ```
+    KeyError: "An error occured while rendering components MyPage > MyComponent > MyComponent(slot:content)
+    ```
+    """
+    try:
+        yield
+    except Exception as err:
+        if not hasattr(err, "_components"):
+            err._components = []  # type: ignore[attr-defined]
+
+        components = getattr(err, "_components", [])
+        components = err._components = [*component_path, *components]  # type: ignore[attr-defined]
+
+        # Access the exception's message, see https://stackoverflow.com/a/75549200/9788634
+        if len(err.args) and err.args[0] is not None:
+            if not components:
+                orig_msg = str(err.args[0])
+            else:
+                orig_msg = err.args[0].split("\n", 1)[-1]
+        else:
+            orig_msg = str(err)
+
+        # Format component path as
+        # "MyPage > MyComponent > MyComponent(slot:content) > Base(slot:tab)"
+        comp_path = " > ".join(components)
+        prefix = f"An error occured while rendering components {comp_path}:\n"
+
+        err.args = (prefix + orig_msg,)  # tuple of one
+
+        # `from None` should still raise the original error, but without showing this
+        # line in the traceback.
+        raise err from None
+
+
+@contextmanager
+def add_slot_to_error_message(component_name: str, slot_name: str) -> Generator[None, None, None]:
+    """
+    This compliments `component_error_message` and is used inside SlotNode to add
+    the slots to the component path in the error message, e.g.:
+
+    ```
+    KeyError: "An error occured while rendering components MyPage > MyComponent > MyComponent(slot:content)
+    ```
+    """
+    try:
+        yield
+    except Exception as err:
+        if not hasattr(err, "_components"):
+            err._components = []  # type: ignore[attr-defined]
+
+        err._components.insert(0, f"{component_name}(slot:{slot_name})")  # type: ignore[attr-defined]
+        raise err from None

--- a/src/django_components/util/misc.py
+++ b/src/django_components/util/misc.py
@@ -20,13 +20,6 @@ def gen_id() -> str:
     )
 
 
-def find_last_index(lst: List, predicate: Callable[[Any], bool]) -> Any:
-    for r_idx, elem in enumerate(reversed(lst)):
-        if predicate(elem):
-            return len(lst) - 1 - r_idx
-    return -1
-
-
 def is_str_wrapped_in_quotes(s: str) -> bool:
     return s.startswith(('"', "'")) and s[0] == s[-1] and len(s) >= 2
 
@@ -62,7 +55,16 @@ def default(val: Optional[T], default: T) -> T:
     return val if val is not None else default
 
 
+def get_index(lst: List, key: Callable[[Any], bool]) -> Optional[int]:
+    """Get the index of the first item in the list that satisfies the key"""
+    for i in range(len(lst)):
+        if key(lst[i]):
+            return i
+    return None
+
+
 def get_last_index(lst: List, key: Callable[[Any], bool]) -> Optional[int]:
+    """Get the index of the last item in the list that satisfies the key"""
     for index, item in enumerate(reversed(lst)):
         if key(item):
             return len(lst) - 1 - index

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -153,7 +153,7 @@ class ComponentTest(BaseTestCase):
             pass
 
         with self.assertRaises(ImproperlyConfigured):
-            EmptyComponent("empty_component")._get_template(Context({}))
+            EmptyComponent("empty_component")._get_template(Context({}), "123")
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_template_string_static_inlined(self):
@@ -425,7 +425,7 @@ class ComponentTest(BaseTestCase):
 
         with self.assertRaisesMessage(
             TypeError,
-            "An error occured while rendering components Root > parent > provider > broken:\n"
+            "An error occured while rendering components Root > parent > provider > provider(slot:content) > broken:\n"
             "tuple indices must be integers or slices, not str",
         ):
             Root.render()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -513,7 +513,7 @@ class OuterContextPropertyTests(BaseTestCase):
         """
 
         def get_context_data(self):
-            return self.outer_context.flatten()
+            return self.outer_context.flatten()  # type: ignore[union-attr]
 
     def setUp(self):
         super().setUp()

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -508,7 +508,7 @@ class MiddlewareTests(BaseTestCase):
 
         assert_dependencies(rendered1)
         self.assertEqual(
-            rendered1.count('Variable: <strong data-djc-id-a1bc41="" data-djc-id-a1bc42="">value</strong>'),
+            rendered1.count('Variable: <strong data-djc-id-a1bc42="" data-djc-id-a1bc41="">value</strong>'),
             1,
         )
 
@@ -519,7 +519,7 @@ class MiddlewareTests(BaseTestCase):
 
         assert_dependencies(rendered2)
         self.assertEqual(
-            rendered2.count('Variable: <strong data-djc-id-a1bc43="" data-djc-id-a1bc44="">value</strong>'),
+            rendered2.count('Variable: <strong data-djc-id-a1bc44="" data-djc-id-a1bc43="">value</strong>'),
             1,
         )
 
@@ -530,6 +530,6 @@ class MiddlewareTests(BaseTestCase):
 
         assert_dependencies(rendered3)
         self.assertEqual(
-            rendered3.count('Variable: <strong data-djc-id-a1bc45="" data-djc-id-a1bc46="">value</strong>'),
+            rendered3.count('Variable: <strong data-djc-id-a1bc46="" data-djc-id-a1bc45="">value</strong>'),
             1,
         )

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -658,9 +658,9 @@ class SpreadOperatorTests(BaseTestCase):
         self.assertHTMLEqual(
             rendered,
             """
-            <div data-djc-id-a1bc40>{'@click': '() =&gt; {}', 'style': 'height: 20px'}</div>
-            <div data-djc-id-a1bc40>[1, 2, 3]</div>
-            <div data-djc-id-a1bc40>1</div>
+            <div data-djc-id-a1bc41>{'@click': '() =&gt; {}', 'style': 'height: 20px'}</div>
+            <div data-djc-id-a1bc41>[1, 2, 3]</div>
+            <div data-djc-id-a1bc41>1</div>
             """,
         )
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -38,8 +38,8 @@ class TemplateCacheTest(BaseTestCase):
                 }
 
         comp = SimpleComponent()
-        template_1 = comp._get_template(Context({}))
+        template_1 = comp._get_template(Context({}), component_id="123")
         template_1._test_id = "123"
 
-        template_2 = comp._get_template(Context({}))
+        template_2 = comp._get_template(Context({}), component_id="123")
         self.assertEqual(template_2._test_id, "123")

--- a/tests/test_templatetags_extends.py
+++ b/tests/test_templatetags_extends.py
@@ -557,7 +557,6 @@ class ExtendsCompatTests(BaseTestCase):
 
         template: types.django_html = """
             {% extends "block_in_component.html" %}
-            {% load component_tags %}
             {% block body %}
             <div>
                 58 giraffes and 2 pantaloons
@@ -826,10 +825,10 @@ class ExtendsCompatTests(BaseTestCase):
             <!DOCTYPE html>
             <html lang="en">
             <body>
-                <custom-template data-djc-id-a1bc43>
+                <custom-template data-djc-id-a1bc44>
                     <header></header>
                     <main>
-                        <div data-djc-id-a1bc47> injected: DepInject(hello='from_block') </div>
+                        <div data-djc-id-a1bc48> injected: DepInject(hello='from_block') </div>
                     </main>
                     <footer>Default footer</footer>
                 </custom-template>

--- a/tests/test_templatetags_slot_fill.py
+++ b/tests/test_templatetags_slot_fill.py
@@ -531,7 +531,7 @@ class ComponentSlotTests(BaseTestCase):
 
         with self.assertRaisesMessage(
             TemplateSyntaxError,
-            "Encountered a SlotNode outside of a ComponentNode context.",
+            "Encountered a SlotNode outside of a Component context.",
         ):
             Template(template_str).render(Context({}))
 

--- a/tests/test_templatetags_templating.py
+++ b/tests/test_templatetags_templating.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 
 from django.template import Context, Template
 
-from django_components import Component, registry, types
+from django_components import Component, register, registry, types
 
 from .django_test_setup import setup_test_config
 from .testutils import BaseTestCase, parametrize_context_behavior
@@ -604,38 +604,10 @@ class ComponentNestingTests(BaseTestCase):
             </div>
         """
 
-    class ComplexChildComponent(Component):
-        template: types.django_html = """
-            {% load component_tags %}
-            <div>
-            {% slot "content" default %}
-                No slot!
-            {% endslot %}
-            </div>
-        """
-
-    class ComplexParentComponent(Component):
-        template: types.django_html = """
-            {% load component_tags %}
-            ITEMS: {{ items|safe }}
-            {% for item in items %}
-            <li>
-                {% component "complex_child" %}
-                    {{ item.value }}
-                {% endcomponent %}
-            </li>
-            {% endfor %}
-        """
-
-        def get_context_data(self, items, *args, **kwargs) -> Dict[str, Any]:
-            return {"items": items}
-
     def setUp(self) -> None:
         super().setUp()
         registry.register("dashboard", self.DashboardComponent)
         registry.register("calendar", self.CalendarComponent)
-        registry.register("complex_child", self.ComplexChildComponent)
-        registry.register("complex_parent", self.ComplexParentComponent)
 
     # NOTE: Second arg in tuple are expected names in nested fills. In "django" mode,
     # the value should be overridden by the component, while in "isolated" it should
@@ -768,27 +740,111 @@ class ComponentNestingTests(BaseTestCase):
         """
         self.assertHTMLEqual(rendered, expected)
 
+    # This test is based on real-life example.
+    # It ensures that deeply nested slots in fills with same names are resolved correctly.
+    # It also ensures that the component_vars.is_filled context is correctly populated.
     @parametrize_context_behavior(["django", "isolated"])
-    def test_component_nesting_deep_slot_inside_component_fill(self):
-        template_str: types.django_html = """
-            {% load component_tags %}
-            {% component "complex_parent" items=items %}{% endcomponent %}
-        """
-        template = Template(template_str)
-        items = [{"value": 1}, {"value": 2}, {"value": 3}]
-        rendered = template.render(Context({"items": items}))
+    def test_component_nesting_deep_slot_inside_component_fill_2(self):
+        @register("TestPage")
+        class TestPage(Component):
+            template: types.django_html = """
+                {% component "TestLayout" %}
+                    {% fill "content" %}
+                        <div class="test-page">
+                            ------PROJ_LAYOUT_TABBED META ------<br/>
+                            component_vars.is_filled: {{ component_vars.is_filled|safe }}<br/>
+                            ------------------------<br/>
+
+                            {% if component_vars.is_filled.left_panel %}
+                                <div style="background-color: red;">
+                                    {% slot "left_panel" / %}
+                                </div>
+                            {% endif %}
+
+                            {% slot "content" default %}
+                                DEFAULT LAYOUT TABBED CONTENT
+                            {% endslot %}
+                        </div>
+                    {% endfill %}
+                {% endcomponent %}
+            """
+
+        @register("TestLayout")
+        class TestLayout(Component):
+            template: types.django_html = """
+            {% component "TestBase" %}
+                {% fill "content" %}
+                    ------LAYOUT META ------<br/>
+                    component_vars.is_filled: {{ component_vars.is_filled|safe }}<br/>
+                    ------------------------<br/>
+
+                    <div class="test-layout">
+                        {% slot "content" default / %}
+                    </div>
+                {% endfill %}
+            {% endcomponent %}
+            """
+
+        @register("TestBase")
+        class TestBase(Component):
+            template: types.django_html = """
+                <!DOCTYPE html>
+                <html lang="en">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                    <title>Test app</title>
+                </head>
+                <body class="test-base">
+                    ------BASE META ------<br/>
+                    component_vars.is_filled: {{ component_vars.is_filled|safe }}<br/>
+                    ------------------------<br/>
+
+                    {% slot "content" default / %}
+                </body>
+                </html>
+            """
+
+        rendered = TestPage.render(
+            slots={
+                "left_panel": "LEFT PANEL SLOT FROM FILL",
+                "content": "CONTENT SLOT FROM FILL",
+            }
+        )
 
         expected = """
-            ITEMS: [{'value': 1}, {'value': 2}, {'value': 3}]
-            <li data-djc-id-a1bc3f>
-                <div data-djc-id-a1bc41> 1 </div>
-            </li>
-            <li data-djc-id-a1bc3f>
-                <div data-djc-id-a1bc43> 2 </div>
-            </li>
-            <li data-djc-id-a1bc3f>
-                <div data-djc-id-a1bc44> 3 </div>
-            </li>
+            <!DOCTYPE html>
+            <html lang="en" data-djc-id-a1bc3e data-djc-id-a1bc43 data-djc-id-a1bc47><head>
+                <meta charset="UTF-8">
+                <meta http-equiv="X-UA-Compatible" content="IE=edge">
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <title>Test app</title>
+            </head>
+            <body class="test-base">
+                ------BASE META ------ <br>
+                component_vars.is_filled: {'content': True}<br>
+                ------------------------ <br>
+
+                ------LAYOUT META ------<br>
+                component_vars.is_filled: {'content': True}<br>
+                ------------------------<br>
+
+                <div class="test-layout">
+                    <div class="test-page">
+                        ------PROJ_LAYOUT_TABBED META ------<br>
+                        component_vars.is_filled: {'left_panel': True, 'content': True}<br>
+                        ------------------------<br>
+
+                        <div style="background-color: red;">
+                            LEFT PANEL SLOT FROM FILL
+                        </div>
+                        CONTENT SLOT FROM FILL
+                    </div>
+                </div>
+                <script src="django_components/django_components.min.js"></script>
+            </body>
+            </html>
         """
         self.assertHTMLEqual(rendered, expected)
 


### PR DESCRIPTION
Closes #923 

## Background

The main goal of this PR was to work around the recusion limits when rendering deeply-nested (see https://github.com/django-components/django-components/issues/923).

I achieved this by:

1. If component is nested in another, instead of the inner component directly rendering its contents, it returns only a placeholder. After the root component is rendered, we check the HTML for any component placeholders, and replace them. It's at this point when we actually render the child components. This repeats recursively - if child component has subcomponents, those subcomponnt will first return only a placeholder, and will be rendered in next iteration. Thus, parent components get to be rendered before child components.

2. To avoid needing to use recursion, when a component's template is about to be rendered, I make a copy (a "snapshot") of the Context object, as it was at that point. Thus we isolate the data needed to render the components template, and we can render it at later time, simply by passing the context snapshot to the Template as `template.render(context)`.

   - I call "snapshot" a copy of the original Context, which can be moved freely. E.g. Django uses context managers to temporarily apply extra layers to the Context:
      ```py
      with context.push({"key": val}):
          print(context["key"])  # works
      print(context["key"])  # KeyError
      ```

      Instead, the context copies the Context layers, so they won't be affected when we leave the context
      ```py
      with context.push({"key": val}):
          snapshot = make_snapshot(context)
          print(snapshot["key"])  # works
      print(snapshot["key"])  # works
      ```

3. And with the above, we can avoid recursion when rendering the components by keeping a queue of components to render, and processing it depth-first, rendering components one at a time, as described in point 1).

So now the components can be nested at arbitrary depth, limited only by available memory.

---

## Changes

However, it was a real pain (it took me what, full 2.5 days?) to figure out what was wrong. Supporting all the different modes:
- Isolated vs django
- Slots/fills
- {% extends %} / {% block %}

and their interaction, wasn't easy to figure out what was going on wrong.

So to be able to debug what is going on, I really had to move things out of the way, so I could understand what is going on with the Context object at each step of the way.

Thus I made some improvements to debugging:

- When a component raises an error, the error message now also includes the slot path ([see here](https://github.com/django-components/django-components/pull/936/files#diff-b35cc8d48a3ea2ddde0c3bc9de0b0b768c567f9e8f532dc4ca1b260fe06e4ac8R428))
   
   E.g. `Root > parent > provider > provider(slot:content) > broken`

- Better tracing - I added tracing messages to when:
   1. Component "prep" starts (that's when we enter `Component.render()`
   2. Component "prep" ends
   3. Actual component render starts
   4. Actual component render end
   5. Slot render starts
   6. Slot render ends
   7. When rendering slot fill that was defined via `{% fill %}` tag

- Instead of storing parent component data directly on the Context, the Context object now contains only a key, and actual data is stored in a separate dictionary.

   The issue is that when there's nested components, then we store also the `outer_context` AKA the state of `Context`, as it was right outside of the Component
   ```django
                    <-- This is outer context
   {% component "table" %}
      {% fill headers %}
        {{ ... }}       <-- This should have access to vars
                                defined in the outer context
      {% endfill %}
   {% endcomponent %}
   ```
   
   This made it really hard to debug. Because when I tried to print out individual layers of the Context, it would also print out the `outer_context` Context object. And if this was a deeply-nested component, then that `outer_context` had an `outer_context`, and that had an `outer_context`, and so on...

   Instead, now there is only the ID there. See below, where the `_DJC_COMPONENT_CTX` is only a short string - the key is actually the component's ID.

   <img width="710" alt="Screenshot 2025-01-28 at 09 09 13" src="https://github.com/user-attachments/assets/dd10eeb3-e72c-4b6c-a549-94f3587e95fe" />

   The added bonus is that it's now easy to access data of any layer. This could be potentially used also for testing, where it would be easy to mock or replace some provided or parent component data, simply by modifying the entries in the dictionary.

- As you can see in the screenshot from previous point, I did the same for data defined via `{% provide %}`. Before, they were defined directly on the Context, now its refered to only by its key.

   In both cases, the component data and the provide data, there is a tradeoff - Because we store the data in separate dictionaries, we have to manually manage their memory - keeping track when when corresponding components are finished rendering, and delete the data from the cache dictionaries.

   With the data from `{% provide %}` it's a bit more complex than with the component data, because for Provide we have to do reference counting - keep track of which components are being rendered while inside `{% provide %}`, and allow to delete the provided data only once all those components are done rendering.

   Because of this, I added the `perfutil/provide.py` file, to house this logic, as its related to optimization of the provide feature, but not to the "business" logic of provide itself.

- Better tracing for slots - I updated how the slot are displayed. So when we print them , the slot shows where it was originally defined - AKA which component it was passed and under which slot name:

   <img width="595" alt="Screenshot 2025-01-28 at 09 52 00" src="https://github.com/user-attachments/assets/2fcbc73c-a3a1-4bc7-a2f3-c9eab794dc8c" />

   To achieve this, I had to pass extra info about the component name & id / slot name here and there.

- Visualizing slots - I also used a snippet to display where and how slots are displayed

   **NOTE: This is NOT included in this PR**, this was simple enough that it could be extracted without breaking everything else. So the plan is to make a separate PR with this, and add a page on troubleshooting, and mention it there.

   <img width="966" alt="Screenshot 2025-01-27 at 22 53 55" src="https://github.com/user-attachments/assets/8d449cb7-7338-4f32-ac71-9a0e08765d6f" />


## Next steps

1. As mentioned above, I want to add the diagnostics feature to highlight slots - actually, maybe this could also highlight components.

2. This PR breaks the `on_render_after` hook, so I want to fix it in separate PR.
    
   Because while before, the hook received a fully-rendered HTML, now it receives HTML, but with placeholders instead of rendered sub-components. So it may look like this:
   ```html
   <div>
     <template djc-render-id="a1b2c3"></template>
   </div>
   ```

   instead of e.g.
   ```html
   <div>
     <button class="btn btn-float" data-djc-id="a1b2c3">
       hello click me!
       ...
     </button>
   </div>
   ```

   the issue here is that, in the latest implementation, we build the final HTML only for the root component. For all subcomponents, we keep their HTML as a list of `[STATIC_TEXT, SUBCOMPONENT_OUTPUT, STATIC_TEXT, ...]

   This could be refactored to intermediately join up the HTML of the subcomponents, so that we could pass their HTML to the `on_render_after` hook. But I want to do so already in a separate PR.