### PR TITLE
docs: mention URL auto-gen in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,11 +253,16 @@ Read more about [HTML attributes](https://django-components.github.io/django-com
 
 - Expose components as views with `get`, `post`, `put`, `patch`, `delete` methods
 
+- Automatically create an endpoint for the component with `Component.Url.public`
+
 ```py
 # components/calendar/calendar.py
 @register("calendar")
 class Calendar(Component):
     template_file = "calendar.html"
+
+    class Url:
+        public = True
 
     class View:
         def get(self, request, *args, **kwargs):
@@ -274,8 +279,11 @@ class Calendar(Component):
             "page": page,
         }
 
-# urls.py
-path("calendar/", Calendar.as_view()),
+# Get auto-generated URL for the component
+url = get_component_url(Calendar)
+
+# Or define explicit URL in urls.py
+path("calendar/", Calendar.as_view())
 ```
 
 ### Type hints

--- a/docs/overview/welcome.md
+++ b/docs/overview/welcome.md
@@ -243,11 +243,16 @@ Read more about [HTML attributes](../../concepts/fundamentals/html_attributes/).
 
 - Expose components as views with `get`, `post`, `put`, `patch`, `delete` methods
 
+- Automatically create an endpoint for the component with `Component.Url.public`
+
 ```py
 # components/calendar/calendar.py
 @register("calendar")
 class Calendar(Component):
     template_file = "calendar.html"
+
+    class Url:
+        public = True
 
     class View:
         def get(self, request, *args, **kwargs):
@@ -264,8 +269,11 @@ class Calendar(Component):
             "page": page,
         }
 
-# urls.py
-path("calendar/", Calendar.as_view()),
+# Get auto-generated URL for the component
+url = get_component_url(Calendar)
+
+# Or define explicit URL in urls.py
+path("calendar/", Calendar.as_view())
 ```
 
 ### Type hints


### PR DESCRIPTION
Tiny docs update to mention the URL endpoint auto generation in the README in the HTML fragment section. What prompted me was that there was a positive feedback from one guy on Reddit on this feature, but I realized that it's not mentioned in the overview.