### PR TITLE
refactor: fix compat with Django 5.2 Finder.find()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## v0.139
+
+#### Fix
+
+- Fix bug: Fix compatibility with `Finder.find()` in Django 5.2 ([#1119](https://github.com/django-components/django-components/issues/1119))
+
 ## v0.138
 
 #### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django_components"
-version = "0.138"
+version = "0.139"
 requires-python = ">=3.8, <4.0"
 description = "A way to create simple reusable template components in Django."
 keywords = ["django", "components", "css", "js", "html"]

--- a/src/django_components/finders.py
+++ b/src/django_components/finders.py
@@ -2,6 +2,7 @@ import os
 import re
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
+from django import VERSION as DJANGO_VERSION
 from django.contrib.staticfiles.finders import BaseFinder
 from django.contrib.staticfiles.utils import get_files
 from django.core.checks import CheckMessage, Error, Warning
@@ -90,17 +91,32 @@ class ComponentsFileSystemFinder(BaseFinder):
         return errors
 
     # NOTE: Same as `FileSystemFinder.find`
-    def find(self, path: str, all: bool = False) -> Union[List[str], str]:
+    def find(self, path: str, **kwargs: Any) -> Union[List[str], str]:
         """
         Look for files in the extra locations as defined in COMPONENTS.dirs.
         """
+        # Handle deprecated `all` parameter:
+        # - In Django 5.2, the `all` parameter was deprecated in favour of `find_all`.
+        # - Between Django 5.2 (inclusive) and 6.1 (exclusive), the `all` parameter was still
+        #   supported, but an error was raised if both were provided.
+        # - In Django 6.1, the `all` parameter was removed.
+        #
+        # See https://github.com/django/django/blob/21f8be76d43aa1ee5ae41c1e0a428cfea1f231c1/django/contrib/staticfiles/finders.py#L58C9-L58C37
+        # And https://github.com/django-components/django-components/issues/1119
+        if DJANGO_VERSION >= (5, 2) and DJANGO_VERSION < (6, 1):
+            find_all = self._check_deprecated_find_param(**kwargs)  # type: ignore
+        elif DJANGO_VERSION >= (6, 1):
+            find_all = kwargs.get("find_all", False)
+        else:
+            find_all = kwargs.get("all", False)
+
         matches: List[str] = []
         for prefix, root in self.locations:
             if root not in searched_locations:
                 searched_locations.append(root)
             matched_path = self.find_location(root, path, prefix)
             if matched_path:
-                if not all:
+                if not find_all:
                     return matched_path
                 matches.append(matched_path)
         return matches

--- a/src/django_components/finders.py
+++ b/src/django_components/finders.py
@@ -101,7 +101,7 @@ class ComponentsFileSystemFinder(BaseFinder):
         #   supported, but an error was raised if both were provided.
         # - In Django 6.1, the `all` parameter was removed.
         #
-        # See https://github.com/django/django/blob/21f8be76d43aa1ee5ae41c1e0a428cfea1f231c1/django/contrib/staticfiles/finders.py#L58C9-L58C37
+        # See https://github.com/django/django/blob/5.2/django/contrib/staticfiles/finders.py#L58C9-L58C37
         # And https://github.com/django-components/django-components/issues/1119
         if DJANGO_VERSION >= (5, 2) and DJANGO_VERSION < (6, 1):
             find_all = self._check_deprecated_find_param(**kwargs)  # type: ignore

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -1,6 +1,7 @@
 import re
 from pathlib import Path
 
+from django.contrib.staticfiles import finders
 from django.contrib.staticfiles.management.commands.collectstatic import Command
 from django.test import SimpleTestCase
 
@@ -224,3 +225,30 @@ class StaticFilesFinderTests(SimpleTestCase):
 
         self.assertListEqual(collected["unmodified"], [])
         self.assertListEqual(collected["post_processed"], [])
+
+    # Handle deprecated `all` parameter:
+    # - In Django 5.2, the `all` parameter was deprecated in favour of `find_all`.
+    # - Between Django 5.2 (inclusive) and 6.1 (exclusive), the `all` parameter was still
+    #   supported, but an error was raised if both were provided.
+    # - In Django 6.1, the `all` parameter was removed.
+    #
+    # See https://github.com/django/django/blob/21f8be76d43aa1ee5ae41c1e0a428cfea1f231c1/django/contrib/staticfiles/finders.py#L58C9-L58C37
+    # And https://github.com/django-components/django-components/issues/1119
+    @djc_test(
+        django_settings={
+            **common_settings,
+            "STATICFILES_FINDERS": [
+                # Default finders
+                "django.contrib.staticfiles.finders.FileSystemFinder",
+                "django.contrib.staticfiles.finders.AppDirectoriesFinder",
+                # Django components
+                "django_components.finders.ComponentsFileSystemFinder",
+            ],
+        },
+        components_settings=COMPONENTS,
+    )
+    def test_find_compat(self):
+        # NOTE: This would raise an error in Django 5.2 without a fix
+        result = finders.find("staticfiles/staticfiles.css")
+
+        assert result.endswith("django-components/tests/components/staticfiles/staticfiles.css")

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -232,7 +232,7 @@ class StaticFilesFinderTests(SimpleTestCase):
     #   supported, but an error was raised if both were provided.
     # - In Django 6.1, the `all` parameter was removed.
     #
-    # See https://github.com/django/django/blob/21f8be76d43aa1ee5ae41c1e0a428cfea1f231c1/django/contrib/staticfiles/finders.py#L58C9-L58C37
+    # See https://github.com/django/django/blob/5.2/django/contrib/staticfiles/finders.py#L58C9-L58C37
     # And https://github.com/django-components/django-components/issues/1119
     @djc_test(
         django_settings={
@@ -251,4 +251,4 @@ class StaticFilesFinderTests(SimpleTestCase):
         # NOTE: This would raise an error in Django 5.2 without a fix
         result = finders.find("staticfiles/staticfiles.css")
 
-        assert result.endswith("django-components/tests/components/staticfiles/staticfiles.css")
+        assert Path(result) == Path("./tests/components/staticfiles/staticfiles.css").resolve()


### PR DESCRIPTION
In Django 5.2 the `Finder.find()` attribute receives a `find_all` kwarg instead of `all` kwarg ([see changelog](https://docs.djangoproject.com/en/5.2/releases/5.2/#features-deprecated-in-5-2)). So, depending on the Django version, our `ComponentsFileSystemFinder` will use either one or another.

Closes https://github.com/django-components/django-components/issues/1119