### PR TITLE
WIP: [REJECT] Cached context keys for fast access

### DIFF
--- a/src/django_components/apps.py
+++ b/src/django_components/apps.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from django.apps import AppConfig
 from django.template import Template
+from django.template.context import BaseContext
 from django.utils.autoreload import file_changed, trigger_reload
 
 
@@ -17,12 +18,12 @@ class ComponentsConfig(AppConfig):
         from django_components.autodiscovery import autodiscover, import_libraries
         from django_components.component_registry import registry
         from django_components.components.dynamic import DynamicComponent
-        from django_components.util.django_monkeypatch import monkeypatch_template_cls
+        from django_components.util.django_monkeypatch import monkeypatch_django_classes
 
         # NOTE: This monkeypatch is applied here, before Django processes any requests.
         #       To make django-components work with django-debug-toolbar-template-profiler
         #       See https://github.com/django-components/django-components/discussions/819
-        monkeypatch_template_cls(Template)
+        monkeypatch_django_classes(Template, BaseContext)
 
         # Import modules set in `COMPONENTS.libraries` setting
         import_libraries()

--- a/src/django_components/util/context2.py
+++ b/src/django_components/util/context2.py
@@ -1,0 +1,722 @@
+from copy import copy
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Set,
+    SupportsIndex,
+    Tuple,
+    Union,
+    cast,
+)
+
+from django.template.context import BaseContext as DjangoBaseContext
+
+
+# TODO - ADD ContextLayer.clear
+# TODO - ADD ContextLayer.copy
+# TODO - ADD ContextLayer.pop
+# TODO - ADD ContextLayer.popitem
+# TODO - ADD ContextLayer.setdefault
+
+
+class ContextPopException(Exception):
+    "pop() has been called more times than push()"
+    pass
+
+
+DictArg = Union[Mapping[Any, Any], Iterable[Tuple[Any, Any]], "BaseContext"]
+
+
+class DictsDescriptor:
+    """
+    Descriptor that handles direct assignments to `BaseContext.dicts`, e.g.
+
+    ```python
+    context = BaseContext()
+    context.dicts = [{"a": 1}, {"b": 2}]
+    ```
+
+    When `BaseContext.dicts` is assigned directly, we need to:
+    1. Clean up old dicts by removing their context references
+    2. Reset the context's state
+    3. Set up the new dicts properly
+
+    Ideally we wouldn't need this and all these mutations would go through
+    BaseContext methods. But since we're not in control of the Django templating,
+    we need to detect these mutations and handle them.
+    """
+
+    def __init__(self) -> None:
+        self.private_name = "_dicts"
+
+    def __get__(self, instance: Optional["BaseContext"], owner: type) -> List[Dict]:
+        # Accessing the attribute on class should raise AttributeError
+        if instance is None:
+            return getattr(owner, "dicts")
+
+        # On instance, return the private attribute
+        return getattr(instance, self.private_name)
+
+    def __set__(self, instance: "BaseContext", value: List[dict]) -> None:
+        # Clean up old layers by removing their context references
+        old_layers = cast(List[ContextLayer], getattr(instance, self.private_name, []))
+        for layer_dict in old_layers:
+            layer_dict._remove_context(instance)
+
+        # Reset the context's state
+        instance._key_index.clear()
+
+        # Create new ContextLayersList and populate it
+        new_layers = ContextLayersList(instance)
+        new_layers.extend(value)
+
+        # Set the new list
+        setattr(instance, self.private_name, new_layers)
+
+
+class BaseContext:
+
+    #####################################
+    # DJANGO API OVERRIDES
+    #####################################
+
+    dicts = DictsDescriptor()
+
+    def __init__(self, dict_: Optional[Union[dict, "BaseContext"]] = None) -> None:
+        self._key_index: Dict[str, Set[int]] = {}  # Maps keys to layers they appear in
+        # We keep track of which key is defined in which layer. However, we only lazily
+        # sort the keys when they are accessed.
+        self._sorted_keys: Dict[str, Optional[List[int]]] = {}
+        self._dicts = ContextLayersList(self)  # Use ContextLayersList for tracking mutations
+        self._reset_dicts(dict_)
+
+    def __hash__(self) -> int:
+        return id(self)
+
+    def _reset_dicts(self, *new_dicts: Optional[Union[dict, "BaseContext"]]) -> None:
+        # Clear
+        self._dicts = ContextLayersList(self)
+        self._key_index.clear()
+
+        # Set defaults
+        builtins = {"True": True, "False": False, "None": None}
+        self.push(builtins)
+
+        for value in new_dicts:
+            if value is not None:
+                self.push(value)
+
+    def __copy__(self) -> "BaseContext":
+        # Create new context instance
+        duplicate = cast(BaseContext, copy(super(DjangoBaseContext, self)))
+
+        # Initialize empty state
+        duplicate._key_index = {}
+        duplicate._sorted_keys = {}
+        duplicate._dicts = ContextLayersList(duplicate)
+
+        # Reuse existing ContextLayers by adding the new context to them
+        for idx, layer_dict in enumerate(self._dicts):
+            layer_dict._add_context(duplicate, idx)
+            duplicate._dicts._append(layer_dict)
+
+        return duplicate
+
+    def __getitem__(self, key: str) -> Any:
+        "Get a variable's value, starting at the current context and going upward"
+        if key in self._key_index and self._key_index[key]:
+            return self.get(key)
+        raise KeyError(key)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        "Set a variable in the current context"
+        self._dicts[-1][key] = value
+
+    def __delitem__(self, key: str) -> None:
+        "Delete a variable from the current context"
+        del self._dicts[-1][key]
+
+    def set_upward(self, key: str, value: Any) -> None:
+        """
+        Set a variable in one of the higher contexts if it exists there,
+        otherwise in the current context.
+        """
+        if key in self._key_index and self._key_index[key]:
+            latest_layer = self._get_latest_layer(key)
+            latest_layer[key] = value
+        else:
+            self[key] = value
+
+    def get(self, key: str, otherwise: Any = None) -> Any:
+        if key in self._key_index and self._key_index[key]:
+            latest_layer = self._get_latest_layer(key)
+            return latest_layer[key]
+        return otherwise
+
+    def flatten(self) -> dict:
+        """Return self.dicts as one dictionary."""
+        flat: Dict[str, Any] = {}
+        # Use the key index to get the latest value for each key
+        for key in self._key_index:
+            if not self._key_index[key]:
+                continue
+
+            latest_layer = self._get_latest_layer(key)
+            flat[key] = latest_layer[key]
+        return flat
+
+    def push(self, *args: DictArg, **kwargs: Any) -> "ContextDict":
+        new_layer = ContextLayer(*args, **kwargs)
+        new_layer._add_context(self, len(self._dicts))
+        self._dicts._append(new_layer)
+        return ContextDict(self, new_layer)
+
+    def pop(self) -> "ContextLayer":
+        if len(self._dicts) == 1:
+            raise ContextPopException
+        return self._dicts.pop()
+
+    def __repr__(self) -> str:
+        return repr(self._dicts)
+
+    def __iter__(self) -> Iterator[dict]:
+        return reversed(self._dicts)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._key_index and bool(self._key_index[key])
+
+    #####################################
+    # CUSTOM METHODS
+    #####################################
+
+    def _remap_layer_indices(self, index_map: Dict[int, int]) -> None:
+        """
+        Remap layer indices after a reordering operation.
+
+        Args:
+            index_map: old_layer_index -> new_layer_index mapping
+        """
+        # Create new key index with remapped layers
+        new_key_index: Dict[str, Set[int]] = {}
+        for key, layer_indices in self._key_index.items():
+            # Map each layer to its new position and maintain reverse sort
+            new_layers = [
+                # NOTE: Some indices may not be in the index_map, in which case we assume
+                #       that they didn't move.
+                index_map[layer] if layer in index_map else layer
+                for layer in layer_indices
+            ]
+            self._sorted_keys[key] = None
+            new_key_index[key] = set(new_layers)
+
+        self._key_index = new_key_index
+
+    def _register_key(self, key: str, layer: int) -> None:
+        """When a key is added to a layer, add it to the key index."""
+        if key not in self._key_index:
+            self._key_index[key] = set()
+
+        if layer not in self._key_index[key]:
+            self._key_index[key].add(layer)
+            self._sorted_keys[key] = None
+
+    def _unregister_key(self, key: str, layer: int) -> None:
+        """When a key is removed from a layer, remove it from the key index."""
+        if key not in self._key_index:
+            return
+
+        self._key_index[key].discard(layer)
+        self._sorted_keys[key] = None
+
+    def _get_latest_layer(self, key: str) -> "ContextLayer":
+        """Get the latest layer that contains the key."""
+        # Should raise KeyError if key not found
+        key_layers = self._key_index[key]
+
+        if key not in self._sorted_keys or self._sorted_keys[key] is None:
+            # Keep latest layer first
+            self._sorted_keys[key] = sorted(key_layers, reverse=True)
+
+        latest_layer_index = self._sorted_keys[key][0]  # type: ignore[index]
+        return self._dicts[latest_layer_index]
+
+
+# TODO - API CHANGE FROM Django:
+#        Updated ContextDict not to subclass from dict. So that means that people
+#        will no longer be able to do `context.push({"d": 1})["d"]`.
+#        Instead, they should do `context.push({"d": 1}); context["d"]`
+class ContextDict:
+    """A context manager that adds and removes a dictionary from the context."""
+
+    def __init__(self, context: "BaseContext", dict_: "ContextLayer"):
+        self.context = context
+        self.dict = dict_
+
+    def __enter__(self) -> "ContextLayer":
+        return self.dict
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        self.context.pop()
+
+
+class ContextBinding(NamedTuple):
+    context: "BaseContext"
+    layer_index: int
+
+
+class ContextLayer(dict):
+    """A dictionary that notifies its parent Contexts of any changes."""
+
+    # NOTE: Although this accepts `*args`, it only uses the first argument.
+    #       The rest is passed to `dict.__init__()` and will raise an error.
+    def __init__(self, *args: DictArg, **kwargs: Any) -> None:
+        # It might happen that a single layer dictionary is pushed to multiple Contexts.
+        # And in those Contexts, it may be at different positions.
+        #
+        # Thus, we store which Contexts the the layer is "connected" to.
+        # And if we update this dict, we will update all contexts that have it.
+        #
+        # NOTE: If `Context.dicts` is reassigned manually, then `DictsDescriptor` will
+        #       remove the `context` from this dict
+        # NOTE: For easier access, the data is keyed by their ID
+        self.contexts: Dict[int, ContextBinding] = {}
+
+        arg = args[0] if args else None
+        new_dict: Dict[Any, Any] = {}
+        if arg is not None:
+            if isinstance(arg, (DjangoBaseContext, BaseContext)):
+                new_dict.update(arg.flatten())
+            else:
+                # NOTE: This should raise if arg is not a dict nor mapping / iterable
+                new_dict.update(arg)
+
+        # Let `dict` raise error if it received more than 1 positional argument
+        updated_args = (new_dict, *args[1:])
+        super().__init__(*updated_args, **kwargs)
+
+    #####################################
+    # CUSTOM METHODS
+    #####################################
+
+    def _get_context_binding(self, context: "BaseContext") -> Optional[ContextBinding]:
+        """Get the context binding for a specific context."""
+        context_id = id(context)
+        if context_id not in self.contexts:
+            return None
+
+        return self.contexts[context_id]
+
+    def _set_context_binding(self, context: "BaseContext", layer_index: int) -> None:
+        """Set the context binding for a specific context."""
+        context_id = id(context)
+        self.contexts[context_id] = ContextBinding(context, layer_index)
+
+    def _delete_context_binding(self, context: "BaseContext") -> None:
+        """Delete the context binding for a specific context."""
+        context_id = id(context)
+        del self.contexts[context_id]
+
+    def _add_context(self, context: "BaseContext", layer_index: int) -> None:
+        """Add a new context binding to this dict's contexts."""
+        context_binding = self._get_context_binding(context)
+        if context_binding is not None:
+            return
+
+        self._set_context_binding(context, layer_index)
+
+        # Register all keys in the new context
+        for key in self:
+            context._register_key(key, layer_index)
+
+    def _remove_context(self, context: "BaseContext") -> None:
+        """Remove a context binding from this dict's contexts."""
+        context_binding = self._get_context_binding(context)
+        if context_binding is None:
+            return
+
+        # Unregister all keys from the context that is being removed
+        for key in self:
+            context._unregister_key(key, context_binding.layer_index)
+
+        self._delete_context_binding(context)
+
+    def _get_cached_layer_index(self, context: "BaseContext") -> int:
+        """Get the index of the layer for a specific context."""
+        context_binding = self._get_context_binding(context)
+        if context_binding is None:
+            raise ValueError(f"Context {context} not found in this ContextLayer")
+
+        return context_binding.layer_index
+
+    def _cache_layer_index(self, context: "BaseContext", new_index: int) -> None:
+        """Set the index of the layer for a specific context."""
+        self._set_context_binding(context, new_index)
+
+    #########################
+    # DICT API OVERRIDES
+    #########################
+
+    # dict[key] = value
+    def __setitem__(self, key: str, value: Any) -> None:
+        is_new_key = key not in self
+        super().__setitem__(key, value)
+        if is_new_key:
+            # Register new key in all contexts
+            for context_binding in self.contexts.values():
+                context_binding.context._register_key(key, context_binding.layer_index)
+
+    # del dict[key]
+    def __delitem__(self, key: str) -> None:
+        # NOTE: Raises KeyError if key not found
+        super().__delitem__(key)
+        # Unregister deleted key from all contexts
+        for context_binding in self.contexts.values():
+            context_binding.context._unregister_key(key, context_binding.layer_index)
+
+    # TODO - API CHANGE FROM DJANGO - If BaseContext is passed as arg, then it is flattened
+    def update(  # type: ignore[override]
+        self,
+        *args: DictArg,
+        **kwargs: Any,
+    ) -> None:
+        # Get new keys before update
+        self_keys: Set[str] = set(self.keys())
+        new_keys: Set[str] = set()
+
+        if args:
+            other = args[0]
+            if isinstance(other, (DjangoBaseContext, BaseContext)):
+                other = other.flatten()
+
+            if isinstance(other, dict):
+                new_keys = set(other.keys())
+            else:
+                new_keys = {k for k, v in other}  # Creates Set
+
+        new_keys.update(set(kwargs.keys()))
+        new_keys = new_keys - self_keys
+
+        super().update(*args, **kwargs)
+
+        # Register new keys in all contexts
+        if new_keys:
+            for context_binding in self.contexts.values():
+                for key in new_keys:
+                    context_binding.context._register_key(key, context_binding.layer_index)
+
+
+class ContextLayersList(List["ContextLayer"]):
+    """
+    A list subclass that notifies its parent context of any modifications.
+
+    This is used to track modifications to `BaseContext.dicts` when they happen
+    directly on the list object rather than through BaseContext's methods.
+
+    Ideally we wouldn't need this and all these mutations would go through
+    BaseContext methods. But since we're not in control of the Django templating,
+    we need to detect these mutations and handle them.
+    """
+
+    def __init__(self, owner: "BaseContext", *args: Any, **kwargs: Any) -> None:
+        self.owner = owner
+        super().__init__(*args, **kwargs)
+
+    #####################################
+    # CUSTOM METHODS
+    #####################################
+
+    def _disconnect_layer(self, layer_dict: "ContextLayer") -> None:
+        """Disconnect a layer from its context. This means the Context will no longer track this layer."""
+        layer_dict._remove_context(self.owner)
+
+    def _reindex_from(self, start: int) -> None:
+        """Update indices of all layers from start onwards."""
+        for new_layer_index, layer_dict in enumerate(self):
+            # Update the layer index in place
+            layer_dict._cache_layer_index(self.owner, new_layer_index)
+
+    def _create_index_map(self) -> Dict[int, int]:
+        """Create a mapping of current indices to track reordering."""
+        index_map = {}
+        for curr_layer_index, layer_dict in enumerate(self):
+            # Get the value as stored in the layer.
+            old_cached_index = layer_dict._get_cached_layer_index(self.owner)
+            # This mapping basically says:
+            # "The old index that's stored in the layer should be updated to the new index of this layer"
+            index_map[old_cached_index] = curr_layer_index
+        return index_map
+
+    def _apply_index_map(self, index_map: Dict[int, int]) -> None:
+        """Apply new indices to ContextLayers and update context's key index."""
+        for layer_dict in self:
+            # Get the value as stored in the layer. This is the value we want to update.
+            # NOTE: This may raise ValueError if the layer is no longer connected to the context
+            try:
+                old_index = layer_dict._get_cached_layer_index(self.owner)
+            except ValueError:
+                continue
+
+            # NOTE: Some indices may not be in the index_map, in which case we assume
+            # that they didn't move.
+            if old_index in index_map:
+                new_index = index_map[old_index]
+                layer_dict._cache_layer_index(self.owner, new_index)
+
+        # Update context's key index
+        self.owner._remap_layer_indices(index_map)
+
+    # The original `append()` method
+    def _append(self, value: Union[dict, "ContextLayer"]) -> None:
+        super().append(value)  # type: ignore[arg-type]
+
+    # The original `extend()` method
+    def _extend(self, values: Iterable[Union[dict, "ContextLayer"]]) -> None:
+        super().extend(values)  # type: ignore[arg-type]
+
+    ##################################################
+    # LIST API OVERRIDES
+    ##################################################
+
+    # For `sort()` and `reverse()`, there's no addition / removal. Also,
+    # the order of dicts can totally change.
+    # One approach could be to clear the Context, and then push the new list.
+    #
+    # But instead, in hopes of being more efficient, we'll just update the indices
+    # after the sort / reverse.
+    #
+    # 1. Store indices of each item as they were before,
+    # 2. Sort/reverse
+    # 3. Get updated indices
+    # 4. With the before and after, we can construct a map of old_index -> new_index.
+    # 5. Tell `BaseContext` to remap the key indices based on this transformation map.
+    def sort(self, *args: Any, **kwargs: Any) -> None:
+        """Sort the list in place and update indices."""
+        # Store current indices
+        old_indices = self._create_index_map()
+
+        # Perform the sort
+        super().sort(*args, **kwargs)
+
+        # Create mapping of old indices to new positions
+        new_indices = self._create_index_map()
+        index_map = {old: new_indices[old] for old in old_indices}
+
+        # Apply the new indices
+        self._apply_index_map(index_map)
+
+    def reverse(self) -> None:
+        """Reverse the list in place and update indices."""
+        # Store current indices
+        old_indices = self._create_index_map()
+
+        # Perform the reverse
+        super().reverse()
+
+        # Create mapping of old indices to new positions
+        new_indices = self._create_index_map()
+        index_map = {old: new_indices[old] for old in old_indices}
+
+        # Apply the new indices
+        self._apply_index_map(index_map)
+
+    # For `append()` and `extend()`, there's no removal, only addition
+    # at the end of the list. So we only need to make sure that the new
+    # dicts are indexed by creating new ContextLayers.
+    def append(self, value: Union[dict, "ContextLayer"]) -> None:
+        """Append a new dict, converting to ContextLayer if needed."""
+        if not isinstance(value, ContextLayer):
+            value = ContextLayer(value)
+
+        # Add this context to the layer
+        value._add_context(self.owner, len(self))
+        super().append(value)
+
+    def extend(self, values: Iterable[Union[dict, "ContextLayer"]]) -> None:
+        """Extend list with new layers, converting each to ContextLayer if needed."""
+        start_idx = len(self)
+        for idx, value in enumerate(values, start_idx):
+            if not isinstance(value, ContextLayer):
+                value = ContextLayer(value)
+
+            # Add this context to the layer
+            value._add_context(self.owner, idx)
+            super().append(value)
+
+    def insert(self, index: SupportsIndex, value: Union[dict, "ContextLayer"]) -> None:
+        """Insert a new layer at index, shifting other layers right."""
+        index = index.__index__()
+
+        # Normalize negative indices
+        if index < 0:
+            index = max(0, len(self) + index)
+
+        # Shift indices by +1 for all items AFTER the insertion point (inclusive)
+        index_map = {}
+        for layer_index in range(index, len(self)):  # NOTE: This is the insertion point
+            layer_dict = self[layer_index]
+            old_cached_index = layer_dict._get_cached_layer_index(self.owner)
+            # Shift indices by +1
+            index_map[old_cached_index] = layer_index + 1
+
+        self._apply_index_map(index_map)
+
+        if not isinstance(value, ContextLayer):
+            value = ContextLayer(value)
+
+        # Insert the new value
+        value._add_context(self.owner, index)
+        super().insert(index, value)
+
+    def pop(self, index: SupportsIndex = -1) -> "ContextLayer":
+        """Remove and return layer at index (default last)."""
+        index = index.__index__()
+
+        # Normalize negative indices
+        if index < 0:
+            index = len(self) + index
+
+        # Get the layer we'll remove
+        layer_to_remove = self[index]
+        layer_to_remove_index = layer_to_remove._get_cached_layer_index(self.owner)
+
+        # Unregister from Context all keys that were defined on this layer
+        for key in list(layer_to_remove.keys()):
+            self.owner._unregister_key(key, layer_to_remove_index)
+
+        # Disconnect the layer from the Context
+        self._disconnect_layer(layer_to_remove)
+
+        # Shift indices by -1 for all items AFTER the popped one.
+        if index != len(self) - 1:  # If not popping from end
+            index_map = {}
+
+            # NOTE: +1 Because we want to update indices of items AFTER the popped one
+            for layer_index in range(index + 1, len(self)):
+                layer_dict = self[layer_index]
+                old_cached_index = layer_dict._get_cached_layer_index(self.owner)
+                # Shift indices by -1
+                index_map[old_cached_index] = layer_index - 1
+
+            self._apply_index_map(index_map)
+
+        # Do the pop
+        return super().pop(index)
+
+    def remove(self, value: "ContextLayer") -> None:
+        """Remove first occurrence of value."""
+        # Raises ValueError if value not found
+        index = self.index(value)
+        self.pop(index)
+
+    def clear(self) -> None:
+        """Remove all items from the list."""
+        for layer_dict in self:
+            # Unregister from Context all keys that were defined on this layer
+            for key in list(layer_dict.keys()):
+                layer_index = layer_dict._get_cached_layer_index(self.owner)
+                self.owner._unregister_key(key, layer_index)
+
+            # Disconnect the layer from the Context
+            self._disconnect_layer(layer_dict)
+
+        super().clear()
+
+    # dicts[index] = value
+    #
+    # Handles both single item and slice assignment.
+    def __setitem__(self, index: Union[SupportsIndex, slice], value: Any) -> None:
+        raw_values = []
+
+        # Convert index or slice to a list of indices
+        if isinstance(index, slice):
+            start = index.start or 0
+            stop = index.stop if index.stop is not None else len(self)
+            indices = list(range(start, stop, index.step or 1))
+
+            if not isinstance(value, Iterable):
+                # Error message based on Python's error message
+                raise TypeError("can only assign an iterable to a slice")
+
+            raw_values = list(value)
+
+            # "Extended slice" is when the slice has a step that's not 1, e.g `my_list[3:4:2]`.
+            # In that case, Python requires that the length of the values matches
+            # the length of the indices. Even if the slice is empty, and even if
+            # the step is -1.
+            is_extended_slice: Optional[bool] = index.step is not None and index.step != 1
+            if is_extended_slice and len(raw_values) != len(indices):
+                # Error message based on Python's error message
+                raise ValueError(
+                    f"attempted to assign sequence of size {len(raw_values)} to extended slice of size {len(indices)}"
+                )
+        else:
+            # Case: Single item case - convert to list of one
+            indices = [index.__index__()]
+            raw_values = [value]
+            is_extended_slice = False
+
+        # Disconnect from Context those layers that will be overwritten
+        for layer_index in indices:
+            layer_dict = self[layer_index]
+            self._disconnect_layer(layer_dict)
+
+        # These are items that will be inserted in their place
+        new_layers: List[ContextLayer] = []
+        for raw_value in raw_values:
+            if isinstance(raw_value, ContextLayer):
+                new_layers.append(raw_value)
+            else:
+                new_layers.append(ContextLayer(raw_value))
+
+        if is_extended_slice:
+            # If this IS an extended slice, then this is a one-for-one replacement
+            # of the old layers with the new layers. So other indices don't shift.
+            for layer_index, new_layer in zip(indices, new_layers):
+                new_layer._add_context(self.owner, layer_index)
+                super().__setitem__(layer_index, new_layer)
+        else:
+            # However, if this is NOT an extended slice, then the number of added layers
+            # may not match the number of indices. So in this case the slice behaves like
+            # JavaScript's `Array.prototype.splice()`.
+            #
+            # In this case, we need to shift the indices of the layers AFTER the insertion point.
+            #
+            # For example, if we have `[1, 2, 3]` and we do `my_list[1:2] = [4, 5, 6]`,
+            # then we need to shift the indices of `[3]` to the right by 2.
+            index_shift = len(new_layers) - len(indices)
+
+            # First shift the indices of the layers AFTER the insertion point (inclusive)
+            # In this case the replacement indices MUST be continuous, so we can find
+            # the last affected index and shift all layers after it.
+            for layer_index in range(max(indices) + 1, len(self)):
+                layer_dict = self[layer_index]
+                layer_dict._cache_layer_index(self.owner, layer_index + index_shift)
+
+            # Then insert the new layers - These are added one after another, practically
+            # at the position of the first replaced index.
+            for layer_index, new_layer in enumerate(new_layers, start=min(indices)):
+                new_layer._add_context(self.owner, layer_index)
+                super().__setitem__(layer_index, new_layer)
+
+    def __delitem__(self, index: Union[SupportsIndex, slice]) -> None:
+        """Handle both single item deletion and slice deletion."""
+        # Convert index or slice to a list of indices and values
+        if isinstance(index, slice):
+            start = index.start or 0
+            stop = index.stop if index.stop is not None else len(self)
+            indices = list(range(start, stop, index.step or 1))
+        else:
+            # Single item case - convert to list of one
+            index = index.__index__()
+            indices = [index]
+
+        # Delete in reverse order to avoid the indices shifting
+        for idx in reversed(indices):
+            # TODO - POTENTIALLY OPTIMIZE BY DEFINING `_pop` that accepts a list of items
+            self.pop(idx)

