### PR TITLE
refactor: save PR number to a file to access it when posting a benchmark comment

### DIFF
--- a/.github/workflows/pr-benchmark-comment.yml
+++ b/.github/workflows/pr-benchmark-comment.yml
@@ -86,6 +86,7 @@ jobs:
           script: |
             const fs = require('fs');
             const results = fs.readFileSync('./benchmark_results.md', 'utf8');
+            const issue_number = Number.parseInt(fs.readFileSync('./pr_number.txt', 'utf8'));
             const body = `## Performance Benchmark Results\n\nComparing PR changes against master branch:\n\n${results}`;
 
             // See https://octokit.github.io/rest.js/v21/#issues-create-comment
@@ -94,5 +95,5 @@ jobs:
               // See https://github.com/actions/toolkit/blob/662b9d91f584bf29efbc41b86723e0e376010e41/packages/github/src/context.ts#L66
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.workflow_run.pull_requests[0].number,
+              issue_number: issue_number,
             });

--- a/.github/workflows/pr-benchmark-generate.yml
+++ b/.github/workflows/pr-benchmark-generate.yml
@@ -93,6 +93,10 @@ jobs:
         echo "Comparing benchmarks..."
         mkdir -p pr
         asv compare upstream/master HEAD --factor 1.1 --split > ./pr/benchmark_results.md
+
+        # Save the PR number to a file, so that it can be used by the next step.
+        echo "${{ github.event.pull_request.number }}" > ./pr/pr_number.txt
+
         echo "Benchmarks comparison DONE."
 
     - name: Save benchmark results


### PR DESCRIPTION
The workflow for benchmarking the PR and posting the results consists of two Github actions:
1. Check out to PR, install deps, run the benchmarks, save them as files ([workflow artifacts](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow))
2. Load the saved file, and post it to the PR as a comment.

The second part is currently not working, because the second workflow is unable to get the metadata about which PR to write the comment to.

Don't know why that metadata is missing, there were some cases where it worked, and I wasn't able to figure out why it's not available.

So in this PR I'm trying a different approach to pass the PR number:
- Before, I tried accessing the metadata from within the second workflow with github script action with `context.payload.workflow_run.pull_requests[0].number`
- Now, instead, the first workflow pushes that info in an extra file pushed as a workflow artifact 

