### PR TITLE
refactor: rename `context_data` field to `template_data`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,26 @@
 
 - `SlotContent` was renamed to `SlotInput`. The old name is deprecated and will be removed in v1.
 
+- In the `on_component_data()` extension hook, the `context_data` field of the context object was superseded by `template_data`.
+
+    The `context_data` field will be removed in v1.0.
+
+    Before:
+
+    ```py
+    class MyExtension(ComponentExtension):
+        def on_component_data(self, ctx: OnComponentDataContext) -> None:
+            ctx.context_data["my_template_var"] = "my_value"
+    ```
+
+    After:
+
+    ```py
+    class MyExtension(ComponentExtension):
+        def on_component_data(self, ctx: OnComponentDataContext) -> None:
+            ctx.template_data["my_template_var"] = "my_value"
+    ```
+
 #### Feat
 
 - New method to render template variables - `get_template_data()`

--- a/docs/reference/extension_hooks.md
+++ b/docs/reference/extension_hooks.md
@@ -61,9 +61,10 @@ name | type | description
 `component` | [`Component`](../api#django_components.Component) | The Component instance that is being rendered
 `component_cls` | [`Type[Component]`](../api#django_components.Component) | The Component class
 `component_id` | `str` | The unique identifier for this component instance
-`context_data` | `Dict` | Dictionary of context data from `Component.get_context_data()`
+`context_data` | `Dict` | Deprecated. Use `template_data` instead. Will be removed in v1.0.
 `css_data` | `Dict` | Dictionary of CSS data from `Component.get_css_data()`
 `js_data` | `Dict` | Dictionary of JavaScript data from `Component.get_js_data()`
+`template_data` | `Dict` | Dictionary of template data from `Component.get_template_data()`
 
 ::: django_components.extension.ComponentExtension.on_component_input
     options:

--- a/docs/reference/template_tags.md
+++ b/docs/reference/template_tags.md
@@ -67,7 +67,7 @@ If you insert this tag multiple times, ALL JS scripts will be duplicately insert
 
 
 
-<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L2772" target="_blank">See source code</a>
+<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L2791" target="_blank">See source code</a>
 
 
 

--- a/docs/scripts/reference.py
+++ b/docs/scripts/reference.py
@@ -873,6 +873,9 @@ def _extract_property_docstrings(cls: Type) -> Dict[str, str]:
             if line.endswith("):\n"):
                 ignore = False
             continue
+        # Ignore comments
+        elif line.strip().startswith("#"):
+            continue
         else:
             attrs_lines.append(line)
 

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -2476,7 +2476,9 @@ class Component(metaclass=ComponentMeta):
                 component=self,
                 component_cls=self.__class__,
                 component_id=render_id,
+                # TODO_V1 - Remove `context_data`
                 context_data=template_data,
+                template_data=template_data,
                 js_data=js_data,
                 css_data=css_data,
             )

--- a/src/django_components/extension.py
+++ b/src/django_components/extension.py
@@ -104,8 +104,11 @@ class OnComponentDataContext(NamedTuple):
     """The Component class"""
     component_id: str
     """The unique identifier for this component instance"""
+    # TODO_V1 - Remove `context_data`
     context_data: Dict
-    """Dictionary of context data from `Component.get_context_data()`"""
+    """Deprecated. Use `template_data` instead. Will be removed in v1.0."""
+    template_data: Dict
+    """Dictionary of template data from `Component.get_template_data()`"""
     js_data: Dict
     """Dictionary of JavaScript data from `Component.get_js_data()`"""
     css_data: Dict

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -300,7 +300,7 @@ class TestExtensionHooks:
         data_call: OnComponentDataContext = extension.calls["on_component_data"][0]
         assert data_call.component_cls == TestComponent
         assert isinstance(data_call.component_id, str)
-        assert data_call.context_data == {"name": "Test"}
+        assert data_call.template_data == {"name": "Test"}
         assert data_call.js_data == {"script": "console.log('Hello!')"}
         assert data_call.css_data == {"style": "body { color: blue; }"}
 


### PR DESCRIPTION
Made this a separate PR from https://github.com/django-components/django-components/pull/1161 so that https://github.com/django-components/django-components/pull/1161 contained no new changes / suggestions.

As part of renaming `get_context_data` to `get_template_data`, there is also one object that had field `context_data`. This PR renames it to `template_data`.

The object was available from within the `on_component_data` extension hook.

Again the old field is kept for backwards compatibility and tagged to be removed in v1.

<img width="990" alt="Screenshot 2025-05-03 at 12 13 55" src="https://github.com/user-attachments/assets/d97b7eb5-ab35-4d7f-a9b7-8b73521bc71d" />
