### PR TITLE
refactor: Change caching methods to accept slots + typing fixes

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -54,7 +54,9 @@ python manage.py components ext run <extension> <command>
 ## `components create`
 
 ```txt
-usage: python manage.py components create [-h] [--path PATH] [--js JS] [--css CSS] [--template TEMPLATE] [--force] [--verbose] [--dry-run] name
+usage: python manage.py components create [-h] [--path PATH] [--js JS] [--css CSS] [--template TEMPLATE] [--force] [--verbose]
+              [--dry-run]
+              name
 
 ```
 
@@ -236,7 +238,7 @@ List all extensions.
 - `--columns COLUMNS`
     - Comma-separated list of columns to show. Available columns: name. Defaults to `--columns name`.
 - `-s`, `--simple`
-    - Only show table data, without headers. Use this option for generating machine-readable output.
+    - Only show table data, without headers. Use this option for generating machine- readable output.
 
 
 
@@ -399,7 +401,7 @@ List all components created in this project.
 - `--columns COLUMNS`
     - Comma-separated list of columns to show. Available columns: name, full_name, path. Defaults to `--columns full_name,path`.
 - `-s`, `--simple`
-    - Only show table data, without headers. Use this option for generating machine-readable output.
+    - Only show table data, without headers. Use this option for generating machine- readable output.
 
 
 
@@ -461,8 +463,9 @@ ProjectDashboardAction    project.components.dashboard_action.ProjectDashboardAc
 ## `upgradecomponent`
 
 ```txt
-usage: upgradecomponent [-h] [--path PATH] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color]
-                        [--force-color] [--skip-checks]
+usage: upgradecomponent [-h] [--path PATH] [--version] [-v {0,1,2,3}] [--settings SETTINGS]
+                        [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color]
+                        [--skip-checks]
 
 ```
 
@@ -506,8 +509,10 @@ Deprecated. Use `components upgrade` instead.
 ## `startcomponent`
 
 ```txt
-usage: startcomponent [-h] [--path PATH] [--js JS] [--css CSS] [--template TEMPLATE] [--force] [--verbose] [--dry-run] [--version] [-v {0,1,2,3}]
-                      [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color] [--skip-checks]
+usage: startcomponent [-h] [--path PATH] [--js JS] [--css CSS] [--template TEMPLATE] [--force]
+                      [--verbose] [--dry-run] [--version] [-v {0,1,2,3}] [--settings SETTINGS]
+                      [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color]
+                      [--skip-checks]
                       name
 
 ```

--- a/docs/reference/template_tags.md
+++ b/docs/reference/template_tags.md
@@ -67,7 +67,7 @@ If you insert this tag multiple times, ALL JS scripts will be duplicately insert
 
 
 
-<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L2785" target="_blank">See source code</a>
+<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L2784" target="_blank">See source code</a>
 
 
 

--- a/src/django_components/extension.py
+++ b/src/django_components/extension.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
 
 TCallable = TypeVar("TCallable", bound=Callable)
+TClass = TypeVar("TClass", bound=Type[Any])
 
 
 ################################################
@@ -29,7 +30,7 @@ TCallable = TypeVar("TCallable", bound=Callable)
 
 # Mark a class as an extension hook context so we can place these in
 # a separate documentation section
-def mark_extension_hook_api(cls: Type[Any]) -> Type[Any]:
+def mark_extension_hook_api(cls: TClass) -> TClass:
     cls._extension_hook_api = True
     return cls
 

--- a/src/django_components/extensions/view.py
+++ b/src/django_components/extensions/view.py
@@ -233,7 +233,7 @@ class ViewExtension(ComponentExtension):
 
     # Create URL route on creation
     def on_component_class_created(self, ctx: OnComponentClassCreatedContext) -> None:
-        comp_cls: Type["Component"] = ctx.component_cls
+        comp_cls = ctx.component_cls
         view_cls: Optional[Type[ComponentView]] = getattr(comp_cls, "View", None)
         if view_cls is None or not view_cls.public:
             return
@@ -254,7 +254,7 @@ class ViewExtension(ComponentExtension):
 
     # Remove URL route on deletion
     def on_component_class_deleted(self, ctx: OnComponentClassDeletedContext) -> None:
-        comp_cls: Type["Component"] = ctx.component_cls
+        comp_cls = ctx.component_cls
         route = self.routes_by_component.pop(comp_cls, None)
         if route is None:
             return

