### PR TITLE
refactor: fix error when template cache is set to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## v0.129
+
+#### Fix
+
+- Fix error when template cache setting (`template_cache_size`) is set to 0.
+
 ## v0.128
 
 #### Feat

--- a/src/django_components/util/cache.py
+++ b/src/django_components/util/cache.py
@@ -63,6 +63,10 @@ class LRUCache(Generic[T]):
         :param key: Key to insert or update.
         :param value: Value to associate with the key.
         """
+        # Noop if maxsize is set to 0
+        if self.maxsize is not None and self.maxsize <= 0:
+            return
+
         if key in self.cache:
             node = self.cache[key]
             # Update the value

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -43,6 +43,27 @@ class CacheTests(TestCase):
         self.assertEqual(cache.get("e"), None)
         self.assertEqual(cache.get("f"), None)
 
+    def test_cache_maxsize_zero(self):
+        cache = LRUCache[int](maxsize=0)
+
+        cache.set("a", 1)
+        self.assertEqual(cache.get("a"), None)
+
+        cache.set("b", 2)
+        cache.set("c", 3)
+        self.assertEqual(cache.get("b"), None)
+        self.assertEqual(cache.get("c"), None)
+
+        # Same with negative numbers
+        cache = LRUCache[int](maxsize=-1)
+        cache.set("a", 1)
+        self.assertEqual(cache.get("a"), None)
+
+        cache.set("b", 2)
+        cache.set("c", 3)
+        self.assertEqual(cache.get("b"), None)
+        self.assertEqual(cache.get("c"), None)
+
 
 class ComponentMediaCacheTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
Closes https://github.com/django-components/django-components/issues/974