### PR TITLE
build: add support for py3.13 windows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: github-actions
+    # This actually targets ./.github/workflows/
+    # See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--
+    directory: "/"
+    schedule:
+      interval: monthly

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -15,12 +15,12 @@ jobs:
     if: github.repository == 'django-components/django-components'
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.13'
       
       - name: Install pypa/build
         run: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
             css = ["*.css"]
     ```
 
+#### Fix
+
+- Fix installation for Python 3.13 on Windows.
+
 ## v0.131
 
 #### Feat

--- a/docs/overview/compatibility.md
+++ b/docs/overview/compatibility.md
@@ -8,3 +8,18 @@ Django-components supports all supported combinations versions of [Django](https
 | 3.11           | 4.2, 5.0, 5.1  |
 | 3.12           | 4.2, 5.0, 5.1  |
 | 3.13           | 5.1            |
+
+### Operating systems
+
+django-components is tested against Ubuntu and Windows, and should work on any operating system that supports Python.
+
+!!! note
+
+    django-components uses Rust-based parsers for better performance.
+
+    These sub-packages are built with [maturin](https://github.com/PyO3/maturin)
+    which supports a wide range of operating systems, architectures, and Python versions ([see the full list](https://pypi.org/project/djc-core-html-parser/#files)).
+    
+    This should cover most of the cases.
+
+    However, if your environment is not supported, you will need to install Rust and Cargo to build the sub-packages from source.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     'Django>=4.2',
-    'djc-core-html-parser>=1.0',
+    'djc-core-html-parser>=1.0.2',
 ]
 license = {text = "MIT"}
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,7 +32,7 @@ distlib==0.3.9
     # via virtualenv
 django==5.1.7
     # via -r requirements-dev.in
-djc-core-html-parser==1.0.1
+djc-core-html-parser==1.0.2
     # via -r requirements-dev.in
 filelock==3.16.1
     # via

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -60,7 +60,7 @@ defusedxml==0.7.1
     # via cairosvg
 django==5.1.7
     # via hatch.envs.docs
-djc-core-html-parser==1.0.1
+djc-core-html-parser==1.0.2
     # via hatch.envs.docs
 ghp-import==2.1.0
     # via mkdocs

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
   django42: Django>=4.2,<4.3
   django50: Django>=5.0,<5.1
   django51: Django>=5.1,<5.2
-  djc-core-html-parser
+  djc-core-html-parser==1.0.2
   pytest
   pytest-xdist
   pytest-django


### PR DESCRIPTION
In https://github.com/django-components/djc-core-html-parser/pull/3 I've updated the parser package to be built also for Python 3.13, and released that as [v1.0.2](https://github.com/django-components/djc-core-html-parser/releases/tag/1.0.2).

The 1.0.2 release now contains also Windows + Python 3.13 build:

<img width="770" alt="Screenshot 2025-03-22 at 12 57 49" src="https://github.com/user-attachments/assets/8b233a5b-385d-4ffa-b2d0-252bbe4e6d15" />

Next, in this django-components package, I've pinned the `djc-core-html-parser` package, to ensure it uses the version with fixed builds.

Other than that, I also included other suggestions from https://github.com/django-components/django-components/issues/1053:

- Document that we use this Rust-based subpackage underneath + implications
- Update our Github Actions
- Update Dependabot to also update Github actions automatically

Closes https://github.com/django-components/django-components/issues/1053

<img width="743" alt="Screenshot 2025-03-22 at 12 45 58" src="https://github.com/user-attachments/assets/06c02669-f1bc-4c5b-82d1-221642f18b1d" />
