### PR TITLE
refactor: use typevar defaults + raise on conflicting extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Release notes
 
-## v0.139
+## v0.139.1
+
+#### Refactor
+
+- When typing a Component, you can now specify as few or as many parameters as you want.
+
+    ```py
+    Component[Args]
+    Component[Args, Kwargs]
+    Component[Args, Kwargs, Slots]
+    Component[Args, Kwargs, Slots, Data]
+    Component[Args, Kwargs, Slots, Data, JsData]
+    Component[Args, Kwargs, Slots, Data, JsData, CssData]
+    ```
+
+    All omitted parameters will default to `Any`.
+
+- Added `typing_extensions` to the project as a dependency
+
+- Multiple extensions with the same name (case-insensitive) now raise an error
+
+- Extension names (case-insensitive) also MUST NOT conflict with existing Component class API.
+  
+    So if you name an extension `render`, it will conflict with the `render()` method of the `Component` class,
+    and thus raise an error.
+
+## v0.139.0
 
 #### Fix
 

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ Components API is fully typed, and supports [static type hints](https://django-c
 To opt-in to static type hints, define types for component's args, kwargs, slots, and more:
 
 ```py
-from typing import NotRequired, Tuple, TypedDict, SlotContent, SlotFunc
+from typing import NotRequired, Tuple, TypedDict, SlotContent, Slot
 
 from django_components import Component
 
@@ -407,22 +407,19 @@ class ButtonKwargs(TypedDict):
     another: int
     maybe_var: NotRequired[int] # May be omitted
 
-class ButtonData(TypedDict):
-    variable: str
-
 class ButtonSlots(TypedDict):
-    my_slot: NotRequired[SlotFunc]
+    # Use `Slot` for slot functions.
+    my_slot: NotRequired[Slot]
+    # Use `SlotContent` when you want to allow either `Slot` instance or plain string
     another_slot: SlotContent
 
-ButtonType = Component[ButtonArgs, ButtonKwargs, ButtonSlots, ButtonData, JsData, CssData]
+ButtonType = Component[ButtonArgs, ButtonKwargs, ButtonSlots]
 
 class Button(ButtonType):
     def get_context_data(self, *args, **kwargs):
         self.input.args[0]  # int
         self.input.kwargs["variable"]  # str
-        self.input.slots["my_slot"]  # SlotFunc[MySlotData]
-
-        return {}  # Error: Key "variable" is missing
+        self.input.slots["my_slot"]  # Slot[MySlotData]
 ```
 
 When you then call

--- a/docs/concepts/advanced/authoring_component_libraries.md
+++ b/docs/concepts/advanced/authoring_component_libraries.md
@@ -103,7 +103,7 @@ For live examples, see the [Community examples](../../overview/community.md#comm
     ```djc_py
     from typing import Dict, NotRequired, Optional, Tuple, TypedDict
 
-    from django_components import Component, SlotFunc, register, types
+    from django_components import Component, SlotContent, register, types
 
     from myapp.templatetags.mytags import comp_registry
 
@@ -114,7 +114,7 @@ For live examples, see the [Community examples](../../overview/community.md#comm
     type MyMenuArgs = Tuple[int, str]
 
     class MyMenuSlots(TypedDict):
-        default: NotRequired[Optional[SlotFunc[EmptyDict]]]
+        default: NotRequired[Optional[SlotContent[EmptyDict]]]
 
     class MyMenuProps(TypedDict):
         vertical: NotRequired[bool]
@@ -124,7 +124,7 @@ For live examples, see the [Community examples](../../overview/community.md#comm
     # Define the component
     # NOTE: Don't forget to set the `registry`!
     @register("my_menu", registry=comp_registry)
-    class MyMenu(Component[MyMenuArgs, MyMenuProps, MyMenuSlots, Any, Any, Any]):
+    class MyMenu(Component[MyMenuArgs, MyMenuProps, MyMenuSlots]):
         def get_context_data(
             self,
             *args,

--- a/docs/concepts/advanced/extensions.md
+++ b/docs/concepts/advanced/extensions.md
@@ -169,6 +169,14 @@ class MyExtension(ComponentExtension):
         ctx.component_cls.my_attr = "my_value"
 ```
 
+!!! warning
+
+    The `name` attribute MUST be unique across all extensions.
+
+    Moreover, the `name` attribute MUST NOT conflict with existing Component class API.
+
+    So if you name an extension `render`, it will conflict with the [`render()`](../../../reference/api/#django_components.Component.render) method of the `Component` class.
+
 ### Defining the extension class
 
 In previous sections we've seen the `View` and `Storybook` extensions classes that were nested within the `Component` class:

--- a/docs/concepts/fundamentals/components_in_python.md
+++ b/docs/concepts/fundamentals/components_in_python.md
@@ -47,7 +47,7 @@ Component.render(
     context: Mapping | django.template.Context | None = None,
     args: List[Any] | None = None,
     kwargs: Dict[str, Any] | None = None,
-    slots: Dict[str, str | SafeString | SlotFunc] | None = None,
+    slots: Dict[str, str | SafeString | SlotContent] | None = None,
     escape_slots_content: bool = True
 ) -> str:
 ```
@@ -60,7 +60,7 @@ Component.render(
 
 - _`slots`_ - Component slot fills. This is the same as pasing `{% fill %}` tags to the component.
   Accepts a dictionary of `{ slot_name: slot_content }` where `slot_content` can be a string
-  or [`SlotFunc`](#slotfunc).
+  or `Slot`.
 
 - _`escape_slots_content`_ - Whether the content from `slots` should be escaped. `True` by default to prevent XSS attacks. If you disable escaping, you should make sure that any content you pass to the slots is safe, especially if it comes from user input.
 

--- a/docs/overview/welcome.md
+++ b/docs/overview/welcome.md
@@ -386,7 +386,7 @@ Components API is fully typed, and supports [static type hints](https://django-c
 To opt-in to static type hints, define types for component's args, kwargs, slots, and more:
 
 ```py
-from typing import NotRequired, Tuple, TypedDict, SlotContent, SlotFunc
+from typing import NotRequired, Tuple, TypedDict, SlotContent, Slot
 
 from django_components import Component
 
@@ -397,22 +397,19 @@ class ButtonKwargs(TypedDict):
     another: int
     maybe_var: NotRequired[int] # May be omitted
 
-class ButtonData(TypedDict):
-    variable: str
-
 class ButtonSlots(TypedDict):
-    my_slot: NotRequired[SlotFunc]
+    # Use `Slot` for slot functions.
+    my_slot: NotRequired[Slot]
+    # Use `SlotContent` when you want to allow either `Slot` instance or plain string
     another_slot: SlotContent
 
-ButtonType = Component[ButtonArgs, ButtonKwargs, ButtonSlots, ButtonData, JsData, CssData]
+ButtonType = Component[ButtonArgs, ButtonKwargs, ButtonSlots]
 
 class Button(ButtonType):
     def get_context_data(self, *args, **kwargs):
         self.input.args[0]  # int
         self.input.kwargs["variable"]  # str
-        self.input.slots["my_slot"]  # SlotFunc[MySlotData]
-
-        return {}  # Error: Key "variable" is missing
+        self.input.slots["my_slot"]  # Slot
 ```
 
 When you then call

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -19,10 +19,6 @@
     options:
       show_if_no_docstring: true
 
-::: django_components.ComponentCommand
-    options:
-      show_if_no_docstring: true
-
 ::: django_components.ComponentDefaults
     options:
       show_if_no_docstring: true
@@ -32,6 +28,10 @@
       show_if_no_docstring: true
 
 ::: django_components.ComponentFileEntry
+    options:
+      show_if_no_docstring: true
+
+::: django_components.ComponentInput
     options:
       show_if_no_docstring: true
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -462,8 +462,8 @@ ProjectDashboardAction    project.components.dashboard_action.ProjectDashboardAc
 ## `upgradecomponent`
 
 ```txt
-usage: upgradecomponent [-h] [--path PATH] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH]
-                        [--traceback] [--no-color] [--force-color] [--skip-checks]
+usage: upgradecomponent [-h] [--path PATH] [--version] [-v {0,1,2,3}] [--settings SETTINGS]
+                        [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color] [--skip-checks]
 
 ```
 
@@ -507,9 +507,9 @@ Deprecated. Use `components upgrade` instead.
 ## `startcomponent`
 
 ```txt
-usage: startcomponent [-h] [--path PATH] [--js JS] [--css CSS] [--template TEMPLATE] [--force] [--verbose] [--dry-run]
-                      [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback]
-                      [--no-color] [--force-color] [--skip-checks]
+usage: startcomponent [-h] [--path PATH] [--js JS] [--css CSS] [--template TEMPLATE] [--force] [--verbose]
+                      [--dry-run] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH]
+                      [--traceback] [--no-color] [--force-color] [--skip-checks]
                       name
 
 ```

--- a/docs/reference/extension_hooks.md
+++ b/docs/reference/extension_hooks.md
@@ -109,6 +109,7 @@ name | type | description
 
 ::: django_components.extension.ComponentExtension.on_component_rendered
     options:
+      heading_level: 3
       show_root_heading: true
       show_signature: true
       separate_signature: true

--- a/docs/reference/template_tags.md
+++ b/docs/reference/template_tags.md
@@ -20,7 +20,7 @@ Import as
 
 
 
-<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L1037" target="_blank">See source code</a>
+<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L1064" target="_blank">See source code</a>
 
 
 
@@ -43,7 +43,7 @@ If you insert this tag multiple times, ALL CSS links will be duplicately inserte
 
 
 
-<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L1059" target="_blank">See source code</a>
+<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L1086" target="_blank">See source code</a>
 
 
 
@@ -67,7 +67,7 @@ If you insert this tag multiple times, ALL JS scripts will be duplicately insert
 
 
 
-<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L1564" target="_blank">See source code</a>
+<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L1669" target="_blank">See source code</a>
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 dependencies = [
     'Django>=4.2',
     'djc-core-html-parser>=1.0.2',
+    'typing-extensions>=4.12.2',
 ]
 license = {text = "MIT"}
 

--- a/requirements-ci.in
+++ b/requirements-ci.in
@@ -7,3 +7,4 @@ whitenoise
 asv
 pytest-asyncio
 pytest-django
+typing-extensions>=4.12.2

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -95,6 +95,7 @@ types-requests==2.32.0.20241016
     # via -r requirements-ci.in
 typing-extensions==4.12.2
     # via
+    #   -r requirements-ci.in
     #   pyee
     #   tox
 urllib3==2.2.3

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -18,3 +18,4 @@ whitenoise
 pygments
 pygments-djc
 asv
+typing-extensions>=4.12.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -150,6 +150,7 @@ types-requests==2.32.0.20241016
     # via -r requirements-dev.in
 typing-extensions==4.12.2
     # via
+    #   -r requirements-dev.in
     #   asgiref
     #   black
     #   mypy

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -21,7 +21,6 @@ from typing import (
     Union,
     cast,
 )
-from typing_extensions import TypeVar
 from weakref import ReferenceType, WeakValueDictionary, finalize
 
 from django.core.exceptions import ImproperlyConfigured
@@ -34,6 +33,7 @@ from django.template.loader_tags import BLOCK_CONTEXT_KEY, BlockContext
 from django.test.signals import template_rendered
 from django.utils.html import conditional_escape
 from django.views import View
+from typing_extensions import TypeVar
 
 from django_components.app_settings import ContextBehavior, app_settings
 from django_components.component_media import ComponentMediaInput, ComponentMediaMeta

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -18,10 +18,10 @@ from typing import (
     Optional,
     Tuple,
     Type,
-    TypeVar,
     Union,
     cast,
 )
+from typing_extensions import TypeVar
 from weakref import ReferenceType, WeakValueDictionary, finalize
 
 from django.core.exceptions import ImproperlyConfigured
@@ -103,12 +103,12 @@ from django_components.component_registry import registry as registry  # NOQA
 COMP_ONLY_FLAG = "only"
 
 # Define TypeVars for args and kwargs
-ArgsType = TypeVar("ArgsType", bound=tuple, contravariant=True)
-KwargsType = TypeVar("KwargsType", bound=Mapping[str, Any], contravariant=True)
-SlotsType = TypeVar("SlotsType", bound=Mapping[SlotName, SlotContent])
-DataType = TypeVar("DataType", bound=Mapping[str, Any], covariant=True)
-JsDataType = TypeVar("JsDataType", bound=Mapping[str, Any])
-CssDataType = TypeVar("CssDataType", bound=Mapping[str, Any])
+ArgsType = TypeVar("ArgsType", bound=tuple, contravariant=True, default=Any)
+KwargsType = TypeVar("KwargsType", bound=Mapping[str, Any], contravariant=True, default=Any)
+SlotsType = TypeVar("SlotsType", bound=Mapping[SlotName, SlotContent], default=Any)
+DataType = TypeVar("DataType", bound=Mapping[str, Any], covariant=True, default=Any)
+JsDataType = TypeVar("JsDataType", bound=Mapping[str, Any], default=Any)
+CssDataType = TypeVar("CssDataType", bound=Mapping[str, Any], default=Any)
 
 
 # NOTE: `ReferenceType` is NOT a generic pre-3.9

--- a/src/django_components/extension.py
+++ b/src/django_components/extension.py
@@ -662,10 +662,11 @@ class ExtensionManager:
         # TODO_V3 - Django-specific logic - replace with hook
         urls: List[URLResolver] = []
         seen_names: Set[str] = set()
+
+        from django_components import Component
+
         for extension in self.extensions:
             # Ensure that the extension name won't conflict with existing Component class API
-            from django_components import Component
-
             if hasattr(Component, extension.name) or hasattr(Component, extension.class_name):
                 raise ValueError(f"Extension name '{extension.name}' conflicts with existing Component class API")
 

--- a/src/django_components/extension.py
+++ b/src/django_components/extension.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional, Set, Tuple, Type, TypeVar, Union
 
 import django.urls
 from django.template import Context
@@ -661,7 +661,19 @@ class ExtensionManager:
         # Populate the `urlpatterns` with URLs specified by the extensions
         # TODO_V3 - Django-specific logic - replace with hook
         urls: List[URLResolver] = []
+        seen_names: Set[str] = set()
         for extension in self.extensions:
+            # Ensure that the extension name won't conflict with existing Component class API
+            from django_components import Component
+
+            if hasattr(Component, extension.name) or hasattr(Component, extension.class_name):
+                raise ValueError(f"Extension name '{extension.name}' conflicts with existing Component class API")
+
+            if extension.name.lower() in seen_names:
+                raise ValueError(f"Multiple extensions cannot have the same name '{extension.name}'")
+
+            seen_names.add(extension.name.lower())
+
             # NOTE: The empty list is a placeholder for the URLs that will be added later
             curr_ext_url_resolver = django.urls.path(f"{extension.name}/", django.urls.include([]))
             urls.append(curr_ext_url_resolver)

--- a/src/django_components/template.py
+++ b/src/django_components/template.py
@@ -5,6 +5,7 @@ from django.template import Origin, Template
 from django_components.cache import get_template_cache
 from django_components.util.misc import get_import_path
 
+
 # Central logic for creating Templates from string, so we can cache the results
 def cached_template(
     template_string: str,

--- a/src/django_components/template.py
+++ b/src/django_components/template.py
@@ -1,12 +1,9 @@
-from typing import Any, Optional, Type, TypeVar
+from typing import Any, Optional, Type
 
 from django.template import Origin, Template
 
 from django_components.cache import get_template_cache
 from django_components.util.misc import get_import_path
-
-TTemplate = TypeVar("TTemplate", bound=Template)
-
 
 # Central logic for creating Templates from string, so we can cache the results
 def cached_template(


### PR DESCRIPTION
When typing a Component, one can now specify as few or as many parameters as you want.

```py
Component[Args]
Component[Args, Kwargs]
Component[Args, Kwargs, Slots]
Component[Args, Kwargs, Slots, Data]
Component[Args, Kwargs, Slots, Data, JsData]
Component[Args, Kwargs, Slots, Data, JsData, CssData]
```

All omitted parameters will default to `Any`.

Closes #1113 