--- a/src/django_components/util/context2_backup.py
+++ b/src/django_components/util/context2_backup.py
@@ -1,0 +1,727 @@
+from copy import copy
+from dataclasses import dataclass
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Set,
+    SupportsIndex,
+    Tuple,
+    Union,
+    cast,
+)
+
+from django.template.context import BaseContext as DjangoBaseContext
+
+
+# TODO - ADD ContextLayer.clear
+# TODO - ADD ContextLayer.copy
+# TODO - ADD ContextLayer.pop
+# TODO - ADD ContextLayer.popitem
+# TODO - ADD ContextLayer.setdefault
+
+
+class ContextPopException(Exception):
+    "pop() has been called more times than push()"
+    pass
+
+
+DictArg = Union[Mapping[Any, Any], Iterable[Tuple[Any, Any]], "BaseContext"]
+
+
+class DictsDescriptor:
+    """
+    Descriptor that handles direct assignments to `BaseContext.dicts`, e.g.
+
+    ```python
+    context = BaseContext()
+    context.dicts = [{"a": 1}, {"b": 2}]
+    ```
+
+    When `BaseContext.dicts` is assigned directly, we need to:
+    1. Clean up old dicts by removing their context references
+    2. Reset the context's state
+    3. Set up the new dicts properly
+
+    Ideally we wouldn't need this and all these mutations would go through
+    BaseContext methods. But since we're not in control of the Django templating,
+    we need to detect these mutations and handle them.
+    """
+
+    def __init__(self) -> None:
+        self.private_name = "_dicts"
+
+    def __get__(self, instance: Optional["BaseContext"], owner: type) -> List[Dict]:
+        # Accessing the attribute on class should raise AttributeError
+        if instance is None:
+            return getattr(owner, "dicts")
+
+        # On instance, return the private attribute
+        return getattr(instance, self.private_name)
+
+    def __set__(self, instance: "BaseContext", value: List[dict]) -> None:
+        # Clean up old layers by removing their context references
+        old_layers = cast(List[ContextLayer], getattr(instance, self.private_name, []))
+        for layer_dict in old_layers:
+            layer_dict._remove_context(instance)
+
+        # Reset the context's state
+        instance._key_index.clear()
+
+        # Create new ContextLayersList and populate it
+        new_layers = ContextLayersList(instance)
+        new_layers.extend(value)
+
+        # Set the new list
+        setattr(instance, self.private_name, new_layers)
+
+
+class BaseContext:
+
+    #####################################
+    # DJANGO API OVERRIDES
+    #####################################
+
+    dicts = DictsDescriptor()
+
+    def __init__(self, dict_: Optional[Union[dict, "BaseContext"]] = None) -> None:
+        self._key_index: Dict[str, List[int]] = {}  # Maps keys to layers they appear in
+        # We keep track of which key is defined in which layer. However, we only lazily
+        # sort the keys when they are accessed.
+        self._dirty_keys: Set[str] = set()
+        self._dicts = ContextLayersList(self)  # Use ContextLayersList for tracking mutations
+        self._reset_dicts(dict_)
+
+    def __hash__(self) -> int:
+        return id(self)
+
+    def _reset_dicts(self, *new_dicts: Optional[Union[dict, "BaseContext"]]) -> None:
+        # Clear
+        self._dicts = ContextLayersList(self)
+        self._key_index.clear()
+
+        # Set defaults
+        builtins = {"True": True, "False": False, "None": None}
+        self.push(builtins)
+
+        for value in new_dicts:
+            if value is not None:
+                self.push(value)
+
+    def __copy__(self) -> "BaseContext":
+        # Create new context instance
+        duplicate = cast(BaseContext, copy(super(DjangoBaseContext, self)))
+
+        # Initialize empty state
+        duplicate._key_index = {}
+        duplicate._dirty_keys = set()
+        duplicate._dicts = ContextLayersList(duplicate)
+
+        # Reuse existing ContextLayers by adding the new context to them
+        for idx, layer_dict in enumerate(self._dicts):
+            layer_dict._add_context(duplicate, idx)
+            duplicate._dicts._append(layer_dict)
+
+        return duplicate
+
+    def __getitem__(self, key: str) -> Any:
+        "Get a variable's value, starting at the current context and going upward"
+        if key in self._key_index:
+            return self.get(key)
+        raise KeyError(key)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        "Set a variable in the current context"
+        self._dicts[-1][key] = value
+
+    def __delitem__(self, key: str) -> None:
+        "Delete a variable from the current context"
+        del self._dicts[-1][key]
+
+    def set_upward(self, key: str, value: Any) -> None:
+        """
+        Set a variable in one of the higher contexts if it exists there,
+        otherwise in the current context.
+        """
+        if key in self._key_index:
+            latest_layer = self._get_latest_layer(key)
+            latest_layer[key] = value
+        else:
+            self[key] = value
+
+    def get(self, key: str, otherwise: Any = None) -> Any:
+        if key in self._key_index:
+            latest_layer = self._get_latest_layer(key)
+            return latest_layer[key]
+        return otherwise
+
+    def flatten(self) -> dict:
+        """Return self.dicts as one dictionary."""
+        flat: Dict[str, Any] = {}
+        # Use the key index to get the latest value for each key
+        for key in self._key_index:
+            latest_layer = self._get_latest_layer(key)
+            flat[key] = latest_layer[key]
+        return flat
+
+    def push(self, *args: DictArg, **kwargs: Any) -> "ContextDict":
+        new_layer = ContextLayer(*args, **kwargs)
+        new_layer._add_context(self, len(self._dicts))
+        self._dicts._append(new_layer)
+        return ContextDict(self, new_layer)
+
+    def pop(self) -> "ContextLayer":
+        if len(self._dicts) == 1:
+            raise ContextPopException
+        return self._dicts.pop()
+
+    def __repr__(self) -> str:
+        return repr(self._dicts)
+
+    def __iter__(self) -> Iterator[dict]:
+        return reversed(self._dicts)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._key_index
+
+    #####################################
+    # CUSTOM METHODS
+    #####################################
+
+    def _remap_layer_indices(self, index_map: Dict[int, int]) -> None:
+        """
+        Remap layer indices after a reordering operation.
+
+        Args:
+            index_map: old_layer_index -> new_layer_index mapping
+        """
+        # Create new key index with remapped layers
+        new_key_index: Dict[str, List[int]] = {}
+        for key, layer_indices in self._key_index.items():
+            # Map each layer to its new position and maintain reverse sort
+            new_layers = [
+                # NOTE: Some indices may not be in the index_map, in which case we assume
+                #       that they didn't move.
+                index_map[layer] if layer in index_map else layer
+                for layer in layer_indices
+            ]
+            self._dirty_keys.add(key)
+            new_key_index[key] = new_layers
+
+        self._key_index = new_key_index
+
+    def _register_key(self, key: str, layer: int) -> None:
+        """When a key is added to a layer, add it to the key index."""
+        if key not in self._key_index:
+            self._key_index[key] = []
+        if layer not in self._key_index[key]:
+            self._key_index[key].append(layer)
+            self._dirty_keys.add(key)
+
+    def _unregister_key(self, key: str, layer: int) -> None:
+        """When a key is removed from a layer, remove it from the key index."""
+        if key not in self._key_index:
+            return
+
+        try:
+            self._key_index[key].remove(layer)
+            if not self._key_index[key]:
+                del self._key_index[key]
+        except ValueError:
+            pass
+
+    def _get_latest_layer(self, key: str) -> "ContextLayer":
+        """Get the latest layer that contains the key."""
+        # Should raise KeyError if key not found
+        key_layers = self._key_index[key]
+
+        if key in self._dirty_keys:
+            key_layers.sort(reverse=True)  # Keep highest layers first
+            self._dirty_keys.remove(key)
+
+        latest_layer_index = key_layers[0]
+        return self._dicts[latest_layer_index]
+
+
+# TODO - API CHANGE FROM Django:
+#        Updated ContextDict not to subclass from dict. So that means that people
+#        will no longer be able to do `context.push({"d": 1})["d"]`.
+#        Instead, they should do `context.push({"d": 1}); context["d"]`
+class ContextDict:
+    """A context manager that adds and removes a dictionary from the context."""
+
+    def __init__(self, context: "BaseContext", dict_: "ContextLayer"):
+        self.context = context
+        self.dict = dict_
+
+    def __enter__(self) -> "ContextLayer":
+        return self.dict
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        self.context.pop()
+
+
+@dataclass
+class ContextBinding:
+    context: "BaseContext"
+    layer_index: int
+
+
+class ContextLayer(dict):
+    """A dictionary that notifies its parent Contexts of any changes."""
+
+    # NOTE: Although this accepts `*args`, it only uses the first argument.
+    #       The rest is passed to `dict.__init__()` and will raise an error.
+    def __init__(self, *args: DictArg, **kwargs: Any) -> None:
+        # It might happen that a single layer dictionary is pushed to multiple Contexts.
+        # And in those Contexts, it may be at different positions.
+        #
+        # Thus, we store which Contexts the the layer is "connected" to.
+        # And if we update this dict, we will update all contexts that have it.
+        #
+        # NOTE: If `Context.dicts` is reassigned manually, then `DictsDescriptor` will
+        #       remove the `context` from this dict
+        # NOTE: For easier access, the data is keyed by their ID
+        self.contexts: Dict[int, ContextBinding] = {}
+
+        arg = args[0] if args else None
+        new_dict: Dict[Any, Any] = {}
+        if arg is not None:
+            if isinstance(arg, (DjangoBaseContext, BaseContext)):
+                new_dict.update(arg.flatten())
+            else:
+                # NOTE: This should raise if arg is not a dict nor mapping / iterable
+                new_dict.update(arg)
+
+        # Let `dict` raise error if it received more than 1 positional argument
+        updated_args = (new_dict, *args[1:])
+        super().__init__(*updated_args, **kwargs)
+
+    #####################################
+    # CUSTOM METHODS
+    #####################################
+
+    def _get_context_binding(self, context: "BaseContext") -> Optional[ContextBinding]:
+        """Get the context binding for a specific context."""
+        context_id = id(context)
+        if context_id not in self.contexts:
+            return None
+
+        return self.contexts[context_id]
+
+    def _set_context_binding(self, context: "BaseContext", layer_index: int) -> None:
+        """Set the context binding for a specific context."""
+        context_id = id(context)
+        self.contexts[context_id] = ContextBinding(context, layer_index)
+
+    def _delete_context_binding(self, context: "BaseContext") -> None:
+        """Delete the context binding for a specific context."""
+        context_id = id(context)
+        del self.contexts[context_id]
+
+    def _add_context(self, context: "BaseContext", layer_index: int) -> None:
+        """Add a new context binding to this dict's contexts."""
+        context_binding = self._get_context_binding(context)
+        if context_binding is not None:
+            return
+
+        self._set_context_binding(context, layer_index)
+
+        # Register all keys in the new context
+        for key in self:
+            context._register_key(key, layer_index)
+
+    def _remove_context(self, context: "BaseContext") -> None:
+        """Remove a context binding from this dict's contexts."""
+        context_binding = self._get_context_binding(context)
+        if context_binding is None:
+            return
+
+        # Unregister all keys from the context that is being removed
+        for key in self:
+            context._unregister_key(key, context_binding.layer_index)
+
+        self._delete_context_binding(context)
+
+    def _get_cached_layer_index(self, context: "BaseContext") -> int:
+        """Get the index of the layer for a specific context."""
+        context_binding = self._get_context_binding(context)
+        if context_binding is None:
+            raise ValueError(f"Context {context} not found in this ContextLayer")
+
+        return context_binding.layer_index
+
+    def _cache_layer_index(self, context: "BaseContext", new_index: int) -> None:
+        """Set the index of the layer for a specific context."""
+        context_binding = self._get_context_binding(context)
+        if context_binding is None:
+            self._set_context_binding(context, new_index)
+        else:
+            context_binding.layer_index = new_index
+
+    #########################
+    # DICT API OVERRIDES
+    #########################
+
+    # dict[key] = value
+    def __setitem__(self, key: str, value: Any) -> None:
+        is_new_key = key not in self
+        super().__setitem__(key, value)
+        if is_new_key:
+            # Register new key in all contexts
+            for context_binding in self.contexts.values():
+                context_binding.context._register_key(key, context_binding.layer_index)
+
+    # del dict[key]
+    def __delitem__(self, key: str) -> None:
+        # NOTE: Raises KeyError if key not found
+        super().__delitem__(key)
+        # Unregister deleted key from all contexts
+        for context_binding in self.contexts.values():
+            context_binding.context._unregister_key(key, context_binding.layer_index)
+
+    # TODO - API CHANGE FROM DJANGO - If BaseContext is passed as arg, then it is flattened
+    def update(  # type: ignore[override]
+        self,
+        *args: DictArg,
+        **kwargs: Any,
+    ) -> None:
+        # Get new keys before update
+        self_keys: Set[str] = set(self.keys())
+        new_keys: Set[str] = set()
+
+        if args:
+            other = args[0]
+            if isinstance(other, (DjangoBaseContext, BaseContext)):
+                other = other.flatten()
+
+            if isinstance(other, dict):
+                new_keys = set(other.keys())
+            else:
+                new_keys = {k for k, v in other}  # Creates Set
+
+        new_keys.update(set(kwargs.keys()))
+        new_keys = new_keys - self_keys
+
+        super().update(*args, **kwargs)
+
+        # Register new keys in all contexts
+        if new_keys:
+            for context_binding in self.contexts.values():
+                for key in new_keys:
+                    context_binding.context._register_key(key, context_binding.layer_index)
+
+
+class ContextLayersList(List["ContextLayer"]):
+    """
+    A list subclass that notifies its parent context of any modifications.
+
+    This is used to track modifications to `BaseContext.dicts` when they happen
+    directly on the list object rather than through BaseContext's methods.
+
+    Ideally we wouldn't need this and all these mutations would go through
+    BaseContext methods. But since we're not in control of the Django templating,
+    we need to detect these mutations and handle them.
+    """
+
+    def __init__(self, owner: "BaseContext", *args: Any, **kwargs: Any) -> None:
+        self.owner = owner
+        super().__init__(*args, **kwargs)
+
+    #####################################
+    # CUSTOM METHODS
+    #####################################
+
+    def _disconnect_layer(self, layer_dict: "ContextLayer") -> None:
+        """Disconnect a layer from its context. This means the Context will no longer track this layer."""
+        layer_dict._remove_context(self.owner)
+
+    def _reindex_from(self, start: int) -> None:
+        """Update indices of all layers from start onwards."""
+        for new_layer_index, layer_dict in enumerate(self):
+            # Update the layer index in place
+            layer_dict._cache_layer_index(self.owner, new_layer_index)
+
+    def _create_index_map(self) -> Dict[int, int]:
+        """Create a mapping of current indices to track reordering."""
+        index_map = {}
+        for curr_layer_index, layer_dict in enumerate(self):
+            # Get the value as stored in the layer.
+            old_cached_index = layer_dict._get_cached_layer_index(self.owner)
+            # This mapping basically says:
+            # "The old index that's stored in the layer should be updated to the new index of this layer"
+            index_map[old_cached_index] = curr_layer_index
+        return index_map
+
+    def _apply_index_map(self, index_map: Dict[int, int]) -> None:
+        """Apply new indices to ContextLayers and update context's key index."""
+        for layer_dict in self:
+            # Get the value as stored in the layer. This is the value we want to update.
+            # NOTE: This may raise ValueError if the layer is no longer connected to the context
+            try:
+                old_index = layer_dict._get_cached_layer_index(self.owner)
+            except ValueError:
+                continue
+
+            # NOTE: Some indices may not be in the index_map, in which case we assume
+            # that they didn't move.
+            if old_index in index_map:
+                new_index = index_map[old_index]
+                layer_dict._cache_layer_index(self.owner, new_index)
+
+        # Update context's key index
+        self.owner._remap_layer_indices(index_map)
+
+    # The original `append()` method
+    def _append(self, value: Union[dict, "ContextLayer"]) -> None:
+        super().append(value)  # type: ignore[arg-type]
+
+    # The original `extend()` method
+    def _extend(self, values: Iterable[Union[dict, "ContextLayer"]]) -> None:
+        super().extend(values)  # type: ignore[arg-type]
+
+    ##################################################
+    # LIST API OVERRIDES
+    ##################################################
+
+    # For `sort()` and `reverse()`, there's no addition / removal. Also,
+    # the order of dicts can totally change.
+    # One approach could be to clear the Context, and then push the new list.
+    #
+    # But instead, in hopes of being more efficient, we'll just update the indices
+    # after the sort / reverse.
+    #
+    # 1. Store indices of each item as they were before,
+    # 2. Sort/reverse
+    # 3. Get updated indices
+    # 4. With the before and after, we can construct a map of old_index -> new_index.
+    # 5. Tell `BaseContext` to remap the key indices based on this transformation map.
+    def sort(self, *args: Any, **kwargs: Any) -> None:
+        """Sort the list in place and update indices."""
+        # Store current indices
+        old_indices = self._create_index_map()
+
+        # Perform the sort
+        super().sort(*args, **kwargs)
+
+        # Create mapping of old indices to new positions
+        new_indices = self._create_index_map()
+        index_map = {old: new_indices[old] for old in old_indices}
+
+        # Apply the new indices
+        self._apply_index_map(index_map)
+
+    def reverse(self) -> None:
+        """Reverse the list in place and update indices."""
+        # Store current indices
+        old_indices = self._create_index_map()
+
+        # Perform the reverse
+        super().reverse()
+
+        # Create mapping of old indices to new positions
+        new_indices = self._create_index_map()
+        index_map = {old: new_indices[old] for old in old_indices}
+
+        # Apply the new indices
+        self._apply_index_map(index_map)
+
+    # For `append()` and `extend()`, there's no removal, only addition
+    # at the end of the list. So we only need to make sure that the new
+    # dicts are indexed by creating new ContextLayers.
+    def append(self, value: Union[dict, "ContextLayer"]) -> None:
+        """Append a new dict, converting to ContextLayer if needed."""
+        if not isinstance(value, ContextLayer):
+            value = ContextLayer(value)
+
+        # Add this context to the layer
+        value._add_context(self.owner, len(self))
+        super().append(value)
+
+    def extend(self, values: Iterable[Union[dict, "ContextLayer"]]) -> None:
+        """Extend list with new layers, converting each to ContextLayer if needed."""
+        start_idx = len(self)
+        for idx, value in enumerate(values, start_idx):
+            if not isinstance(value, ContextLayer):
+                value = ContextLayer(value)
+
+            # Add this context to the layer
+            value._add_context(self.owner, idx)
+            super().append(value)
+
+    def insert(self, index: SupportsIndex, value: Union[dict, "ContextLayer"]) -> None:
+        """Insert a new layer at index, shifting other layers right."""
+        index = index.__index__()
+
+        # Normalize negative indices
+        if index < 0:
+            index = max(0, len(self) + index)
+
+        # Shift indices by +1 for all items AFTER the insertion point (inclusive)
+        index_map = {}
+        for layer_index in range(index, len(self)): # NOTE: This is the insertion point
+            layer_dict = self[layer_index]
+            old_cached_index = layer_dict._get_cached_layer_index(self.owner)
+            # Shift indices by +1
+            index_map[old_cached_index] = layer_index + 1
+
+        self._apply_index_map(index_map)
+
+        if not isinstance(value, ContextLayer):
+            value = ContextLayer(value)
+
+        # Insert the new value
+        value._add_context(self.owner, index)
+        super().insert(index, value)
+
+    def pop(self, index: SupportsIndex = -1) -> "ContextLayer":
+        """Remove and return layer at index (default last)."""
+        index = index.__index__()
+
+        # Normalize negative indices
+        if index < 0:
+            index = len(self) + index
+
+        # Get the layer we'll remove
+        layer_to_remove = self[index]
+        layer_to_remove_index = layer_to_remove._get_cached_layer_index(self.owner)
+
+        # Unregister from Context all keys that were defined on this layer
+        for key in list(layer_to_remove.keys()):
+            self.owner._unregister_key(key, layer_to_remove_index)
+
+        # Disconnect the layer from the Context
+        self._disconnect_layer(layer_to_remove)
+
+        # Shift indices by -1 for all items AFTER the popped one.
+        if index != len(self) - 1:  # If not popping from end
+            index_map = {}
+
+            # NOTE: +1 Because we want to update indices of items AFTER the popped one
+            for layer_index in range(index + 1, len(self)):
+                layer_dict = self[layer_index]
+                old_cached_index = layer_dict._get_cached_layer_index(self.owner)
+                # Shift indices by -1
+                index_map[old_cached_index] = layer_index - 1
+
+            self._apply_index_map(index_map)
+
+        # Do the pop
+        return super().pop(index)
+
+    def remove(self, value: "ContextLayer") -> None:
+        """Remove first occurrence of value."""
+        # Raises ValueError if value not found
+        index = self.index(value)
+        self.pop(index)
+
+    def clear(self) -> None:
+        """Remove all items from the list."""
+        for layer_dict in self:
+            # Unregister from Context all keys that were defined on this layer
+            for key in list(layer_dict.keys()):
+                layer_index = layer_dict._get_cached_layer_index(self.owner)
+                self.owner._unregister_key(key, layer_index)
+
+            # Disconnect the layer from the Context
+            self._disconnect_layer(layer_dict)
+
+        super().clear()
+
+    # dicts[index] = value
+    #
+    # Handles both single item and slice assignment.
+    def __setitem__(self, index: Union[SupportsIndex, slice], value: Any) -> None:
+        raw_values = []
+
+        # Convert index or slice to a list of indices
+        if isinstance(index, slice):
+            start = index.start or 0
+            stop = index.stop if index.stop is not None else len(self)
+            indices = list(range(start, stop, index.step or 1))
+
+            if not isinstance(value, Iterable):
+                # Error message based on Python's error message
+                raise TypeError("can only assign an iterable to a slice")
+
+            raw_values = list(value)
+
+            # "Extended slice" is when the slice has a step that's not 1, e.g `my_list[3:4:2]`.
+            # In that case, Python requires that the length of the values matches
+            # the length of the indices. Even if the slice is empty, and even if
+            # the step is -1.
+            is_extended_slice: Optional[bool] = index.step is not None and index.step != 1
+            if is_extended_slice and len(raw_values) != len(indices):
+                # Error message based on Python's error message
+                raise ValueError(
+                    f"attempted to assign sequence of size {len(raw_values)} to extended slice of size {len(indices)}"
+                )
+        else:
+            # Case: Single item case - convert to list of one
+            indices = [index.__index__()]
+            raw_values = [value]
+            is_extended_slice = False
+
+        # Disconnect from Context those layers that will be overwritten
+        for layer_index in indices:
+            layer_dict = self[layer_index]
+            self._disconnect_layer(layer_dict)
+
+        # These are items that will be inserted in their place
+        new_layers: List[ContextLayer] = []
+        for raw_value in raw_values:
+            if isinstance(raw_value, ContextLayer):
+                new_layers.append(raw_value)
+            else:
+                new_layers.append(ContextLayer(raw_value))
+
+        if is_extended_slice:
+            # If this IS an extended slice, then this is a one-for-one replacement
+            # of the old layers with the new layers. So other indices don't shift.
+            for layer_index, new_layer in zip(indices, new_layers):
+                new_layer._add_context(self.owner, layer_index)
+                super().__setitem__(layer_index, new_layer)
+        else:
+            # However, if this is NOT an extended slice, then the number of added layers
+            # may not match the number of indices. So in this case the slice behaves like
+            # JavaScript's `Array.prototype.splice()`.
+            #
+            # In this case, we need to shift the indices of the layers AFTER the insertion point.
+            #
+            # For example, if we have `[1, 2, 3]` and we do `my_list[1:2] = [4, 5, 6]`,
+            # then we need to shift the indices of `[3]` to the right by 2.
+            index_shift = len(new_layers) - len(indices)
+
+            # First shift the indices of the layers AFTER the insertion point (inclusive)
+            # In this case the replacement indices MUST be continuous, so we can find
+            # the last affected index and shift all layers after it.
+            for layer_index in range(max(indices) + 1, len(self)):
+                layer_dict = self[layer_index]
+                layer_dict._cache_layer_index(self.owner, layer_index + index_shift)
+
+            # Then insert the new layers - These are added one after another, practically
+            # at the position of the first replaced index.
+            for layer_index, new_layer in enumerate(new_layers, start=min(indices)):
+                new_layer._add_context(self.owner, layer_index)
+                super().__setitem__(layer_index, new_layer)
+
+    def __delitem__(self, index: Union[SupportsIndex, slice]) -> None:
+        """Handle both single item deletion and slice deletion."""
+        # Convert index or slice to a list of indices and values
+        if isinstance(index, slice):
+            start = index.start or 0
+            stop = index.stop if index.stop is not None else len(self)
+            indices = list(range(start, stop, index.step or 1))
+        else:
+            # Single item case - convert to list of one
+            index = index.__index__()
+            indices = [index]
+
+        # Delete in reverse order to avoid the indices shifting
+        for idx in reversed(indices):
+            # TODO - POTENTIALLY OPTIMIZE BY DEFINING `_pop` that accepts a list of items
+            self.pop(idx)

