### PR TITLE
Update indenting typo in slots_and_blocks.md

### DIFF
--- a/docs/guides/devguides/slots_and_blocks.md
+++ b/docs/guides/devguides/slots_and_blocks.md
@@ -5,44 +5,44 @@
     template was inlined. So if the "included" template contains `slot` tags, then the component
     uses those slots.
 
-        So if you have a template `abc.html`:
-        ```django
-        <div>
-          hello
-          {% slot "body" %}{% endslot %}
-        </div>
-        ```
+    So if you have a template `abc.html`:
+    ```django
+    <div>
+      hello
+      {% slot "body" %}{% endslot %}
+    </div>
+    ```
 
-        And components that make use of `abc.html` via `include` or `extends`:
-        ```py
-        from django_components import Component, register
+    And components that make use of `abc.html` via `include` or `extends`:
+    ```py
+    from django_components import Component, register
 
-        @register("my_comp_extends")
-        class MyCompWithExtends(Component):
-            template = """{% extends "abc.html" %}"""
+    @register("my_comp_extends")
+    class MyCompWithExtends(Component):
+        template = """{% extends "abc.html" %}"""
 
-        @register("my_comp_include")
-        class MyCompWithInclude(Component):
-            template = """{% include "abc.html" %}"""
-        ```
+    @register("my_comp_include")
+    class MyCompWithInclude(Component):
+        template = """{% include "abc.html" %}"""
+    ```
 
-        Then you can set slot fill for the slot imported via `include/extends`:
+    Then you can set slot fill for the slot imported via `include/extends`:
 
-        ```django
-        {% component "my_comp_extends" %}
-        	{% fill "body" %}
-        		123
-        	{% endfill %}
-        {% endcomponent %}
-        ```
+    ```django
+    {% component "my_comp_extends" %}
+        {% fill "body" %}
+            123
+        {% endfill %}
+    {% endcomponent %}
+    ```
 
-        And it will render:
-        ```html
-        <div>
-          hello
-          123
-        </div>
-        ```
+    And it will render:
+    ```html
+    <div>
+      hello
+      123
+    </div>
+    ```
 
 2.  Slot and block
 


### PR DESCRIPTION
Fix extra indent that was making the whole text of the list item appear as a code block.

![image](https://github.com/user-attachments/assets/fd47b4cc-015c-4755-a3d1-b1b47f7028c9)
