### PR TITLE
refactor: fix ext URLs lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,15 @@
     # settings.py
     COMPONENTS = {
         "extensions": [
-            "djc_ext_pydantic.PydanticExtension",
+            "djc_pydantic.PydanticExtension",
         ],
     }
     ```
+
+#### Fix
+
+- Fix the default value for `COMPONENTS.dirs`
+- Make it possible to resolve URLs added by extensions by their names
 
 ## v0.135
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
 
 #### Fix
 
-- Fix the default value for `COMPONENTS.dirs`
 - Make it possible to resolve URLs added by extensions by their names
 
 ## v0.135

--- a/docs/concepts/advanced/typing_and_validation.md
+++ b/docs/concepts/advanced/typing_and_validation.md
@@ -193,7 +193,7 @@ And add the extension to your project:
 ```py
 COMPONENTS = {
     "extensions": [
-        "djc_ext_pydantic.PydanticExtension",
+        "djc_pydantic.PydanticExtension",
     ],
 }
 ```

--- a/src/django_components/app_settings.py
+++ b/src/django_components/app_settings.py
@@ -722,7 +722,7 @@ class InternalSettings:
         self._settings = ComponentsSettings(
             autodiscover=default(components_settings.autodiscover, defaults.autodiscover),
             cache=default(components_settings.cache, defaults.cache),
-            dirs=default(components_settings.dirs, dirs_default),
+            dirs=dirs_default,
             app_dirs=default(components_settings.app_dirs, defaults.app_dirs),
             debug_highlight_components=default(
                 components_settings.debug_highlight_components, defaults.debug_highlight_components

--- a/src/django_components/app_settings.py
+++ b/src/django_components/app_settings.py
@@ -722,7 +722,7 @@ class InternalSettings:
         self._settings = ComponentsSettings(
             autodiscover=default(components_settings.autodiscover, defaults.autodiscover),
             cache=default(components_settings.cache, defaults.cache),
-            dirs=dirs_default,
+            dirs=default(components_settings.dirs, dirs_default),
             app_dirs=default(components_settings.app_dirs, defaults.app_dirs),
             debug_highlight_components=default(
                 components_settings.debug_highlight_components, defaults.debug_highlight_components

--- a/src/django_components/extension.py
+++ b/src/django_components/extension.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Tuple, 
 
 import django.urls
 from django.template import Context
-from django.urls import URLResolver, get_urlconf, get_resolver
+from django.urls import URLResolver, get_resolver, get_urlconf
 
 from django_components.app_settings import app_settings
 from django_components.compat.django import routes_to_django

--- a/src/django_components/extension.py
+++ b/src/django_components/extension.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Tuple, 
 
 import django.urls
 from django.template import Context
-from django.urls import URLResolver
+from django.urls import URLResolver, get_urlconf, get_resolver
 
 from django_components.app_settings import app_settings
 from django_components.compat.django import routes_to_django
@@ -633,6 +633,11 @@ class ExtensionManager:
         # - `url_patterns` to override the caching
         ext_url_resolver.urlconf_name = urls
         ext_url_resolver.url_patterns = urls
+
+        # Rebuild URL resolver cache to be able to resolve the new routes by their names.
+        urlconf = get_urlconf()
+        resolver = get_resolver(urlconf)
+        resolver._populate()
 
     def get_extension(self, name: str) -> ComponentExtension:
         for extension in self.extensions:

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -75,6 +75,8 @@ COMPONENTS = {
     "dirs": [Path(__file__).resolve().parent / "components"],
 }
 
+urlpatterns: list = []
+
 
 class StaticFilesFinderTests(SimpleTestCase):
     @djc_test(


### PR DESCRIPTION
Small fixes to be part of v0.136:


- Renamed the module import path of djc-ext-pydantic from `djc_ext_pydantic` to `djc_pydantic`
- Trigger `URLResolver._populate()` when we are registering extensions to allow the URLs introduced by extensions to be looked up with `reverse()`