--- a/tests/test_context2.py
+++ b/tests/test_context2.py
@@ -1,0 +1,1091 @@
+from copy import copy
+from typing import List, cast
+
+from django.template.context import BaseContext as DjangoBaseContext
+from django_components.util.context2 import BaseContext, ContextBinding, ContextPopException, ContextLayer
+
+from .django_test_setup import setup_test_config
+from .testutils import BaseTestCase
+
+setup_test_config({"autodiscover": False})
+
+
+# TODO - SLICES WHERE FEWER ITEMS BEING INSERTED THAN DELETED
+# TODO - SLICES WHERE MORE ITEMS BEING INSERTED THAN DELETED
+# TODO - ADD ContextLayer.clear
+# TODO - ADD ContextLayer.copy
+# TODO - ADD ContextLayer.pop
+# TODO - ADD ContextLayer.popitem
+# TODO - ADD ContextLayer.setdefault
+
+
+class DictsAssignmentTests(BaseTestCase):
+    """
+    Test that, when we assign a list of dicts to a context, the dicts are properly bound to the context.
+
+    ```py
+    context = BaseContext()
+    context.dicts = [{"a": 1}, {"b": 2, "c": 3}]  # <-- HERE
+    ```
+    """
+
+    def test_assign_list_of_regular_dicts(self):
+        # Create fresh context
+        context = BaseContext()
+        old_dicts = cast(List[ContextLayer], list(context.dicts))  # Copy of initial dicts
+
+        # Assign new dicts
+        new_dicts = [{"a": 1}, {"b": 2, "c": 3}]
+        context.dicts = new_dicts
+
+        # Verify conversion to ContextLayers
+        self.assertEqual(len(context.dicts), len(new_dicts))
+        for i, d in enumerate(cast(List[ContextLayer], context.dicts)):
+            self.assertIsInstance(d, ContextLayer)
+            self.assertEqual(d.contexts, {id(context): ContextBinding(context, i)})
+
+        # Verify key index
+        self.assertIn("a", context._key_index)
+        self.assertIn("b", context._key_index)
+        self.assertIn("c", context._key_index)
+        self.assertEqual(context._key_index["a"], [0])  # Layer 0
+        self.assertEqual(context._key_index["b"], [1])  # Layer 1
+        self.assertEqual(context._key_index["c"], [1])  # Layer 1
+
+        # Verify old dicts are unbound
+        for d in old_dicts:
+            self.assertEqual(d.contexts, {})
+
+        # Verify lookups work
+        self.assertEqual(context["a"], 1)
+        self.assertEqual(context["b"], 2)
+        self.assertEqual(context["c"], 3)
+
+    def test_assign_list_context_dict_bound_to_multiple_contexts(self):
+        # Create contexts
+        context = BaseContext()
+        other_context = BaseContext({"x": 1})
+        other_context.push({"y": 2})
+        other_indexed_dicts = cast(List[ContextLayer], list(other_context.dicts))
+
+        # Assign mix of regular and indexed dicts
+        new_dicts = [{"a": 4}, *other_indexed_dicts, {"z": 3}]
+        context.dicts = new_dicts
+
+        # Verify dicts of context
+        context_dicts = cast(List[ContextLayer], context.dicts)
+
+        self.assertEqual(len(context_dicts), 5)
+        for d in context_dicts:
+            self.assertIsInstance(d, ContextLayer)
+
+        # Bound only to context
+        self.assertEqual(context_dicts[0].contexts, {id(context): ContextBinding(context, 0)})
+        # Bound to context AND other_context
+        self.assertEqual(
+            context_dicts[1].contexts,
+            {id(context): ContextBinding(context, 1), id(other_context): ContextBinding(other_context, 0)},
+        )
+        self.assertEqual(
+            context_dicts[2].contexts,
+            {id(context): ContextBinding(context, 2), id(other_context): ContextBinding(other_context, 1)},
+        )
+        self.assertEqual(
+            context_dicts[3].contexts,
+            {id(context): ContextBinding(context, 3), id(other_context): ContextBinding(other_context, 2)},
+        )
+        # Bound only to context
+        self.assertEqual(context_dicts[4].contexts, {id(context): ContextBinding(context, 4)})
+
+        # Verify dicts of other_context
+        # Bound to context AND other_context
+        self.assertEqual(
+            other_indexed_dicts[0].contexts,
+            {id(context): ContextBinding(context, 1), id(other_context): ContextBinding(other_context, 0)},
+        )
+        self.assertEqual(
+            other_indexed_dicts[1].contexts,
+            {id(context): ContextBinding(context, 2), id(other_context): ContextBinding(other_context, 1)},
+        )
+        self.assertEqual(
+            other_indexed_dicts[2].contexts,
+            {id(context): ContextBinding(context, 3), id(other_context): ContextBinding(other_context, 2)},
+        )
+
+        # Verify key index
+        self.assertEqual(context._key_index["a"], [0])
+        self.assertEqual(context._key_index["True"], [1])
+        self.assertEqual(context._key_index["x"], [2])
+        self.assertEqual(context._key_index["y"], [3])
+        self.assertEqual(context._key_index["z"], [4])
+
+        # Verify lookups work
+        self.assertEqual(context["a"], 4)
+        self.assertEqual(context["True"], True)
+        self.assertEqual(context["x"], 1)
+        self.assertEqual(context["y"], 2)
+        self.assertEqual(context["z"], 3)
+
+    def test_assign_list_old_context_dict_bound_if_in_new_dicts_list(self):
+        # Create contexts
+        context = BaseContext({"x": 1})
+        context.push({"y": 2})
+        old_indexed_dicts = cast(List[ContextLayer], list(context.dicts))
+
+        # Assign mix of regular and indexed dicts
+        new_dicts = [{"a": 4}, *old_indexed_dicts, {"z": 3}]
+        context.dicts = new_dicts
+
+        # Verify all dicts are properly set up
+        context_dicts = cast(List[ContextLayer], context.dicts)
+        self.assertEqual(len(context_dicts), len(new_dicts))
+        for i, d in enumerate(context_dicts):
+            self.assertIsInstance(d, ContextLayer)
+
+        # Bound only to context
+        self.assertEqual(context_dicts[0].contexts, {id(context): ContextBinding(context, 0)})
+        # Bound to context AND other_context
+        self.assertEqual(context_dicts[1].contexts, {id(context): ContextBinding(context, 1)})
+        self.assertEqual(context_dicts[2].contexts, {id(context): ContextBinding(context, 2)})
+        self.assertEqual(context_dicts[3].contexts, {id(context): ContextBinding(context, 3)})
+        # Bound only to context
+        self.assertEqual(context_dicts[4].contexts, {id(context): ContextBinding(context, 4)})
+
+        # Verify old reference points to the same dicts
+        self.assertEqual(old_indexed_dicts[0].contexts, {id(context): ContextBinding(context, 1)})
+        self.assertEqual(old_indexed_dicts[1].contexts, {id(context): ContextBinding(context, 2)})
+        self.assertEqual(old_indexed_dicts[2].contexts, {id(context): ContextBinding(context, 3)})
+
+        # Verify key index
+        self.assertEqual(context._key_index["a"], [0])
+        self.assertEqual(context._key_index["True"], [1])
+        self.assertEqual(context._key_index["x"], [2])
+        self.assertEqual(context._key_index["y"], [3])
+        self.assertEqual(context._key_index["z"], [4])
+
+        # Verify lookups work
+        self.assertEqual(context["a"], 4)
+        self.assertEqual(context["True"], True)
+        self.assertEqual(context["x"], 1)
+        self.assertEqual(context["y"], 2)
+        self.assertEqual(context["z"], 3)
+
+    def test_assign_empty_list(self):
+        # Create context with some data
+        context = BaseContext()
+        context.push({"a": 1})
+        context.push({"b": 2})
+        old_dicts = cast(List[ContextLayer], list(context.dicts))
+
+        # Assign empty list
+        context.dicts = []
+
+        # Verify only builtins remain
+        self.assertEqual(len(context.dicts), 0)
+
+        # Verify old dicts are cleaned up
+        for d in old_dicts:
+            self.assertEqual(d.contexts, {})
+
+    def test_assign_raises_on_non_iterable(self):
+        # Create context with some data
+        context = BaseContext()
+        context.push({"a": 1})
+
+        with self.assertRaisesMessage(TypeError, "'NoneType' object is not iterable"):
+            context.dicts = None  # type: ignore
+
+
+class ListMutationTests(BaseTestCase):
+    def test_append_regular_dict(self):
+        context = BaseContext()
+
+        # Append a regular dict
+        context.dicts.append({"a": 1, "b": 2})
+
+        # Verify length increased
+        self.assertEqual(len(context.dicts), 2)
+
+        # Verify conversion to ContextLayer
+        new_dict = cast(ContextLayer, context.dicts[-1])
+        self.assertIsInstance(new_dict, ContextLayer)
+        self.assertEqual(new_dict.contexts, {id(context): ContextBinding(context, 1)})
+
+        # Verify key index
+        self.assertEqual(context._key_index["a"], [1])
+        self.assertEqual(context._key_index["b"], [1])
+
+        # Verify lookups work
+        self.assertEqual(context["a"], 1)
+        self.assertEqual(context["b"], 2)
+
+    def test_append_indexed_dict(self):
+        # Create two contexts
+        context = BaseContext()
+        other = BaseContext()
+        other.dicts.append({"x": 1, "y": 2})
+        other_indexed_dict = cast(ContextLayer, other.dicts[-1])
+
+        # Append ContextLayer from other context
+        context.dicts.append(other_indexed_dict)
+
+        # Verify length increased
+        self.assertEqual(len(context.dicts), 2)
+
+        # Verify dict was properly reindexed
+        new_dict = cast(ContextLayer, context.dicts[-1])
+        self.assertIsInstance(new_dict, ContextLayer)
+        self.assertEqual(
+            new_dict.contexts,
+            {id(context): ContextBinding(context, 1), id(other): ContextBinding(other, 1)},
+        )
+        self.assertIs(other_indexed_dict, new_dict)
+
+        # Verify key index
+        self.assertEqual(context._key_index["x"], [1])
+        self.assertEqual(context._key_index["y"], [1])
+
+        # Verify lookups work
+        self.assertEqual(context["x"], 1)
+        self.assertEqual(context["y"], 2)
+
+    def test_extend_with_regular_dicts(self):
+        context = BaseContext()
+
+        # Extend with regular dicts
+        new_dicts = [{"a": 1}, {"b": 2, "c": 3}]
+        context.dicts.extend(new_dicts)
+
+        # Verify length increased
+        self.assertEqual(len(context.dicts), 3)
+
+        # Verify conversion to ContextLayers
+        for i, d in enumerate(cast(List[ContextLayer], context.dicts)):
+            self.assertIsInstance(d, ContextLayer)
+            self.assertEqual(d.contexts, {id(context): ContextBinding(context, i)})
+
+        # Verify key index
+        self.assertEqual(context._key_index["True"], [0])
+        self.assertEqual(context._key_index["a"], [1])
+        self.assertEqual(context._key_index["b"], [2])
+        self.assertEqual(context._key_index["c"], [2])
+
+        # Verify lookups work
+        self.assertEqual(context["True"], True)
+        self.assertEqual(context["a"], 1)
+        self.assertEqual(context["b"], 2)
+        self.assertEqual(context["c"], 3)
+
+    def test_extend_with_mixed_dicts(self):
+        # Create two contexts
+        context = BaseContext()
+        other = BaseContext()
+        other.dicts.append({"x": 1})
+        indexed_dict = cast(ContextLayer, other.dicts[-1])
+
+        # Extend with mix of regular and indexed dicts
+        mixed_dicts = [{"a": 1}, indexed_dict, {"b": 2}]
+        context.dicts.extend(mixed_dicts)
+
+        # Verify length increased
+        self.assertEqual(len(context.dicts), 4)
+
+        # Verify all dicts are properly set up
+        context_dicts = cast(List[ContextLayer], context.dicts)
+        for d in context_dicts:
+            self.assertIsInstance(d, ContextLayer)
+
+        # Bound only to context
+        self.assertEqual(context_dicts[0].contexts, {id(context): ContextBinding(context, 0)})
+        self.assertEqual(context_dicts[1].contexts, {id(context): ContextBinding(context, 1)})
+        # Bound to context AND other_context
+        self.assertEqual(
+            context_dicts[2].contexts,
+            {id(context): ContextBinding(context, 2), id(other): ContextBinding(other, 1)},
+        )
+        # Bound only to context
+        self.assertEqual(context_dicts[3].contexts, {id(context): ContextBinding(context, 3)})
+
+        # The dict is shared between contexts
+        self.assertIs(indexed_dict, context.dicts[2])
+
+        # Verify key index
+        self.assertEqual(context._key_index["True"], [0])
+        self.assertEqual(context._key_index["a"], [1])
+        self.assertEqual(context._key_index["x"], [2])
+        self.assertEqual(context._key_index["b"], [3])
+
+        # Verify lookups work
+        self.assertEqual(context["True"], True)
+        self.assertEqual(context["a"], 1)
+        self.assertEqual(context["x"], 1)
+        self.assertEqual(context["b"], 2)
+
+    def test_insert_at_beginning(self):
+        # Create context with some data
+        context = BaseContext()
+        context.dicts.append({"a": 1})
+        context.dicts.append({"b": 2})
+
+        # Insert at beginning (after builtins)
+        context.dicts.insert(1, {"x": 3})
+
+        # Verify length increased
+        self.assertEqual(len(context.dicts), 4)
+
+        # Verify inserted dict is properly set up
+        inserted = cast(ContextLayer, context.dicts[1])
+        self.assertIsInstance(inserted, ContextLayer)
+        self.assertEqual(inserted.contexts, {id(context): ContextBinding(context, 1)})
+
+        # Verify subsequent items were reindexed
+        context_dicts = cast(List[ContextLayer], context.dicts)
+        self.assertEqual(context_dicts[2].contexts, {id(context): ContextBinding(context, 2)})
+        self.assertEqual(context_dicts[3].contexts, {id(context): ContextBinding(context, 3)})
+
+        # Verify key index
+        self.assertEqual(context._key_index["True"], [0])
+        self.assertEqual(context._key_index["x"], [1])
+        self.assertEqual(context._key_index["a"], [2])
+        self.assertEqual(context._key_index["b"], [3])
+
+        # Verify lookups work
+        self.assertEqual(context["True"], True)
+        self.assertEqual(context["x"], 3)
+        self.assertEqual(context["a"], 1)
+        self.assertEqual(context["b"], 2)
+
+    def test_insert_in_middle(self):
+        # Create context with some data
+        context = BaseContext()
+        context.dicts.append({"a": 1})
+        context.dicts.append({"b": 2})
+
+        # Insert in middle
+        context.dicts.insert(2, {"x": 3})
+
+        # Verify length increased
+        self.assertEqual(len(context.dicts), 4)
+
+        # Verify inserted dict is properly set up
+        inserted = cast(ContextLayer, context.dicts[2])
+        self.assertIsInstance(inserted, ContextLayer)
+        self.assertEqual(inserted.contexts, {id(context): ContextBinding(context, 2)})
+
+        # Verify only subsequent items were reindexed
+        context_dicts = cast(List[ContextLayer], context.dicts)
+        self.assertEqual(context_dicts[1].contexts, {id(context): ContextBinding(context, 1)})  # Unchanged
+        self.assertEqual(context_dicts[3].contexts, {id(context): ContextBinding(context, 3)})  # Reindexed
+
+        # Verify key index
+        self.assertEqual(context._key_index["True"], [0])
+        self.assertEqual(context._key_index["a"], [1])
+        self.assertEqual(context._key_index["x"], [2])
+        self.assertEqual(context._key_index["b"], [3])
+
+        # Verify lookups work
+        self.assertEqual(context["True"], True)
+        self.assertEqual(context["a"], 1)
+        self.assertEqual(context["x"], 3)
+        self.assertEqual(context["b"], 2)
+
+    def test_insert_from_end(self):
+        # Create context with some data
+        context = BaseContext()
+        context.dicts.append({"a": 1})
+        context.dicts.append({"b": 2})
+
+        # Insert at end
+        context.dicts.insert(-1, {"x": 3})
+
+        # Verify length increased
+        self.assertEqual(len(context.dicts), 4)
+
+        # Verify inserted dict is properly set up
+        inserted = cast(ContextLayer, context.dicts[-2])
+        self.assertIsInstance(inserted, ContextLayer)
+        self.assertEqual(inserted.contexts, {id(context): ContextBinding(context, 2)})
+
+        # Verify only subsequent items were reindexed
+        context_dicts = cast(List[ContextLayer], context.dicts)
+        self.assertEqual(context_dicts[1].contexts, {id(context): ContextBinding(context, 1)})  # Unchanged
+        self.assertEqual(context_dicts[3].contexts, {id(context): ContextBinding(context, 3)})  # Reindexed
+
+        # Verify key index
+        self.assertEqual(context._key_index["True"], [0])
+        self.assertEqual(context._key_index["a"], [1])
+        self.assertEqual(context._key_index["x"], [2])
+        self.assertEqual(context._key_index["b"], [3])
+
+        # Verify lookups work
+        self.assertEqual(context["True"], True)
+        self.assertEqual(context["a"], 1)
+        self.assertEqual(context["b"], 2)
+        self.assertEqual(context["x"], 3)
+
+    def test_pop_from_end(self):
+        # Create context with some data
+        context = BaseContext()
+        context.dicts.append({"a": 1})
+        context.dicts.append({"b": 2})
+
+        # Pop from end
+        popped = cast(ContextLayer, context.dicts.pop())
+
+        # Verify length decreased
+        self.assertEqual(len(context.dicts), 2)
+
+        # Verify popped dict is cleaned up
+        self.assertEqual(popped.contexts, {})
+
+        # Verify no reindexing was needed
+        context_dicts = cast(List[ContextLayer], context.dicts)
+        self.assertEqual(context_dicts[1].contexts, {id(context): ContextBinding(context, 1)})
+
+        # Verify key index
+        self.assertEqual(context._key_index["True"], [0])
+        self.assertEqual(context._key_index["a"], [1])
+        self.assertNotIn("b", context._key_index)
+
+        # Verify lookups
+        self.assertEqual(context["True"], True)
+        self.assertEqual(context["a"], 1)
+        with self.assertRaises(KeyError):
+            _ = context["b"]
+
+    def test_pop_from_middle(self):
+        # Create context with some data
+        context = BaseContext()
+        context.dicts.append({"a": 1})
+        context.dicts.append({"b": 2})
+        context.dicts.append({"c": 3})
+
+        # Pop from middle
+        popped = cast(ContextLayer, context.dicts.pop(2))
+
+        # Verify length decreased
+        self.assertEqual(len(context.dicts), 3)
+
+        # Verify popped dict is cleaned up
+        self.assertEqual(popped.contexts, {})
+
+        # Verify subsequent items were reindexed
+        context_dicts = cast(List[ContextLayer], context.dicts)
+        self.assertEqual(context_dicts[1].contexts, {id(context): ContextBinding(context, 1)})  # Unchanged
+        self.assertEqual(context_dicts[2].contexts, {id(context): ContextBinding(context, 2)})  # Reindexed
+
+        # Verify key index
+        self.assertEqual(context._key_index["True"], [0])
+        self.assertEqual(context._key_index["a"], [1])
+        self.assertNotIn("b", context._key_index)
+        self.assertEqual(context._key_index["c"], [2])  # Reindexed
+
+        # Verify lookups
+        self.assertEqual(context["True"], True)
+        self.assertEqual(context["a"], 1)
+        with self.assertRaises(KeyError):
+            _ = context["b"]
+        self.assertEqual(context["c"], 3)
+
+    def test_pop_from_beginning(self):
+        # Create context with some data
+        context = BaseContext()
+        context.dicts.append({"a": 1})
+        context.dicts.append({"b": 2})
+        context.dicts.append({"c": 3})
+
+        # Pop from beginning (after builtins)
+        popped = cast(ContextLayer, context.dicts.pop(1))
+
+        # Verify length decreased
+        self.assertEqual(len(context.dicts), 3)
+
+        # Verify popped dict is cleaned up
+        self.assertEqual(popped.contexts, {})
+
+        # Verify all subsequent items were reindexed
+        context_dicts = cast(List[ContextLayer], context.dicts)
+        self.assertEqual(context_dicts[1].contexts, {id(context): ContextBinding(context, 1)})  # Reindexed
+        self.assertEqual(context_dicts[2].contexts, {id(context): ContextBinding(context, 2)})  # Reindexed
+
+        # Verify key index
+        self.assertEqual(context._key_index["True"], [0])
+        self.assertNotIn("a", context._key_index)
+        self.assertEqual(context._key_index["b"], [1])  # Reindexed
+        self.assertEqual(context._key_index["c"], [2])  # Reindexed
+
+        # Verify lookups
+        self.assertEqual(context["True"], True)
+        with self.assertRaises(KeyError):
+            _ = context["a"]
+        self.assertEqual(context["b"], 2)
+        self.assertEqual(context["c"], 3)
+
+    def test_remove_existing_item(self):
+        # Create context with some data
+        context = BaseContext()
+        context.dicts.append({"a": 1})
+        context.dicts.append({"b": 2})
+        context.dicts.append({"c": 3})
+        to_remove = cast(ContextLayer, context.dicts[2])  # Middle item
+
+        # Remove middle item
+        context.dicts.remove(to_remove)
+
+        # Verify length decreased
+        self.assertEqual(len(context.dicts), 3)
+
+        # Verify removed dict is cleaned up
+        self.assertEqual(to_remove.contexts, {})
+
+        # Verify subsequent items were reindexed
+        context_dicts = cast(List[ContextLayer], context.dicts)
+        self.assertEqual(context_dicts[1].contexts, {id(context): ContextBinding(context, 1)})  # Unchanged
+        self.assertEqual(context_dicts[2].contexts, {id(context): ContextBinding(context, 2)})  # Reindexed
+
+        # Verify key index
+        self.assertEqual(context._key_index["True"], [0])
+        self.assertEqual(context._key_index["a"], [1])
+        self.assertNotIn("b", context._key_index)
+        self.assertEqual(context._key_index["c"], [2])  # Reindexed
+
+        # Verify lookups
+        self.assertEqual(context["True"], True)
+        self.assertEqual(context["a"], 1)
+        with self.assertRaises(KeyError):
+            _ = context["b"]
+        self.assertEqual(context["c"], 3)
+
+    def test_remove_nonexistent_item(self):
+        # Create context with some data
+        context = BaseContext()
+        context.dicts.append({"a": 1})
+
+        # Create a dict that's not in the context
+        nonexistent = ContextLayer({"x": 1})
+        other_context = BaseContext()
+        nonexistent._add_context(other_context, 0)
+
+        # Try to remove non-existent item
+        with self.assertRaises(ValueError):
+            context.dicts.remove(nonexistent)
+
+        # Verify nothing changed
+        self.assertEqual(len(context.dicts), 2)
+        self.assertEqual(context._key_index["a"], [1])
+        self.assertEqual(context["a"], 1)
+
+        # Verify nonexistent dict still has its original context
+        self.assertEqual(nonexistent.contexts, {id(other_context): ContextBinding(other_context, 0)})
+
+    def test_clear(self):
+        # Create context with some data
+        context = BaseContext()
+        context.dicts.append({"a": 1})
+        context.dicts.append({"b": 2})
+        old_dicts = cast(List[ContextLayer], list(context.dicts))
+
+        # Clear all items
+        context.dicts.clear()
+
+        # Verify also builtins removed
+        self.assertEqual(len(context.dicts), 0)
+        self.assertNotIn("True", context)
+
+        # Verify old dicts are cleaned up
+        for d in old_dicts:
+            self.assertIsInstance(d, ContextLayer)
+            self.assertEqual(d.contexts, {})
+
+        # Verify key index
+        self.assertEqual(set(context._key_index.keys()), set())
+
+
+class KeyIndexingTests(BaseTestCase):
+    def test_key_layer_tracking(self):
+        context = BaseContext()
+
+        # Add multiple layers with some shared keys
+        context.dicts.append({"a": 1, "b": 2})
+        context.dicts.append({"b": 3, "c": 4})
+        context.dicts.append({"a": 5, "d": 6})
+
+        # Touch the keys to ensure it's sorted
+        context["a"]
+        context["b"]
+        context["c"]
+        context["d"]
+
+        # Verify key index tracks all layers correctly
+        self.assertEqual(context._key_index["a"], [3, 1])  # Layers 1 and 3
+        self.assertEqual(context._key_index["b"], [2, 1])  # Layers 1 and 2
+        self.assertEqual(context._key_index["c"], [2])  # Layer 2 only
+        self.assertEqual(context._key_index["d"], [3])  # Layer 3 only
+
+        # Verify builtins are still tracked
+        self.assertEqual(context._key_index["True"], [0])
+        self.assertEqual(context._key_index["False"], [0])
+        self.assertEqual(context._key_index["None"], [0])
+
+    def test_key_shadowing(self):
+        context = BaseContext()
+
+        # Create layers with shadowed keys
+        context.dicts.append({"x": "layer1"})
+        context.dicts.append({"x": "layer2", "y": "only_layer2"})
+        context.dicts.append({"x": "layer3"})
+
+        # Verify most recent value is returned
+        self.assertEqual(context["x"], "layer3")
+        self.assertEqual(context["y"], "only_layer2")
+
+        # Pop top layer and verify shadowing
+        context.dicts.pop()
+        self.assertEqual(context["x"], "layer2")
+
+        # Pop middle layer and verify shadowing
+        context.dicts.pop()
+        self.assertEqual(context["x"], "layer1")
+        with self.assertRaises(KeyError):
+            _ = context["y"]
+
+    def test_key_deletion(self):
+        context = BaseContext()
+
+        # Create layers with shared keys
+        context.dicts.append({"a": 1, "b": 2})
+        context.dicts.append({"a": 3, "c": 4})
+
+        # Delete key from top layer
+        del context.dicts[-1]["a"]
+
+        # Verify key index is updated
+        self.assertEqual(context._key_index["a"], [1])  # Only layer 1 remains
+        self.assertEqual(context["a"], 1)  # Falls back to layer 1
+
+        # Delete key from remaining layer
+        del context.dicts[1]["a"]
+
+        # Verify key is completely removed
+        self.assertNotIn("a", context._key_index)
+        with self.assertRaises(KeyError):
+            _ = context["a"]
+
+        # Verify other keys are unaffected
+        self.assertEqual(context["b"], 2)
+        self.assertEqual(context["c"], 4)
+
+    def test_key_updates(self):
+        context = BaseContext()
+
+        # Create initial layer
+        context.dicts.append({"x": 1, "y": 2})
+        initial_x_layers = list(context._key_index["x"])
+
+        # Update existing key
+        context.dicts[1]["x"] = 10
+
+        # Verify key index unchanged but value updated
+        self.assertEqual(context._key_index["x"], initial_x_layers)
+        self.assertEqual(context["x"], 10)
+
+        # Add new layer with same key
+        context.dicts.append({"x": 20})
+
+        # Touch the key to ensure it's sorted
+        context["x"]
+
+        # Verify key index updated
+        self.assertEqual(context._key_index["x"], [2, 1])
+        self.assertEqual(context["x"], 20)
+
+        # Update in lower layer
+        context.dicts[1]["x"] = 30
+
+        # Verify shadowing maintained
+        self.assertEqual(context["x"], 20)  # Still shadowed by top layer
+
+    def test_key_index_consistency(self):
+        context = BaseContext()
+
+        # Add some initial data
+        context.dicts.append({"a": 1, "b": 2})
+        context.dicts.append({"b": 3, "c": 4})
+
+        # Perform various operations
+        context.dicts.insert(2, {"d": 5})
+        context.dicts.pop(1)
+        context.dicts.append({"a": 6})
+
+        # Verify key index accurately reflects final state
+        self.assertEqual(context._key_index["a"], [3])
+        self.assertEqual(context._key_index["b"], [2])
+        self.assertEqual(context._key_index["c"], [2])
+        self.assertEqual(context._key_index["d"], [1])
+
+        # Verify all lookups work correctly
+        self.assertEqual(context["a"], 6)
+        self.assertEqual(context["b"], 3)
+        self.assertEqual(context["c"], 4)
+        self.assertEqual(context["d"], 5)
+
+
+class ContextOperationTests(BaseTestCase):
+    def test_push_pop_behavior(self):
+        context = BaseContext()
+
+        # Test basic push/pop
+        context.push({"a": 1})
+        self.assertEqual(context["a"], 1)
+
+        context.push({"a": 2, "b": 3})
+        self.assertEqual(context["a"], 2)  # Shadowed
+        self.assertEqual(context["b"], 3)
+
+        # Test pop returns correct dict
+        popped = context.pop()
+        self.assertIsInstance(popped, dict)
+        self.assertEqual(popped, {"a": 2, "b": 3})
+
+        # Verify state after pop
+        self.assertEqual(context["a"], 1)  # Original value
+        with self.assertRaises(KeyError):
+            _ = context["b"]  # No longer exists
+
+        # Test pop with empty context (except builtins)
+        context.pop()
+        with self.assertRaises(KeyError):
+            _ = context["a"]
+
+        # Verify builtins remain
+        self.assertTrue(context["True"])
+        self.assertFalse(context["False"])
+        self.assertIsNone(context["None"])
+
+    def test_flatten_multiple_layers(self):
+        context = BaseContext()
+
+        # Create multiple layers with overlapping keys
+        context.push({"a": 1, "b": 2})
+        context.push({"b": 3, "c": 4})
+        context.push({"a": 5, "d": 6})
+
+        initial_len = len(context.dicts)
+
+        # Flatten the context
+        flattened = context.flatten()
+
+        self.assertIsInstance(flattened, dict)
+
+        # Verify flattened has correct values (most recent values)
+        self.assertEqual(flattened["a"], 5)
+        self.assertEqual(flattened["b"], 3)
+        self.assertEqual(flattened["c"], 4)
+        self.assertEqual(flattened["d"], 6)
+
+        # Verify original context is unchanged
+        self.assertEqual(len(context.dicts), initial_len)
+        self.assertEqual(context["a"], 5)
+
+        # Verify builtins are preserved in flattened context
+        self.assertTrue(flattened["True"])
+        self.assertFalse(flattened["False"])
+        self.assertIsNone(flattened["None"])
+
+    def test_set_upward_existing_key(self):
+        context = BaseContext()
+
+        # Create multiple layers
+        context.push({"x": 1})
+        context.push({"y": 2})
+        context.push({"z": 3})
+
+        # Set upward for key in bottom layer
+        context.set_upward("x", 10)
+        self.assertEqual(context["x"], 10)
+
+        # Set upward for key in middle layer
+        context.set_upward("y", 20)
+        self.assertEqual(context["y"], 20)
+
+        # Verify layers below modification point are unchanged
+        self.assertEqual(context.dicts[1]["x"], 10)
+        self.assertEqual(context.dicts[2]["y"], 20)
+
+        # Verify key indices are unchanged
+        self.assertEqual(context._key_index["x"], [1])
+        self.assertEqual(context._key_index["y"], [2])
+
+    def test_set_upward_new_key(self):
+        context = BaseContext()
+
+        # Create multiple layers
+        context.push({"a": 1})
+        context.push({"b": 2})
+
+        # Try to set upward for non-existent key
+        context.set_upward("c", 3)
+
+        # Verify key was added to top layer
+        self.assertEqual(context["c"], 3)
+        self.assertEqual(context._key_index["c"], [2])
+
+        # Verify existing keys are unchanged
+        self.assertEqual(context["a"], 1)
+        self.assertEqual(context["b"], 2)
+
+        # Verify key indices are unchanged for existing keys
+        self.assertEqual(context._key_index["a"], [1])
+        self.assertEqual(context._key_index["b"], [2])
+
+    def test_key_lookup_order(self):
+        context = BaseContext()
+
+        # Create layers with various patterns
+        context.push({"a": 1, "b": 1, "c": 1})  # Layer 1
+        context.push({"b": 2, "c": 2})  # Layer 2
+        context.push({"c": 3})  # Layer 3
+
+        # Test lookup order
+        self.assertEqual(context["a"], 1)  # Only in layer 1
+        self.assertEqual(context["b"], 2)  # Layer 2 shadows layer 1
+        self.assertEqual(context["c"], 3)  # Layer 3 shadows layer 2
+
+        # Pop top layer and verify new lookup order
+        context.pop()
+        self.assertEqual(context["c"], 2)  # Now from layer 2
+
+        # Pop middle layer and verify final lookup order
+        context.pop()
+        self.assertEqual(context["c"], 1)  # Now from layer 1
+
+    def test_copy_behavior(self):
+        # To test `copy`, the __copy__ method must be called from within
+        # a class that subclasses Django's BaseContext.
+        class ContextSubclass(BaseContext, DjangoBaseContext):
+            pass
+
+        context = ContextSubclass()
+
+        # Create original context with multiple layers
+        context.push({"a": 1, "b": {"nested": 2}})
+        context.push({"c": 3})
+        original_len = len(context.dicts)
+
+        # Create copy
+        copied = copy(context)
+
+        # Verify copy is a new context
+        self.assertIsInstance(copied, ContextSubclass)
+        self.assertIsNot(copied, context)
+
+        # Verify all layers are copied
+        self.assertEqual(len(copied.dicts), original_len)
+
+        # Verify values are equal but distinct
+        self.assertEqual(copied["a"], 1)
+        self.assertEqual(copied["b"]["nested"], 2)
+        self.assertEqual(copied["c"], 3)
+
+        # Verify each layer is properly bound to both contexts
+        for i, d in enumerate(cast(List[ContextLayer], context.dicts)):
+            self.assertEqual(
+                d.contexts, {id(context): ContextBinding(context, i), id(copied): ContextBinding(copied, i)}
+            )
+
+        # Verify nested dicts are only shallow copied
+        self.assertIs(copied.dicts[1]["b"], context.dicts[1]["b"])
+
+        # Modify original and verify copy is affected (since they share the same dicts)
+        context.dicts[1]["a"] = 10
+        context.dicts[1]["b"]["nested"] = 20
+        self.assertEqual(copied["a"], 10)  # Changed from 1 to 10 since dicts are shared
+        self.assertEqual(copied["b"]["nested"], 20)
+
+        # Verify builtins are present too
+        self.assertTrue(copied["True"])
+
+    def test_push_none_behavior(self):
+        context = BaseContext()
+
+        # Test pushing None
+        context.push(None)  # type: ignore
+
+        # Verify it creates an empty layer
+        self.assertEqual(len(context.dicts), 2)  # Builtins + empty layer
+        self.assertEqual(len(context.dicts[-1]), 0)
+
+        # Verify we can add to the empty layer
+        context.dicts[-1]["a"] = 1
+        self.assertEqual(context["a"], 1)
+
+    def test_push_empty_dict_behavior(self):
+        context = BaseContext()
+
+        # Test pushing empty dict
+        context.push({})
+
+        # Verify it creates an empty layer
+        self.assertEqual(len(context.dicts), 2)  # Builtins + empty layer
+        self.assertEqual(len(context.dicts[-1]), 0)
+
+        # Verify we can add to the empty layer
+        context.dicts[-1]["a"] = 1
+        self.assertEqual(context["a"], 1)
+
+    def test_pop_to_builtins(self):
+        context = BaseContext()
+
+        # Create multiple layers
+        context.push({"a": 1})
+        context.push({"b": 2})
+
+        # Pop all layers except builtins
+        while len(context.dicts) > 1:
+            context.pop()
+
+        # Verify only builtins remain
+        self.assertEqual(len(context.dicts), 1)
+        self.assertTrue(context["True"])
+
+        # Verify can't pop builtins layer
+        with self.assertRaises(ContextPopException):
+            context.pop()
+
+    def test_flatten_empty_layers(self):
+        context = BaseContext()
+
+        # Create context with empty layers
+        context.push({})
+        context.push({"a": 1})
+        context.push({})
+        context.push({"b": 2})
+        context.push({})
+
+        # Flatten context
+        flattened = context.flatten()
+
+        # Verify all data is preserved
+        self.assertEqual(flattened["a"], 1)
+        self.assertEqual(flattened["b"], 2)
+
+
+class EdgeCaseTests(BaseTestCase):
+    def test_negative_indices(self):
+        context = BaseContext()
+
+        # Setup test data
+        context.push({"a": 1})
+        context.push({"b": 2})
+        context.push({"c": 3})
+
+        # Test negative index access
+        self.assertEqual(context.dicts[-1]["c"], 3)
+        self.assertEqual(context.dicts[-2]["b"], 2)
+        self.assertEqual(context.dicts[-3]["a"], 1)
+
+        # Test negative index insertion
+        context.push({"d": 4})
+        context.dicts.insert(-1, {"x": 5})
+        self.assertEqual(context.dicts[-2]["x"], 5)
+        self.assertEqual(context.dicts[-1]["d"], 4)
+
+        # Test negative index deletion
+        popped = context.dicts.pop(-2)
+        self.assertEqual(popped["x"], 5)
+        self.assertEqual(context.dicts[-1]["d"], 4)
+
+        # Test out of bounds negative index
+        with self.assertRaises(IndexError):
+            _ = context.dicts[-10]
+
+    def test_invalid_operations(self):
+        # Test popping from empty context (except builtins)
+        context = BaseContext()
+        with self.assertRaises(ContextPopException):
+            context.pop()
+
+        # Test popping builtins layer
+        context = BaseContext()
+        context.dicts.pop(0)
+
+        # Test inserting before builtins layer
+        context = BaseContext()
+        context.dicts.insert(0, {"x": 1})
+
+        # Test deleting builtins layer
+        context = BaseContext()
+        del context.dicts[0]
+
+        # Test assigning to builtins layer
+        context = BaseContext()
+        context.dicts[0] = {"x": 1}
+
+        # Test clearing builtins
+        context = BaseContext()
+        context.dicts.clear()
+        self.assertEqual(len(context.dicts), 0)
+
+        # Test non-string keys
+        context = BaseContext({123: "a", None: "b"})
+        self.assertEqual(context[123], "a")  # type: ignore
+        self.assertEqual(context[None], "b")  # type: ignore
+
+        # Test modifying read-only builtins
+        context = BaseContext()
+        context.dicts[0]["True"] = False
+        self.assertEqual(context["True"], False)
+
+    def test_slice_operations(self):
+        context = BaseContext()
+
+        # Setup test data
+        context.push({"a": 1})
+        context.push({"b": 2})
+        context.push({"c": 3})
+        context.push({"d": 4})
+        context.push({"e": 5})
+        initial_len = len(context.dicts)
+
+        # Test basic slicing
+        slice_view = context.dicts[2:4]
+        self.assertEqual(len(slice_view), 2)
+        self.assertEqual(slice_view[0]["b"], 2)
+        self.assertEqual(slice_view[1]["c"], 3)
+
+        # Test slice with step
+        slice_view = context.dicts[1::2]  # Every other layer
+        self.assertEqual(len(slice_view), 3)
+        self.assertEqual(slice_view[0]["a"], 1)
+        self.assertEqual(slice_view[1]["c"], 3)
+        self.assertEqual(slice_view[2]["e"], 5)
+
+        # Test negative slice indices
+        slice_view = context.dicts[-3:-1]
+        self.assertEqual(len(slice_view), 2)
+        self.assertEqual(slice_view[0]["c"], 3)
+        self.assertEqual(slice_view[1]["d"], 4)
+
+        # Test slice deletion
+        del context.dicts[2:4]
+        self.assertEqual(len(context.dicts), initial_len - 2)
+        self.assertEqual(context.dicts[1]["a"], 1)
+        self.assertEqual(context.dicts[2]["d"], 4)
+        self.assertEqual(context.dicts[3]["e"], 5)
+
+        # Test slice assignment
+        context.dicts[1:3] = [{"x": 6}, {"y": 7}]
+        self.assertEqual(context.dicts[1]["x"], 6)
+        self.assertEqual(context.dicts[2]["y"], 7)
+
+        # Test SIMPLE slice with different length assignment is OK
+        context.dicts[1:2] = [{"p": 8}, {"q": 9}]
+        self.assertEqual(context.dicts[1]["p"], 8)
+        self.assertEqual(context.dicts[2]["q"], 9)
+
+        # Test EXTENDED slice (with step) with different length assignment
+        with self.assertRaises(ValueError):
+            context.dicts[1:2:3] = [{"p": 8}, {"q": 9}]  # Too many items
+
+        # Test slice including builtins
+        del context.dicts[0:2]  # Can't delete builtins


