### PR TITLE
ci: Make a separate PR when pushing release benchmark data

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,11 +46,6 @@ jobs:
 
       - name: Configure git
         run: |
-          # Get the master branch so we can run benchmarks on it
-          git remote add upstream https://github.com/${{ github.repository }}.git
-          git fetch origin master:master
-          git checkout master
-
           # required for "mike deploy" command below which pushes to gh-pages
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -62,6 +57,11 @@ jobs:
       - name: Run benchmarks for tag
         if: github.ref_type == 'tag' && github.event_name == 'push'
         run: |
+          # Get the master branch so we can run benchmarks on it
+          git remote add upstream https://github.com/${{ github.repository }}.git
+          git fetch origin master:master
+          git checkout master
+
           # Get tag name
           TAG=${GITHUB_REF#refs/tags/}
           echo "TAG: $TAG"
@@ -117,13 +117,29 @@ jobs:
           echo "Benchmarks site DONE."
 
           # Stage and commit benchmark results
+          # 1. Create a new branch and commit benchmark results
           echo "Staging and committing benchmark results..."
+          git checkout -b "benchmark-${TAG}"
           git add .asv/results/
           git add docs/benchmarks/
           git commit -m "Add benchmark results for ${TAG}"
           echo "Benchmark results committed."
-          git push origin master
+
+          # 2. Push to the new branch
+          echo "Pushing benchmark results to new branch..."
+          git push -u origin "benchmark-${TAG}"
+
+          # 3. Create a PR
+          PR_URL="$(gh pr create --title "chore: Add benchmark results for ${TAG}" --body "Add benchmark results for ${TAG}" --base master)"
+          echo "PR URL: ${PR_URL}"
+
+          # 4. Merge the PR
+          gh pr merge "${PR_URL}" --admin --squash --delete-branch
           echo "Benchmark results pushed to master."
+
+          # 5. Go back to the original branch
+          git checkout master
+          git pull
 
       ##############################
       # BUILD & DEPLOY DOCS


### PR DESCRIPTION
Fix (hopefully) for https://github.com/django-components/django-components/issues/1044.

The issue is that `master` is a protected branch, and the CI bot doesn't have permissions to push to that branch.

One potential workaround is to use the `gh` CLI tool to create a PR with the changes, and also push it, before updating the docs.