### PR TITLE
feat: add setting to specify a render type provider for ComponentDependencyMiddleware

### DIFF
--- a/src/django_components/__init__.py
+++ b/src/django_components/__init__.py
@@ -17,7 +17,11 @@ from django_components.component_registry import (
     registry,
 )
 from django_components.components import DynamicComponent
-from django_components.dependencies import render_dependencies
+from django_components.dependencies import (
+    render_dependencies,
+    static_document_render_type,
+    static_fragment_render_type,
+)
 from django_components.library import TagProtectedError
 from django_components.node import BaseNode, template_tag
 from django_components.slots import SlotContent, Slot, SlotFunc, SlotRef, SlotResult
@@ -71,6 +75,8 @@ __all__ = [
     "SlotFunc",
     "SlotRef",
     "SlotResult",
+    "static_document_render_type",
+    "static_fragment_render_type",
     "TagFormatterABC",
     "TagProtectedError",
     "TagResult",

--- a/src/django_components/app_settings.py
+++ b/src/django_components/app_settings.py
@@ -493,6 +493,8 @@ class ComponentsSettings(NamedTuple):
         See [Security notes](../../overview/security_notes).
     """
 
+    render_type_provider: Optional[str] = None
+
     tag_formatter: Optional[Union["TagFormatterABC", str]] = None
     """
     Configure what syntax is used inside Django templates to render components.
@@ -664,6 +666,7 @@ defaults = ComponentsSettings(
         # Python files
         ".py", ".pyc",
     ],
+    render_type_provider="django_components.static_document_render_type",
     tag_formatter="django_components.component_formatter",
     template_cache_size=128,
 )
@@ -754,6 +757,10 @@ class InternalSettings:
         except ValueError:
             valid_values = [behavior.value for behavior in ContextBehavior]
             raise ValueError(f"Invalid context behavior: {raw_value}. Valid options are {valid_values}")
+
+    @property
+    def RENDER_TYPE_PROVIDER(self) -> str:
+        return default(self._settings.render_type_provider, cast(str, defaults.render_type_provider))
 
     @property
     def TAG_FORMATTER(self) -> Union["TagFormatterABC", str]:


### PR DESCRIPTION
Currently the render type will always be `document` in the ComponentDependencyMiddleware and this can not be altered by the developer without providing his own middleware.

This PR adds a new setting that allows the user to customize the render type that is used for a given request and response. The default will be `document` regardless of the request or response.

Ultimately this allows the developer to provide his own render type provider which could e.g. look like the following for htmx:

```python
def htmx_render_type(request: HttpRequest, response: HttpResponse) -> Literal["document", "fragment"]:
    assert hasattr(request, "htmx"), "The htmx middleware is not installed"
    if request.htmx:
        return "fragment"
    return "document"
```