### PR TITLE
refactor: remove use of eval for node validation

### DIFF
--- a/src/django_components/util/template_tag.py
+++ b/src/django_components/util/template_tag.py
@@ -276,7 +276,7 @@ def apply_params_in_original_order(
 
     # Find the last positional parameter index (excluding *args)
     max_positional_index = 0
-    for i, (_, signature_param) in enumerate(params_by_name.items()):
+    for i, signature_param in enumerate(params_by_name.values()):
         if signature_param.kind in (
             inspect.Parameter.POSITIONAL_ONLY,
             inspect.Parameter.POSITIONAL_OR_KEYWORD,

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -128,7 +128,7 @@ class HtmlAttrsTests(BaseTestCase):
         template = Template(self.template_str)
 
         with self.assertRaisesMessage(
-            TypeError, "Invalid parameters for tag 'html_attrs': too many positional arguments"
+            TypeError, "Invalid parameters for tag 'html_attrs': takes 2 positional argument(s) but more were given"
         ):
             template.render(Context({"class_var": "padding-top-8"}))
 
@@ -269,7 +269,7 @@ class HtmlAttrsTests(BaseTestCase):
         template = Template(self.template_str)
 
         with self.assertRaisesMessage(
-            TypeError, "Invalid parameters for tag 'html_attrs': multiple values for argument 'attrs'"
+            TypeError, "Invalid parameters for tag 'html_attrs': got multiple values for argument 'attrs'"
         ):
             template.render(Context({"class_var": "padding-top-8"}))
 

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -737,7 +737,7 @@ class SpreadOperatorTests(BaseTestCase):
 
         template1 = Template(template_str1)
 
-        with self.assertRaisesMessage(SyntaxError, "keyword argument repeated"):
+        with self.assertRaisesMessage(TypeError, "got multiple values for argument 'x'"):
             template1.render(context)
 
         # But, similarly to python, we can merge multiple **kwargs by instead


### PR DESCRIPTION
Part of #935.

As described [here](https://github.com/django-components/django-components/issues/935#issuecomment-2629165443), I tried to replace `eval()` with manual input validation, to see if it improves performance.

I does not. But at least we got rid of the eval, so that's still a win in my book.

No API changes.