### PR TITLE
ci: update ubuntu version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
-        os: [ubuntu-20.04, windows-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
     # Configure git to handle long paths
@@ -45,7 +45,7 @@ jobs:
 
   # Verify that docs build
   test_docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.13']
@@ -70,7 +70,7 @@ jobs:
 
   # Verify that the sample project works
   test_sampleproject:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.13']


### PR DESCRIPTION
When running CI tests for https://github.com/django-components/django-components/issues/1136#issuecomment-2816850699, there was a notification from Github that their Ubuntu 20.04 image was deprecated.

So I've updated the jobs to run on the latest Ubuntu