### PR DESCRIPTION
In https://github.com/django-components/django-components/issues/14#issuecomment-2631557434 I mentioned it might be worthwhile to check the time spent retrieving data from the Context object.

Well, it turned out to be red herring:
 - my implementation added a whole 1 second to the render, so 10x slower than original.
- I also wasn't able to find my previous claim about "~0.1s was spent accessing data from Context object".

I'm creating the PR to document the code and share how it can be done, but I won't pursue this further.

---

Under the belief that there was 100ms (~10%) to be gained, I tried to update the  `BaseContext` class, so that keys are indexed when being set. So that, on access, this would be O(1).

However, this wouldn't be maybe such a problem if Context was a black box. But because one can modify the context layers directly via `context.dicts`, and even modify indivual layers like so:

```py
ctx = Context()
ctx.dicts[0]["True"] = False

# or replace entirely
ctx.dicts = [{"a": 1}]
```

So I wanted to keep my patch compatible with this design.

But to achieve that, I had to expanded the implementation to also handle all of this:
- Detect when `context.dicts` is being set with Descriptors
- Make `context.dicts` a custom subclass of `list`, in order to detect in-place mutations like `list.pop`, `append`, etc.
- Each dictionary in `context.dicts` was also a custom subclass of `dict`, in order to detect in-place mutations and get / set / del operations.

All of that, only so that, when one adds a key like this:

```py
ctx.dicts[0]["True"] = False
```

Then this info would get to the Context(s) that have this dictionary in their `Context.dicts` list, so that each Context would have an awareness of which key is defined on which layer:

```py
{
    "True": [0],
    "data": [1, 5, 8],
    "header": [1],
}
```