### PR TITLE
Bug : Relative path in `extends` and `include` does not work when using template_file

### DIFF
--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -737,7 +737,10 @@ class Component(
                 template: Template = cached_template(
                     template_string=template_body,
                     name=self.template_file or self.name,
-                    origin=Origin(name=self.template_file or get_import_path(self.__class__)),
+                    origin=Origin(
+                        name=self.template_file or get_import_path(self.__class__),
+                        template_name=self.template_file or self.name,
+                    ),
                 )
             else:
                 template = template_body

--- a/tests/templates/relative_extends.html
+++ b/tests/templates/relative_extends.html
@@ -1,0 +1,5 @@
+{% extends './block.html' %}
+
+{% block body %}
+  BLOCK OVERRIDEN
+{% endblock %}

--- a/tests/test_templatetags_extends.py
+++ b/tests/test_templatetags_extends.py
@@ -18,6 +18,15 @@ class BlockedAndSlottedComponent(Component):
     template_file = "blocked_and_slotted_template.html"
 
 
+class RelativeFileComponentUsingTemplateFile(Component):
+    template_file = "relative_extends.html"
+
+
+class RelativeFileComponentUsingGetTemplateName(Component):
+    def get_template_name(self, context):
+        return "relative_extends.html"
+
+
 #######################
 # TESTS
 #######################
@@ -833,6 +842,52 @@ class ExtendsCompatTests(BaseTestCase):
                     <footer>Default footer</footer>
                 </custom-template>
             </body>
+            </html>
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    @parametrize_context_behavior(["django", "isolated"])
+    def test_component_using_template_file_extends_relative_file(self):
+        registry.register("relative_file_component_using_template_file", RelativeFileComponentUsingTemplateFile)
+
+        template: types.django_html = """
+            {% load component_tags %}
+            {% component "relative_file_component_using_template_file" %}{% endcomponent %}
+        """
+        rendered = Template(template).render(Context())
+        expected = """
+            <!DOCTYPE html>
+            <html data-djc-id-a1bc3f="" lang="en">
+              <body>
+                <main role="main">
+                  <div class='container main-container'>
+                    BLOCK OVERRIDEN
+                  </div>
+                </main>
+              </body>
+            </html>
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    @parametrize_context_behavior(["django", "isolated"])
+    def test_component_using_get_template_name_extends_relative_file(self):
+        registry.register("relative_file_component_using_get_template_name", RelativeFileComponentUsingGetTemplateName)
+
+        template: types.django_html = """
+            {% load component_tags %}
+            {% component "relative_file_component_using_get_template_name" %}{% endcomponent %}
+        """
+        rendered = Template(template).render(Context())
+        expected = """
+            <!DOCTYPE html>
+            <html data-djc-id-a1bc3f="" lang="en">
+              <body>
+                <main role="main">
+                  <div class='container main-container'>
+                    BLOCK OVERRIDEN
+                  </div>
+                </main>
+              </body>
             </html>
         """
         self.assertHTMLEqual(rendered, expected)


### PR DESCRIPTION
Hi, i've created some test to demonstrate an issue i'm facing when : 
- Component use `template_file` to declare it's template
- template use `extends` or `include` with relative path e.g: `../base_template.html`