--- a/src/django_components/util/command.py
+++ b/src/django_components/util/command.py
@@ -1,15 +1,31 @@
 import sys
 from argparse import Action, ArgumentParser
 from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Protocol, Sequence, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Protocol,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+)
 
 if TYPE_CHECKING:
     from argparse import _ArgumentGroup, _FormatterClass
 
 
+TClass = TypeVar("TClass", bound=Type[Any])
+
+
 # Mark object as related to extension commands so we can place these in
 # a separate documentation section
-def mark_extension_command_api(obj: Any) -> Any:
+def mark_extension_command_api(obj: TClass) -> TClass:
     obj._extension_command_api = True
     return obj
 
@@ -27,7 +43,7 @@ The basic type of action to be taken when this argument is encountered at the co
 This is a subset of the values for `action` in
 [`ArgumentParser.add_argument()`](https://docs.python.org/3/library/argparse.html#the-add-argument-method).
 """
-mark_extension_command_api(CommandLiteralAction)
+mark_extension_command_api(CommandLiteralAction)  # type: ignore
 
 
 @mark_extension_command_api

--- a/src/django_components/util/routing.py
+++ b/src/django_components/util/routing.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, Optional, Protocol
+from typing import Any, Dict, Iterable, Optional, Protocol, Type, TypeVar
+
+TClass = TypeVar("TClass", bound=Type[Any])
 
 
 # Mark object as related to extension URLs so we can place these in
 # a separate documentation section
-def mark_extension_url_api(obj: Any) -> Any:
+def mark_extension_url_api(obj: TClass) -> TClass:
     obj._extension_url_api = True
     return obj
 

--- a/tests/test_component_cache.py
+++ b/tests/test_component_cache.py
@@ -45,7 +45,7 @@ class TestComponentCache:
         assert result == "Hello"
 
         # Check if the cache entry is set
-        cache_key = component.cache.get_cache_key()
+        cache_key = component.cache.get_cache_key([], {}, {})
         assert cache_key == "components:cache:TestComponent_c9770f::"
         assert component.cache.get_entry(cache_key) == "<!-- _RENDERED TestComponent_c9770f,ca1bc3e,, -->Hello"
         assert caches["default"].get(cache_key) == "<!-- _RENDERED TestComponent_c9770f,ca1bc3e,, -->Hello"
@@ -81,7 +81,7 @@ class TestComponentCache:
 
         # Check if the cache entry is not set
         cache_instance = component.cache
-        cache_key = cache_instance.get_cache_key()
+        cache_key = cache_instance.get_cache_key([], {}, {})
         assert cache_instance.get_entry(cache_key) is None
 
         # Second render
@@ -104,7 +104,7 @@ class TestComponentCache:
         component.render()
 
         cache_instance = component.cache
-        cache_key = cache_instance.get_cache_key()
+        cache_key = cache_instance.get_cache_key([], {}, {})
         assert cache_instance.get_entry(cache_key) == "<!-- _RENDERED TestComponent_42aca9,ca1bc3e,, -->Hello"
 
         # Wait for TTL to expire
@@ -186,7 +186,7 @@ class TestComponentCache:
 
         # The key consists of `component._class_hash`, hashed args, and hashed kwargs
         expected_key = "1,2:key-value"
-        assert component.cache.hash(1, 2, key="value") == expected_key
+        assert component.cache.hash([1, 2], {"key": "value"}) == expected_key
 
     def test_override_hash_methods(self):
         class TestComponent(Component):
@@ -207,7 +207,7 @@ class TestComponentCache:
 
         # The key should use the custom hash methods
         expected_key = "components:cache:TestComponent_28880f:custom-args-and-kwargs"
-        assert component.cache.get_cache_key(1, 2, key="value") == expected_key
+        assert component.cache.get_cache_key([1, 2], {"key": "value"}, {}) == expected_key
 
     def test_cached_component_inside_include(self):
 


### PR DESCRIPTION
Phew, last one for today!

As mentioned in https://github.com/django-components/django-components/issues/1164#issuecomment-2849451094, this is part of changes to allow component caching to take into the account the slots that were used to render the component.

This specific PR only updates the methods of `Component.Cache` so they already receive the slots. This is so that this small breaking change is released with the rest of them in v0.140.

Before:

```py
def get_cache_key(self, *args: Any, **kwargs: Any) -> str:

def hash(self, *args: Any, **kwargs: Any) -> str:
```

After:

```py
def get_cache_key(self, args: Any, kwargs: Any, slots: Any) -> str:

def hash(self, args: Any, kwargs: Any) -> str:
```