### PR TITLE
feat: allow to set query and fragment on get_component_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,19 @@
         - Ignores placeholders and any `<head>` / `<body>` tags.
         - No extra script loaded.
 
+- `get_component_url()` now optionally accepts `query` and `fragment` arguments.
+
+    ```py
+    from django_components import get_component_url
+
+    url = get_component_url(
+        MyComponent,
+        query={"foo": "bar"},
+        fragment="baz",
+    )
+    # /components/ext/view/components/c1ab2c3?foo=bar#baz
+    ```
+
 ## v0.139.1
 
 #### Fix

--- a/docs/concepts/fundamentals/component_views_urls.md
+++ b/docs/concepts/fundamentals/component_views_urls.md
@@ -147,3 +147,16 @@ url = get_component_url(MyComponent)
 ```
 
 This way you don't have to mix your app URLs with component URLs.
+
+!!! info
+
+    If you need to pass query parameters or a fragment to the component URL, you can do so by passing the `query` and `fragment` arguments to [`get_component_url()`](../../../reference/api#django_components.get_component_url):
+
+    ```py
+    url = get_component_url(
+        MyComponent,
+        query={"foo": "bar"},
+        fragment="baz",
+    )
+    # /components/ext/view/components/c1ab2c3?foo=bar#baz
+    ```

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -373,6 +373,16 @@ class TestComponent:
         with pytest.raises(KeyError):
             get_component_by_class_id("nonexistent")
 
+    def test_component_render_id(self):
+        class SimpleComponent(Component):
+            template = "render_id: {{ render_id }}"
+
+            def get_template_data(self, args, kwargs, slots, context):
+                return {"render_id": self.id}
+
+        rendered = SimpleComponent.render()
+        assert rendered == "render_id: ca1bc3e"
+
     def test_get_context_data_returns_none(self):
         class SimpleComponent(Component):
             template = "Hello"

--- a/tests/test_component_view.py
+++ b/tests/test_component_view.py
@@ -297,6 +297,24 @@ class TestComponentAsView(SimpleTestCase):
             response.content,
         )
 
+    def test_component_url(self):
+        class TestComponent(Component):
+            template = "Hello"
+
+            class View:
+                public = True
+
+        # Check if the URL is correctly generated
+        component_url = get_component_url(TestComponent)
+        assert component_url == f"/components/ext/view/components/{TestComponent.class_id}/"
+
+        component_url2 = get_component_url(TestComponent, query={"foo": "bar"}, fragment="baz")
+        assert component_url2 == f"/components/ext/view/components/{TestComponent.class_id}/?foo=bar#baz"
+
+        # Check that the query and fragment are correctly escaped
+        component_url3 = get_component_url(TestComponent, query={"f'oo": "b ar&ba'z"}, fragment='q u"x')
+        assert component_url3 == f"/components/ext/view/components/{TestComponent.class_id}/?f%27oo=b+ar%26ba%27z#q%20u%22x"  # noqa: E501
+
     def test_public_url(self):
         did_call_get = False
         did_call_post = False


### PR DESCRIPTION
Updates `get_component_url()` to now optionally accept `query` and `fragment` arguments.

```py
from django_components import get_component_url

url = get_component_url(
    MyComponent,
    query={"foo": "bar"},
    fragment="baz",
)
# /components/ext/view/components/c1ab2c3?foo=bar#baz
```

Closes https://github.com/django-components/django-components/issues/1149