### PR TITLE
feat: add "simple", "prepend", and "append" render types

### DIFF
--- a/docs/concepts/advanced/html_fragments.md
+++ b/docs/concepts/advanced/html_fragments.md
@@ -1,5 +1,5 @@
-Django-components provides a seamless integration with HTML fragments ([HTML over the wire](https://hotwired.dev/)),
-whether you're using HTMX, AlpineJS, or vanilla JavaScript.
+Django-components provides a seamless integration with HTML fragments with AJAX ([HTML over the wire](https://hotwired.dev/)),
+whether you're using jQuery, HTMX, AlpineJS, or vanilla JavaScript.
 
 When you define a component that has extra JS or CSS, and you use django-components
 to render the fragment, django-components will:
@@ -22,15 +22,17 @@ to render the fragment, django-components will:
     4. A library like HTMX, AlpineJS, or custom function inserts the new HTML into
        the correct place.
 
-## Document and fragment types
+## Document and fragment strategies
 
-Components support two modes of rendering - As a "document" or as a "fragment".
+Components support different "strategies" for rendering JS and CSS.
+
+Two of them are used to enable HTML fragments - "document" and "fragment".
 
 What's the difference?
 
-### Document mode
+### Document strategy
 
-Document mode assumes that the rendered components will be embedded into the HTML
+Document strategy assumes that the rendered components will be embedded into the HTML
 of the initial page load. This means that:
 
 - The JS and CSS is embedded into the HTML as `<script>` and `<style>` tags
@@ -42,7 +44,7 @@ A component is rendered as a "document" when:
 - It is embedded inside a template as [`{% component %}`](../../reference/template_tags.md#component)
 - It is rendered with [`Component.render()`](../../../reference/api#django_components.Component.render)
 or [`Component.render_to_response()`](../../../reference/api#django_components.Component.render_to_response)
-  with the `type` kwarg set to `"document"` (default)
+  with the `deps_strategy` kwarg set to `"document"` (default)
 
 Example:
 
@@ -55,13 +57,13 @@ MyTable.render(
 
 MyTable.render(
     kwargs={...},
-    type="document",
+    deps_strategy="document",
 )
 ```
 
-### Fragment mode
+### Fragment strategy
 
-Fragment mode assumes that the main HTML has already been rendered and loaded on the page.
+Fragment strategy assumes that the main HTML has already been rendered and loaded on the page.
 The component renders HTML that will be inserted into the page as a fragment, at a LATER time:
 
 - JS and CSS is not directly embedded to avoid duplicately executing the same JS scripts.
@@ -75,14 +77,14 @@ A component is rendered as "fragment" when:
 
 - It is rendered with [`Component.render()`](../../../reference/api#django_components.Component.render)
   or [`Component.render_to_response()`](../../../reference/api#django_components.Component.render_to_response)
-  with the `type` kwarg set to `"fragment"`
+  with the `deps_strategy` kwarg set to `"fragment"`
 
 Example:
 
 ```py
 MyTable.render(
     kwargs={...},
-    type="fragment",
+    deps_strategy="fragment",
 )
 ```
 
@@ -143,8 +145,8 @@ class Frag(Component):
         def get(self, request):
             return self.component.render_to_response(
                 request=request,
-                # IMPORTANT: Don't forget `type="fragment"`
-                type="fragment",
+                # IMPORTANT: Don't forget `deps_strategy="fragment"`
+                deps_strategy="fragment",
             )
 
     template = """
@@ -230,8 +232,8 @@ class Frag(Component):
         def get(self, request):
             return self.component.render_to_response(
                 request=request,
-                # IMPORTANT: Don't forget `type="fragment"`
-                type="fragment",
+                # IMPORTANT: Don't forget `deps_strategy="fragment"`
+                deps_strategy="fragment",
             )
 
     # NOTE: We wrap the actual fragment in a template tag with x-if="false" to prevent it
@@ -329,8 +331,8 @@ class Frag(Component):
         def get(self, request):
             return self.component.render_to_response(
                 request=request,
-                # IMPORTANT: Don't forget `type="fragment"`
-                type="fragment",
+                # IMPORTANT: Don't forget `deps_strategy="fragment"`
+                deps_strategy="fragment",
             )
 
     template = """

--- a/docs/concepts/fundamentals/html_js_css_files.md
+++ b/docs/concepts/fundamentals/html_js_css_files.md
@@ -145,7 +145,7 @@ Here is how the HTML is post-processed:
     </div>
     ```
 
-3. **Insert JS and CSS**: After the HTML is rendered, Django Components handles inserting JS and CSS dependencies into the page based on the [render type](../rendering_components/#render-types) (document, fragment, or inline).
+3. **Insert JS and CSS**: After the HTML is rendered, Django Components handles inserting JS and CSS dependencies into the page based on the [dependencies rendering strategy](../rendering_components/#dependencies-rendering) (document, fragment, or inline).
 
     For example, if your component contains the
     [`{% component_js_dependencies %}`](../../reference/template_tags.md#component_js_dependencies)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -67,6 +67,10 @@
     options:
       show_if_no_docstring: true
 
+::: django_components.DependenciesStrategy
+    options:
+      show_if_no_docstring: true
+
 ::: django_components.Empty
     options:
       show_if_no_docstring: true

--- a/docs/reference/template_tags.md
+++ b/docs/reference/template_tags.md
@@ -20,7 +20,7 @@ Import as
 
 
 
-<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L1066" target="_blank">See source code</a>
+<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L1069" target="_blank">See source code</a>
 
 
 
@@ -43,7 +43,7 @@ If you insert this tag multiple times, ALL CSS links will be duplicately inserte
 
 
 
-<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L1088" target="_blank">See source code</a>
+<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L1091" target="_blank">See source code</a>
 
 
 
@@ -67,7 +67,7 @@ If you insert this tag multiple times, ALL JS scripts will be duplicately insert
 
 
 
-<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L2619" target="_blank">See source code</a>
+<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L2794" target="_blank">See source code</a>
 
 
 
@@ -75,81 +75,45 @@ Renders one of the components that was previously registered with
 [`@register()`](./api.md#django_components.register)
 decorator.
 
-**Args:**
+The `{% component %}` tag takes:
 
-- `name` (str, required): Registered name of the component to render
-- All other args and kwargs are defined based on the component itself.
-
-If you defined a component `"my_table"`
-
-```python
-from django_component import Component, register
-
-@register("my_table")
-class MyTable(Component):
-    template = """
-      <table>
-        <thead>
-          {% for header in headers %}
-            <th>{{ header }}</th>
-          {% endfor %}
-        </thead>
-        <tbody>
-          {% for row in rows %}
-            <tr>
-              {% for cell in row %}
-                <td>{{ cell }}</td>
-              {% endfor %}
-            </tr>
-          {% endfor %}
-        <tbody>
-      </table>
-    """
-
-    def get_context_data(self, rows: List, headers: List):
-        return {
-            "rows": rows,
-            "headers": headers,
-        }
-```
-
-Then you can render this component by referring to `MyTable` via its
-registered name `"my_table"`:
+- Component's registered name as the first positional argument,
+- Followed by any number of positional and keyword arguments.
 
 ```django
-{% component "my_table" rows=rows headers=headers ... / %}
+{% load component_tags %}
+<div>
+    {% component "button" name="John" job="Developer" / %}
+</div>
 ```
 
-### Component input
+The component name must be a string literal.
 
-Positional and keyword arguments can be literals or template variables.
-
-The component name must be a single- or double-quotes string and must
-be either:
-
-- The first positional argument after `component`:
-
-    ```django
-    {% component "my_table" rows=rows headers=headers ... / %}
-    ```
-
-- Passed as kwarg `name`:
-
-    ```django
-    {% component rows=rows headers=headers name="my_table" ... / %}
-    ```
-
-### Inserting into slots
+### Inserting slot fills
 
 If the component defined any [slots](../concepts/fundamentals/slots.md), you can
-pass in the content to be placed inside those slots by inserting [`{% fill %}`](#fill) tags,
-directly within the `{% component %}` tag:
+"fill" these slots by placing the [`{% fill %}`](#fill) tags within the `{% component %}` tag:
 
 ```django
-{% component "my_table" rows=rows headers=headers ... / %}
+{% component "my_table" rows=rows headers=headers %}
   {% fill "pagination" %}
     < 1 | 2 | 3 >
   {% endfill %}
+{% endcomponent %}
+```
+
+You can even nest [`{% fill %}`](#fill) tags within
+[`{% if %}`](https://docs.djangoproject.com/en/5.2/ref/templates/builtins/#if),
+[`{% for %}`](https://docs.djangoproject.com/en/5.2/ref/templates/builtins/#for)
+and other tags:
+
+```django
+{% component "my_table" rows=rows headers=headers %}
+    {% if rows %}
+        {% fill "pagination" %}
+            < 1 | 2 | 3 >
+        {% endfill %}
+    {% endif %}
 {% endcomponent %}
 ```
 
@@ -164,6 +128,36 @@ can access only the data that was explicitly passed to it:
 
 ```django
 {% component "name" positional_arg keyword_arg=value ... only %}
+```
+
+Alternatively, you can set all components to be isolated by default, by setting
+[`context_behavior`](../settings#django_components.app_settings.ComponentsSettings.context_behavior)
+to `"isolated"` in your settings:
+
+```python
+# settings.py
+COMPONENTS = {
+    "context_behavior": "isolated",
+}
+```
+
+### Omitting the `component` keyword
+
+If you would like to omit the `component` keyword, and simply refer to your
+components by their registered names:
+
+```django
+{% button name="John" job="Developer" / %}
+```
+
+You can do so by setting the "shorthand" [Tag formatter](../../concepts/advanced/tag_formatters)
+in the settings:
+
+```python
+# settings.py
+COMPONENTS = {
+    "tag_formatter": "django_components.component_shorthand_formatter",
+}
 ```
 
 ## fill

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -154,7 +154,7 @@ mkdocstrings==0.29.1
     #   mkdocstrings-python
 mkdocstrings-python==1.16.10
     # via hatch.envs.docs
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via black
 packaging==25.0
     # via

--- a/sampleproject/components/calendar/calendar.py
+++ b/sampleproject/components/calendar/calendar.py
@@ -25,6 +25,7 @@ class Calendar(Component):
                 kwargs={
                     "date": request.GET.get("date", ""),
                 },
+                deps_strategy="append",
             )
 
 
@@ -52,4 +53,5 @@ class CalendarRelative(Component):
                 kwargs={
                     "date": request.GET.get("date", ""),
                 },
+                deps_strategy="append",
             )

--- a/sampleproject/components/fragment.py
+++ b/sampleproject/components/fragment.py
@@ -107,7 +107,7 @@ class FragmentBaseHtmx(Component):
 class FragJs(Component):
     class View:
         def get(self, request):
-            return FragJs.render_to_response(request=request, type="fragment")
+            return FragJs.render_to_response(request=request, deps_strategy="fragment")
 
     template: types.django_html = """
         <div class="frag">
@@ -131,7 +131,7 @@ class FragJs(Component):
 class FragAlpine(Component):
     class View:
         def get(self, request):
-            return FragAlpine.render_to_response(request=request, type="fragment")
+            return FragAlpine.render_to_response(request=request, deps_strategy="fragment")
 
     # NOTE: We wrap the actual fragment in a template tag with x-if="false" to prevent it
     #       from being rendered until we have registered the component with AlpineJS.

--- a/sampleproject/components/nested/calendar/calendar.py
+++ b/sampleproject/components/nested/calendar/calendar.py
@@ -25,4 +25,5 @@ class CalendarNested(Component):
                 kwargs={
                     "date": request.GET.get("date", ""),
                 },
+                deps_strategy="append",
             )

--- a/src/django_components/__init__.py
+++ b/src/django_components/__init__.py
@@ -34,7 +34,7 @@ from django_components.component_registry import (
     all_registries,
 )
 from django_components.components import DynamicComponent
-from django_components.dependencies import render_dependencies
+from django_components.dependencies import DependenciesStrategy, render_dependencies
 from django_components.extension import (
     ComponentExtension,
     OnComponentRegisteredContext,
@@ -100,6 +100,7 @@ __all__ = [
     "component_shorthand_formatter",
     "ContextBehavior",
     "Default",
+    "DependenciesStrategy",
     "DynamicComponent",
     "Empty",
     "format_attributes",

--- a/src/django_components/components/dynamic.py
+++ b/src/django_components/components/dynamic.py
@@ -118,12 +118,13 @@ class DynamicComponent(Component):
             "kwargs": kwargs,
         }
 
+    # TODO: Replace combination of `on_render_before()` + `template` with single `on_render()`
     # NOTE: The inner component is rendered in `on_render_before`, so that the `Context` object
     # is already configured as if the inner component was rendered inside the template.
     # E.g. the `_COMPONENT_CONTEXT_KEY` is set, which means that the child component
     # will know that it's a child of this component.
     def on_render_before(self, context: Context, template: Template) -> Context:
-        comp_class = context["comp_class"]
+        comp_class: type[Component] = context["comp_class"]
         args = context["args"]
         kwargs = context["kwargs"]
 
@@ -140,7 +141,7 @@ class DynamicComponent(Component):
             # NOTE: Since we're accessing slots as `self.input.slots`, the content of slot functions
             # was already escaped (if set so).
             escape_slots_content=False,
-            type=self.input.type,
+            deps_strategy=self.input.deps_strategy,
             render_dependencies=self.input.render_dependencies,
         )
 

--- a/tests/e2e/testserver/testserver/views.py
+++ b/tests/e2e/testserver/testserver/views.py
@@ -250,9 +250,9 @@ def fragment_base_htmx_view(request):
 def fragment_view(request):
     fragment_type = request.GET["frag"]
     if fragment_type == "comp":
-        return FragComp.render_to_response(type="fragment")
+        return FragComp.render_to_response(deps_strategy="fragment")
     elif fragment_type == "media":
-        return FragMedia.render_to_response(type="fragment")
+        return FragMedia.render_to_response(deps_strategy="fragment")
     else:
         raise ValueError("Invalid fragment type")
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -409,7 +409,7 @@ class TestDependenciesStrategyDocument:
             </html>
         """
         rendered_raw = Template(template_str).render(Context({}))
-        rendered = render_dependencies(rendered_raw)
+        rendered = render_dependencies(rendered_raw, strategy="document")
 
         assert rendered.count("<script") == 4
         assert rendered.count("<style") == 1
@@ -458,7 +458,7 @@ class TestDependenciesStrategyDocument:
             </html>
         """
         rendered_raw = Template(template_str).render(Context({}))
-        rendered = render_dependencies(rendered_raw)
+        rendered = render_dependencies(rendered_raw, strategy="document")
 
         assert rendered.count("<script") == 4
         assert rendered.count("<style") == 1

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -50,6 +50,24 @@ class SimpleComponent(Component):
 
 
 @djc_test
+class TestDependenciesLegacy:
+    # TODO_v1 - Remove
+    def test_render_with_type_arg(self):
+        rendered = SimpleComponent.render(kwargs={"variable": "foo"}, type="append")
+
+        # Dependency manager script NOT present
+        assertInHTML('<script src="django_components/django_components.min.js"></script>', rendered, count=0)
+
+        # Check that it contains inlined JS and CSS, and Media.css
+        assert rendered.strip() == (
+            'Variable: <strong data-djc-id-ca1bc3e="">foo</strong>\n'
+            '    <script src="script.js"></script><script>console.log("xyz");</script><style>.xyz {\n'
+            "            color: red;\n"
+            '        }</style><link href="style.css" media="all" rel="stylesheet">'
+        )
+
+
+@djc_test
 class TestRenderDependencies:
     def test_standalone_render_dependencies(self):
         registry.register(name="test", component=SimpleComponent)
@@ -61,7 +79,7 @@ class TestRenderDependencies:
             {% component 'test' variable='foo' / %}
         """
         template = Template(template_str)
-        rendered_raw = template.render(Context({}))
+        rendered_raw: str = template.render(Context({}))
 
         # Placeholders
         assert rendered_raw.count('<link name="CSS_PLACEHOLDER">') == 1
@@ -194,6 +212,189 @@ class TestRenderDependencies:
         assert rendered.count("<link") == 1
         assert rendered.count("<style") == 1
 
+    # NOTE: Some HTML parser libraries like selectolax or lxml try to "correct" the given HTML.
+    #       We want to avoid this behavior, so user gets the exact same HTML back.
+    def test_does_not_try_to_add_close_tags(self):
+        registry.register(name="test", component=SimpleComponent)
+
+        template_str: types.django_html = """
+            <thead>
+        """
+
+        rendered_raw = Template(template_str).render(Context({"formset": [1]}))
+        rendered = render_dependencies(rendered_raw, strategy="fragment")
+
+        assertHTMLEqual(rendered, "<thead>")
+
+    def test_does_not_modify_html_when_no_component_used(self):
+        registry.register(name="test", component=SimpleComponent)
+
+        template_str: types.django_html = """
+            <table class="table-auto border-collapse divide-y divide-x divide-slate-300 w-full">
+                <!-- Table head -->
+                <thead>
+                    <tr class="py-0 my-0 h-7">
+                        <!-- Empty row -->
+                        <th class="min-w-12">#</th>
+                    </tr>
+                </thead>
+                <!-- Table body -->
+                <tbody id="items" class="divide-y divide-slate-300">
+                    {% for form in formset %}
+                        {% with row_number=forloop.counter %}
+                            <tr class=" hover:bg-gray-200 py-0 {% cycle 'bg-white' 'bg-gray-50' %} divide-x "
+                                aria-rowindex="{{ row_number }}">
+                                <!-- row num -->
+                                <td class="whitespace-nowrap w-fit text-center px-4 w-px"
+                                    aria-colindex="1">
+                                    {{ row_number }}
+                                </td>
+                            </tr>
+                        {% endwith %}
+                    {% endfor %}
+                </tbody>
+            </table>
+        """
+
+        rendered_raw = Template(template_str).render(Context({"formset": [1]}))
+        rendered = render_dependencies(rendered_raw, strategy="fragment")
+
+        expected = """
+            <table class="table-auto border-collapse divide-y divide-x divide-slate-300 w-full">
+                <!-- Table head -->
+                <thead>
+                    <tr class="py-0 my-0 h-7">
+                        <!-- Empty row -->
+                        <th class="min-w-12">#</th>
+                    </tr>
+                </thead>
+                <!-- Table body -->
+                <tbody id="items" class="divide-y divide-slate-300">
+                    <tr class=" hover:bg-gray-200 py-0 bg-white divide-x "
+                        aria-rowindex="1">
+                        <!-- row num -->
+                        <td class="whitespace-nowrap w-fit text-center px-4 w-px"
+                            aria-colindex="1">
+                            1
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        """
+
+        assertHTMLEqual(expected, rendered)
+
+    # Explanation: The component is used in the template, but the template doesn't use
+    # {% component_js_dependencies %} or {% component_css_dependencies %} tags,
+    # nor defines a `<head>` or `<body>` tag. In which case, the dependencies are not rendered.
+    def test_does_not_modify_html_when_component_used_but_nowhere_to_insert(self):
+        registry.register(name="test", component=SimpleComponent)
+
+        template_str: types.django_html = """
+            {% load component_tags %}
+            <table class="table-auto border-collapse divide-y divide-x divide-slate-300 w-full">
+                <!-- Table head -->
+                <thead>
+                    <tr class="py-0 my-0 h-7">
+                        <!-- Empty row -->
+                        <th class="min-w-12">#</th>
+                    </tr>
+                </thead>
+                <!-- Table body -->
+                <tbody id="items" class="divide-y divide-slate-300">
+                    {% for form in formset %}
+                        {% with row_number=forloop.counter %}
+                            <tr class=" hover:bg-gray-200 py-0 {% cycle 'bg-white' 'bg-gray-50' %} divide-x "
+                                aria-rowindex="{{ row_number }}">
+                                <!-- row num -->
+                                <td class="whitespace-nowrap w-fit text-center px-4 w-px"
+                                    aria-colindex="1">
+                                    {{ row_number }}
+                                    {% component "test" variable="hi" / %}
+                                </td>
+                            </tr>
+                        {% endwith %}
+                    {% endfor %}
+                </tbody>
+            </table>
+        """
+
+        rendered_raw = Template(template_str).render(Context({"formset": [1]}))
+        rendered = render_dependencies(rendered_raw, strategy="fragment")
+
+        # Base64 encodings:
+        # `PGxpbmsgaHJlZj0ic3R5bGUuY3NzIiBtZWRpYT0iYWxsIiByZWw9InN0eWxlc2hlZXQiPg==` -> `<link href="style.css" media="all" rel="stylesheet">`  # noqa: E501
+        # `PGxpbmsgaHJlZj0iL2NvbXBvbmVudHMvY2FjaGUvU2ltcGxlQ29tcG9uZW50XzMxMTA5Ny5jc3MiIG1lZGlhPSJhbGwiIHJlbD0ic3R5bGVzaGVldCI+` -> `<link href="/components/cache/SimpleComponent_311097.css" media="all" rel="stylesheet">`  # noqa: E501
+        # `PHNjcmlwdCBzcmM9InNjcmlwdC5qcyI+PC9zY3JpcHQ+` -> `<script src="script.js"></script>`
+        # `PHNjcmlwdCBzcmM9Ii9jb21wb25lbnRzL2NhY2hlL1NpbXBsZUNvbXBvbmVudF8zMTEwOTcuanMiPjwvc2NyaXB0Pg==` -> `<script src="/components/cache/SimpleComponent_311097.js"></script>`  # noqa: E501
+        expected = """
+            <table class="table-auto border-collapse divide-y divide-x divide-slate-300 w-full">
+                <!-- Table head -->
+                <thead>
+                    <tr class="py-0 my-0 h-7">
+                        <!-- Empty row -->
+                        <th class="min-w-12">#</th>
+                    </tr>
+                </thead>
+                <!-- Table body -->
+                <tbody id="items" class="divide-y divide-slate-300">
+                    <tr class=" hover:bg-gray-200 py-0 bg-white divide-x "
+                        aria-rowindex="1">
+                        <!-- row num -->
+                        <td class="whitespace-nowrap w-fit text-center px-4 w-px"
+                            aria-colindex="1">
+                            1
+                            Variable: <strong data-djc-id-ca1bc3f>hi</strong>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <script type="application/json" data-djc>
+                {"loadedCssUrls": [],
+                "loadedJsUrls": [],
+                "toLoadCssTags": ["PGxpbmsgaHJlZj0ic3R5bGUuY3NzIiBtZWRpYT0iYWxsIiByZWw9InN0eWxlc2hlZXQiPg==",
+                    "PGxpbmsgaHJlZj0iL2NvbXBvbmVudHMvY2FjaGUvU2ltcGxlQ29tcG9uZW50XzMxMTA5Ny5jc3MiIG1lZGlhPSJhbGwiIHJlbD0ic3R5bGVzaGVldCI+"],
+                "toLoadJsTags": ["PHNjcmlwdCBzcmM9InNjcmlwdC5qcyI+PC9zY3JpcHQ+",
+                "PHNjcmlwdCBzcmM9Ii9jb21wb25lbnRzL2NhY2hlL1NpbXBsZUNvbXBvbmVudF8zMTEwOTcuanMiPjwvc2NyaXB0Pg=="]}
+            </script>
+        """  # noqa: E501
+
+        assertHTMLEqual(expected, rendered)
+
+    def test_raises_if_script_end_tag_inside_component_js(self):
+        class ComponentWithScript(SimpleComponent):
+            js: types.js = """
+                console.log("</script  >");
+            """
+
+        registry.register(name="test", component=ComponentWithScript)
+
+        with pytest.raises(
+            RuntimeError,
+            match=re.escape("Content of `Component.js` for component 'ComponentWithScript' contains '</script>' end tag."),  # noqa: E501
+        ):
+            ComponentWithScript.render(kwargs={"variable": "foo"})
+
+    def test_raises_if_script_end_tag_inside_component_css(self):
+        class ComponentWithScript(SimpleComponent):
+            css: types.css = """
+                /* </style  > */
+                .xyz {
+                    color: red;
+                }
+            """
+
+        registry.register(name="test", component=ComponentWithScript)
+
+        with pytest.raises(
+            RuntimeError,
+            match=re.escape("Content of `Component.css` for component 'ComponentWithScript' contains '</style>' end tag."),  # noqa: E501
+        ):
+            ComponentWithScript.render(kwargs={"variable": "foo"})
+
+
+@djc_test
+class TestDependenciesStrategyDocument:
     def test_inserts_styles_and_script_to_default_places_if_not_overriden(self):
         registry.register(name="test", component=SimpleComponent)
 
@@ -291,185 +492,480 @@ class TestRenderDependencies:
             count=1,
         )
 
-    # NOTE: Some HTML parser libraries like selectolax or lxml try to "correct" the given HTML.
-    #       We want to avoid this behavior, so user gets the exact same HTML back.
-    def test_does_not_try_to_add_close_tags(self):
-        registry.register(name="test", component=SimpleComponent)
 
-        template_str: types.django_html = """
-            <thead>
-        """
-
-        rendered_raw = Template(template_str).render(Context({"formset": [1]}))
-        rendered = render_dependencies(rendered_raw, type="fragment")
-
-        assertHTMLEqual(rendered, "<thead>")
-
-    def test_does_not_modify_html_when_no_component_used(self):
-        registry.register(name="test", component=SimpleComponent)
-
-        template_str: types.django_html = """
-            <table class="table-auto border-collapse divide-y divide-x divide-slate-300 w-full">
-                <!-- Table head -->
-                <thead>
-                    <tr class="py-0 my-0 h-7">
-                        <!-- Empty row -->
-                        <th class="min-w-12">#</th>
-                    </tr>
-                </thead>
-                <!-- Table body -->
-                <tbody id="items" class="divide-y divide-slate-300">
-                    {% for form in formset %}
-                        {% with row_number=forloop.counter %}
-                            <tr class=" hover:bg-gray-200 py-0 {% cycle 'bg-white' 'bg-gray-50' %} divide-x "
-                                aria-rowindex="{{ row_number }}">
-                                <!-- row num -->
-                                <td class="whitespace-nowrap w-fit text-center px-4 w-px"
-                                    aria-colindex="1">
-                                    {{ row_number }}
-                                </td>
-                            </tr>
-                        {% endwith %}
-                    {% endfor %}
-                </tbody>
-            </table>
-        """
-
-        rendered_raw = Template(template_str).render(Context({"formset": [1]}))
-        rendered = render_dependencies(rendered_raw, type="fragment")
-
-        expected = """
-            <table class="table-auto border-collapse divide-y divide-x divide-slate-300 w-full">
-                <!-- Table head -->
-                <thead>
-                    <tr class="py-0 my-0 h-7">
-                        <!-- Empty row -->
-                        <th class="min-w-12">#</th>
-                    </tr>
-                </thead>
-                <!-- Table body -->
-                <tbody id="items" class="divide-y divide-slate-300">
-                    <tr class=" hover:bg-gray-200 py-0 bg-white divide-x "
-                        aria-rowindex="1">
-                        <!-- row num -->
-                        <td class="whitespace-nowrap w-fit text-center px-4 w-px"
-                            aria-colindex="1">
-                            1
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        """
-
-        assertHTMLEqual(expected, rendered)
-
-    # Explanation: The component is used in the template, but the template doesn't use
-    # {% component_js_dependencies %} or {% component_css_dependencies %} tags,
-    # nor defines a `<head>` or `<body>` tag. In which case, the dependencies are not rendered.
-    def test_does_not_modify_html_when_component_used_but_nowhere_to_insert(self):
+@djc_test
+class TestDependenciesStrategySimple:
+    def test_single_component(self):
         registry.register(name="test", component=SimpleComponent)
 
         template_str: types.django_html = """
             {% load component_tags %}
-            <table class="table-auto border-collapse divide-y divide-x divide-slate-300 w-full">
-                <!-- Table head -->
-                <thead>
-                    <tr class="py-0 my-0 h-7">
-                        <!-- Empty row -->
-                        <th class="min-w-12">#</th>
-                    </tr>
-                </thead>
-                <!-- Table body -->
-                <tbody id="items" class="divide-y divide-slate-300">
-                    {% for form in formset %}
-                        {% with row_number=forloop.counter %}
-                            <tr class=" hover:bg-gray-200 py-0 {% cycle 'bg-white' 'bg-gray-50' %} divide-x "
-                                aria-rowindex="{{ row_number }}">
-                                <!-- row num -->
-                                <td class="whitespace-nowrap w-fit text-center px-4 w-px"
-                                    aria-colindex="1">
-                                    {{ row_number }}
-                                    {% component "test" variable="hi" / %}
-                                </td>
-                            </tr>
-                        {% endwith %}
-                    {% endfor %}
-                </tbody>
-            </table>
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
+            {% component 'test' variable='foo' / %}
         """
+        template = Template(template_str)
+        rendered_raw: str = template.render(Context({}))
 
-        rendered_raw = Template(template_str).render(Context({"formset": [1]}))
-        rendered = render_dependencies(rendered_raw, type="fragment")
+        # Placeholders
+        assert rendered_raw.count('<link name="CSS_PLACEHOLDER">') == 1
+        assert rendered_raw.count('<script name="JS_PLACEHOLDER"></script>') == 1
 
-        # Base64 encodings:
-        # `PGxpbmsgaHJlZj0ic3R5bGUuY3NzIiBtZWRpYT0iYWxsIiByZWw9InN0eWxlc2hlZXQiPg==` -> `<link href="style.css" media="all" rel="stylesheet">`  # noqa: E501
-        # `PGxpbmsgaHJlZj0iL2NvbXBvbmVudHMvY2FjaGUvU2ltcGxlQ29tcG9uZW50XzMxMTA5Ny5jc3MiIG1lZGlhPSJhbGwiIHJlbD0ic3R5bGVzaGVldCI+` -> `<link href="/components/cache/SimpleComponent_311097.css" media="all" rel="stylesheet">`  # noqa: E501
-        # `PHNjcmlwdCBzcmM9InNjcmlwdC5qcyI+PC9zY3JpcHQ+` -> `<script src="script.js"></script>`
-        # `PHNjcmlwdCBzcmM9Ii9jb21wb25lbnRzL2NhY2hlL1NpbXBsZUNvbXBvbmVudF8zMTEwOTcuanMiPjwvc2NyaXB0Pg==` -> `<script src="/components/cache/SimpleComponent_311097.js"></script>`  # noqa: E501
-        expected = """
-            <table class="table-auto border-collapse divide-y divide-x divide-slate-300 w-full">
-                <!-- Table head -->
-                <thead>
-                    <tr class="py-0 my-0 h-7">
-                        <!-- Empty row -->
-                        <th class="min-w-12">#</th>
-                    </tr>
-                </thead>
-                <!-- Table body -->
-                <tbody id="items" class="divide-y divide-slate-300">
-                    <tr class=" hover:bg-gray-200 py-0 bg-white divide-x "
-                        aria-rowindex="1">
-                        <!-- row num -->
-                        <td class="whitespace-nowrap w-fit text-center px-4 w-px"
-                            aria-colindex="1">
-                            1
-                            Variable: <strong data-djc-id-ca1bc3f>hi</strong>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-            <script type="application/json" data-djc>
-                {"loadedCssUrls": [],
-                "loadedJsUrls": [],
-                "toLoadCssTags": ["PGxpbmsgaHJlZj0ic3R5bGUuY3NzIiBtZWRpYT0iYWxsIiByZWw9InN0eWxlc2hlZXQiPg==",
-                    "PGxpbmsgaHJlZj0iL2NvbXBvbmVudHMvY2FjaGUvU2ltcGxlQ29tcG9uZW50XzMxMTA5Ny5jc3MiIG1lZGlhPSJhbGwiIHJlbD0ic3R5bGVzaGVldCI+"],
-                "toLoadJsTags": ["PHNjcmlwdCBzcmM9InNjcmlwdC5qcyI+PC9zY3JpcHQ+",
-                "PHNjcmlwdCBzcmM9Ii9jb21wb25lbnRzL2NhY2hlL1NpbXBsZUNvbXBvbmVudF8zMTEwOTcuanMiPjwvc2NyaXB0Pg=="]}
-            </script>
-        """  # noqa: E501
+        assert rendered_raw.count("<script") == 1
+        assert rendered_raw.count("<style") == 0
+        assert rendered_raw.count("<link") == 1
+        assert rendered_raw.count("_RENDERED") == 1
 
-        assertHTMLEqual(expected, rendered)
+        rendered = render_dependencies(rendered_raw, strategy="simple")
 
-    def test_raises_if_script_end_tag_inside_component_js(self):
-        class ComponentWithScript(SimpleComponent):
-            js: types.js = """
-                console.log("</script  >");
+        # Dependency manager script NOT present
+        assertInHTML('<script src="django_components/django_components.min.js"></script>', rendered, count=0)
+
+        # Check that it contains inlined JS and CSS, and Media.css
+        assert rendered.strip() == (
+            '<script src="script.js"></script><script>console.log("xyz");</script>\n'
+            "            <style>.xyz {\n"
+            "            color: red;\n"
+            '        }</style><link href="style.css" media="all" rel="stylesheet">\n'
+            "            \n"
+            '        Variable: <strong data-djc-id-ca1bc41="">foo</strong>'
+        )
+
+    def test_multiple_components_dependencies(self):
+        class SimpleComponentNested(Component):
+            template: types.django_html = """
+                {% load component_tags %}
+                <div>
+                    {% component "inner" variable=variable / %}
+                    {% slot "default" default / %}
+                </div>
             """
 
-        registry.register(name="test", component=ComponentWithScript)
-
-        with pytest.raises(
-            RuntimeError,
-            match=re.escape("Content of `Component.js` for component 'ComponentWithScript' contains '</script>' end tag."),  # noqa: E501
-        ):
-            ComponentWithScript.render(kwargs={"variable": "foo"})
-
-    def test_raises_if_script_end_tag_inside_component_css(self):
-        class ComponentWithScript(SimpleComponent):
             css: types.css = """
-                /* </style  > */
+                .my-class {
+                    color: red;
+                }
+            """
+
+            js: types.js = """
+                console.log("Hello");
+            """
+
+            def get_context_data(self, variable):
+                return {}
+
+            class Media:
+                css = ["style.css", "style2.css"]
+                js = "script2.js"
+
+        class OtherComponent(Component):
+            template: types.django_html = """
+                XYZ: <strong>{{ variable }}</strong>
+            """
+
+            css: types.css = """
                 .xyz {
                     color: red;
                 }
             """
 
-        registry.register(name="test", component=ComponentWithScript)
+            js: types.js = """
+                console.log("xyz");
+            """
 
-        with pytest.raises(
-            RuntimeError,
-            match=re.escape("Content of `Component.css` for component 'ComponentWithScript' contains '</style>' end tag."),  # noqa: E501
-        ):
-            ComponentWithScript.render(kwargs={"variable": "foo"})
+            def get_context_data(self, variable):
+                return {}
+
+            class Media:
+                css = "xyz1.css"
+                js = "xyz1.js"
+
+        registry.register(name="inner", component=SimpleComponent)
+        registry.register(name="outer", component=SimpleComponentNested)
+        registry.register(name="other", component=OtherComponent)
+
+        template_str: types.django_html = """
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
+            {% component 'outer' variable='variable' %}
+                {% component 'other' variable='variable_inner' / %}
+            {% endcomponent %}
+        """
+        template = Template(template_str)
+        rendered_raw: str = template.render(Context({}))
+
+        rendered = render_dependencies(rendered_raw, strategy="simple")
+
+        # Dependency manager script NOT present
+        assertInHTML('<script src="django_components/django_components.min.js"></script>', rendered, count=0)
+
+        assert rendered.count("<script") == 6  # 3 Component.js and 3 Media.js
+        assert rendered.count("<link") == 3  # Media.css
+        assert rendered.count("<style") == 3  # Component.css
+
+        # Components' inlined CSS
+        # NOTE: Each of these should be present only ONCE!
+        assertInHTML(
+            """
+            <style>.my-class { color: red; }</style>
+            <style>.xyz { color: red; }</style>
+            """,
+            rendered,
+            count=1,
+        )
+
+        # Components' Media.css
+        # Order:
+        # - "style.css", "style2.css" (from SimpleComponentNested)
+        # - "style.css" (from SimpleComponent inside SimpleComponentNested)
+        # - "xyz1.css" (from OtherComponent inserted into SimpleComponentNested)
+        assertInHTML(
+            """
+            <link href="style.css" media="all" rel="stylesheet">
+            <link href="style2.css" media="all" rel="stylesheet">
+            <link href="xyz1.css" media="all" rel="stylesheet">
+            """,
+            rendered,
+            count=1,
+        )
+
+        # Components' Media.js followed by inlined JS
+        # Order:
+        # - "script2.js" (from SimpleComponentNested)
+        # - "script.js" (from SimpleComponent inside SimpleComponentNested)
+        # - "xyz1.js" (from OtherComponent inserted into SimpleComponentNested)
+        assertInHTML(
+            """
+            <script src="script2.js"></script>
+            <script src="script.js"></script>
+            <script src="xyz1.js"></script>
+            <script>console.log("Hello");</script>
+            <script>console.log("xyz");</script>
+            """,
+            rendered,
+            count=1,
+        )
+
+        # Check that there's no payload like with "document" or "fragment" modes
+        assert "application/json" not in rendered
+
+
+@djc_test
+class TestDependenciesStrategyPrepend:
+    def test_single_component(self):
+        registry.register(name="test", component=SimpleComponent)
+
+        template_str: types.django_html = """
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
+            {% component 'test' variable='foo' / %}
+        """
+        template = Template(template_str)
+        rendered_raw: str = template.render(Context({}))
+
+        # Placeholders
+        assert rendered_raw.count('<link name="CSS_PLACEHOLDER">') == 1
+        assert rendered_raw.count('<script name="JS_PLACEHOLDER"></script>') == 1
+
+        assert rendered_raw.count("<script") == 1
+        assert rendered_raw.count("<style") == 0
+        assert rendered_raw.count("<link") == 1
+        assert rendered_raw.count("_RENDERED") == 1
+
+        rendered = render_dependencies(rendered_raw, strategy="prepend")
+
+        # Dependency manager script NOT present
+        assertInHTML('<script src="django_components/django_components.min.js"></script>', rendered, count=0)
+
+        # Check that it contains inlined JS and CSS, and Media.css
+        assert rendered.strip() == (
+            '<script src="script.js"></script><script>console.log("xyz");</script><style>.xyz {\n'
+            "            color: red;\n"
+            '        }</style><link href="style.css" media="all" rel="stylesheet">\n'
+            "            \n"
+            "            \n"
+            "            \n"
+            "            \n"
+            '        Variable: <strong data-djc-id-ca1bc41="">foo</strong>'
+        )
+
+    def test_multiple_components_dependencies(self):
+        class SimpleComponentNested(Component):
+            template: types.django_html = """
+                {% load component_tags %}
+                <div>
+                    {% component "inner" variable=variable / %}
+                    {% slot "default" default / %}
+                </div>
+            """
+
+            css: types.css = """
+                .my-class {
+                    color: red;
+                }
+            """
+
+            js: types.js = """
+                console.log("Hello");
+            """
+
+            def get_context_data(self, variable):
+                return {}
+
+            class Media:
+                css = ["style.css", "style2.css"]
+                js = "script2.js"
+
+        class OtherComponent(Component):
+            template: types.django_html = """
+                XYZ: <strong>{{ variable }}</strong>
+            """
+
+            css: types.css = """
+                .xyz {
+                    color: red;
+                }
+            """
+
+            js: types.js = """
+                console.log("xyz");
+            """
+
+            def get_context_data(self, variable):
+                return {}
+
+            class Media:
+                css = "xyz1.css"
+                js = "xyz1.js"
+
+        registry.register(name="inner", component=SimpleComponent)
+        registry.register(name="outer", component=SimpleComponentNested)
+        registry.register(name="other", component=OtherComponent)
+
+        template_str: types.django_html = """
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
+            {% component 'outer' variable='variable' %}
+                {% component 'other' variable='variable_inner' / %}
+            {% endcomponent %}
+        """
+        template = Template(template_str)
+        rendered_raw: str = template.render(Context({}))
+
+        rendered = render_dependencies(rendered_raw, strategy="prepend")
+
+        # Dependency manager script NOT present
+        assertInHTML('<script src="django_components/django_components.min.js"></script>', rendered, count=0)
+
+        assert rendered.count("<script") == 6  # 3 Component.js and 3 Media.js
+        assert rendered.count("<link") == 3  # Media.css
+        assert rendered.count("<style") == 3  # Component.css
+
+        # Components' inlined CSS
+        # NOTE: Each of these should be present only ONCE!
+        assertInHTML(
+            """
+            <style>.my-class { color: red; }</style>
+            <style>.xyz { color: red; }</style>
+            """,
+            rendered,
+            count=1,
+        )
+
+        # Components' Media.css
+        # Order:
+        # - "style.css", "style2.css" (from SimpleComponentNested)
+        # - "style.css" (from SimpleComponent inside SimpleComponentNested)
+        # - "xyz1.css" (from OtherComponent inserted into SimpleComponentNested)
+        assertInHTML(
+            """
+            <link href="style.css" media="all" rel="stylesheet">
+            <link href="style2.css" media="all" rel="stylesheet">
+            <link href="xyz1.css" media="all" rel="stylesheet">
+            """,
+            rendered,
+            count=1,
+        )
+
+        # Components' Media.js followed by inlined JS
+        # Order:
+        # - "script2.js" (from SimpleComponentNested)
+        # - "script.js" (from SimpleComponent inside SimpleComponentNested)
+        # - "xyz1.js" (from OtherComponent inserted into SimpleComponentNested)
+        assertInHTML(
+            """
+            <script src="script2.js"></script>
+            <script src="script.js"></script>
+            <script src="xyz1.js"></script>
+            <script>console.log("Hello");</script>
+            <script>console.log("xyz");</script>
+            """,
+            rendered,
+            count=1,
+        )
+
+        # Check that there's no payload like with "document" or "fragment" modes
+        assert "application/json" not in rendered
+
+
+@djc_test
+class TestDependenciesStrategyAppend:
+    def test_single_component(self):
+        registry.register(name="test", component=SimpleComponent)
+
+        template_str: types.django_html = """
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
+            {% component 'test' variable='foo' / %}
+        """
+        template = Template(template_str)
+        rendered_raw: str = template.render(Context({}))
+
+        # Placeholders
+        assert rendered_raw.count('<link name="CSS_PLACEHOLDER">') == 1
+        assert rendered_raw.count('<script name="JS_PLACEHOLDER"></script>') == 1
+
+        assert rendered_raw.count("<script") == 1
+        assert rendered_raw.count("<style") == 0
+        assert rendered_raw.count("<link") == 1
+        assert rendered_raw.count("_RENDERED") == 1
+
+        rendered = render_dependencies(rendered_raw, strategy="append")
+
+        # Dependency manager script NOT present
+        assertInHTML('<script src="django_components/django_components.min.js"></script>', rendered, count=0)
+
+        # Check that it contains inlined JS and CSS, and Media.css
+        assert rendered.strip() == (
+            'Variable: <strong data-djc-id-ca1bc41="">foo</strong>\n'
+            "    \n"
+            '        <script src="script.js"></script><script>console.log("xyz");</script><style>.xyz {\n'
+            "            color: red;\n"
+            '        }</style><link href="style.css" media="all" rel="stylesheet">'
+        )
+
+    def test_multiple_components_dependencies(self):
+        class SimpleComponentNested(Component):
+            template: types.django_html = """
+                {% load component_tags %}
+                <div>
+                    {% component "inner" variable=variable / %}
+                    {% slot "default" default / %}
+                </div>
+            """
+
+            css: types.css = """
+                .my-class {
+                    color: red;
+                }
+            """
+
+            js: types.js = """
+                console.log("Hello");
+            """
+
+            def get_context_data(self, variable):
+                return {}
+
+            class Media:
+                css = ["style.css", "style2.css"]
+                js = "script2.js"
+
+        class OtherComponent(Component):
+            template: types.django_html = """
+                XYZ: <strong>{{ variable }}</strong>
+            """
+
+            css: types.css = """
+                .xyz {
+                    color: red;
+                }
+            """
+
+            js: types.js = """
+                console.log("xyz");
+            """
+
+            def get_context_data(self, variable):
+                return {}
+
+            class Media:
+                css = "xyz1.css"
+                js = "xyz1.js"
+
+        registry.register(name="inner", component=SimpleComponent)
+        registry.register(name="outer", component=SimpleComponentNested)
+        registry.register(name="other", component=OtherComponent)
+
+        template_str: types.django_html = """
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
+            {% component 'outer' variable='variable' %}
+                {% component 'other' variable='variable_inner' / %}
+            {% endcomponent %}
+        """
+        template = Template(template_str)
+        rendered_raw: str = template.render(Context({}))
+
+        rendered = render_dependencies(rendered_raw, strategy="append")
+
+        # Dependency manager script NOT present
+        assertInHTML('<script src="django_components/django_components.min.js"></script>', rendered, count=0)
+
+        assert rendered.count("<script") == 6  # 3 Component.js and 3 Media.js
+        assert rendered.count("<link") == 3  # Media.css
+        assert rendered.count("<style") == 3  # Component.css
+
+        # Components' inlined CSS
+        # NOTE: Each of these should be present only ONCE!
+        assertInHTML(
+            """
+            <style>.my-class { color: red; }</style>
+            <style>.xyz { color: red; }</style>
+            """,
+            rendered,
+            count=1,
+        )
+
+        # Components' Media.css
+        # Order:
+        # - "style.css", "style2.css" (from SimpleComponentNested)
+        # - "style.css" (from SimpleComponent inside SimpleComponentNested)
+        # - "xyz1.css" (from OtherComponent inserted into SimpleComponentNested)
+        assertInHTML(
+            """
+            <link href="style.css" media="all" rel="stylesheet">
+            <link href="style2.css" media="all" rel="stylesheet">
+            <link href="xyz1.css" media="all" rel="stylesheet">
+            """,
+            rendered,
+            count=1,
+        )
+
+        # Components' Media.js followed by inlined JS
+        # Order:
+        # - "script2.js" (from SimpleComponentNested)
+        # - "script.js" (from SimpleComponent inside SimpleComponentNested)
+        # - "xyz1.js" (from OtherComponent inserted into SimpleComponentNested)
+        assertInHTML(
+            """
+            <script src="script2.js"></script>
+            <script src="script.js"></script>
+            <script src="xyz1.js"></script>
+            <script>console.log("Hello");</script>
+            <script>console.log("xyz");</script>
+            """,
+            rendered,
+            count=1,
+        )
+
+        # Check that there's no payload like with "document" or "fragment" modes
+        assert "application/json" not in rendered
 
 
 @djc_test


### PR DESCRIPTION
Closes https://github.com/django-components/django-components/issues/971

The actual convo is here https://github.com/django-components/django-components/pull/959#issuecomment-2824018780

---

Currently in django-components we assumed that components would be rendered only in browsers. So even if one wanted to use djc to generate HTML for emails, we would still insert the `<script>` tag with our client-side dependency manager.

There were two "modes" for deciding how to render the JS and CSS, configured by the `type` kwarg that we pass to `Component.render()` - `"document"` and `"fragment"`.

This PR adds 3 more options - `"simple"`, `"prepend"`, `"append"`

```py
Calendar.render_to_response(
    request=request,
    kwargs={
        "date": request.GET.get("date", ""),
    },
    type="append",
)
```

Overview

- `"document"` (default)
    - Smartly inserts JS / CSS into placeholders or into `<head>` and `<body>` tags.
    - Inserts extra script to allow `fragment` types to work.
    - Assumes the HTML will be rendered in a JS-enabled browser.
- `"fragment"`
    - A lightweight HTML fragment to be inserted into a document.
    - No JS / CSS included.
- `"simple"`
    - Smartly insert JS / CSS into placeholders or into `<head>` and `<body>` tags.
    - No extra script loaded.
- `"prepend"`
    - Insert JS / CSS before the rendered HTML.
    - No extra script loaded.
- `"append"`
    - Insert JS / CSS after the rendered HTML.
    - No extra script loaded.

Other way to think about these is that:
- `"simple"` is the same as `"document"`, except we don't insert our dependency manager JS.
- `"prepend"` and `"append"` are the same as `"simple"`, except we ignore the placeholders and `<head>`/`<body>`, and always prepend/append all JS/CSS.