### PR TITLE
Fix context processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -370,6 +370,10 @@
     # /components/ext/view/components/c1ab2c3?foo=bar#baz
     ```
 
+#### Fix
+
+- Fix bug: Context processors data was being generated anew for each component. Now the data correctly created once and reused across components with the same request ([#1165](https://github.com/django-components/django-components/issues/1165)).
+
 ## v0.139.1
 
 #### Fix

--- a/src/django_components/util/context.py
+++ b/src/django_components/util/context.py
@@ -131,7 +131,7 @@ def _copy_block_context(block_context: BlockContext) -> BlockContext:
 # See https://github.com/django/django/blame/2d34ebe49a25d0974392583d5bbd954baf742a32/django/template/context.py#L255
 def gen_context_processors_data(context: BaseContext, request: HttpRequest) -> Dict[str, Any]:
     if request in context_processors_data:
-        return context_processors_data[request]
+        return context_processors_data[request].copy()
 
     # TODO_REMOVE_IN_V2 - In v2, if we still support context processors,
     #     it should be set on our settings, so we wouldn't have to get the Engine for that.
@@ -152,5 +152,7 @@ def gen_context_processors_data(context: BaseContext, request: HttpRequest) -> D
             processors_data.update(data)
         except TypeError as e:
             raise TypeError(f"Context processor {processor.__qualname__} didn't return a " "dictionary.") from e
+
+    context_processors_data[request] = processors_data
 
     return processors_data


### PR DESCRIPTION
See #1165 

When generating context processors data, in `gen_context_processors_data()`, we meant to cache the results, so we would reuse the same data for the same request object. But the line of code to save the generated data was missing.

Closes #1165