### PR TITLE
refactor: fix missing docs dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,8 @@ detached = false
 # We only add black for formatting code in the docs
 dependencies = [
     "black",
+    "pygments",
+    "pygments-djc",
 ]
 
 [tool.hatch.env.collectors.mkdocs.docs]


### PR DESCRIPTION
Docs publish and release pipeline [failed](https://github.com/django-components/django-components/actions/runs/13433593422/job/37530728162) because I forgot to add the dependencies to pyproject.toml.

This should fix it

