### PR TITLE
feat: add BaseNode.contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -406,6 +406,36 @@
     # /components/ext/view/components/c1ab2c3?foo=bar#baz
     ```
 
+- The `BaseNode` class has a new `contents` attribute, which contains the raw contents (string) of the tag body.
+
+    This is relevant when you define custom template tags with `@template_tag` decorator or `BaseNode` class.
+
+    When you define a custom template tag like so:
+
+    ```py
+    from django_components import BaseNode, template_tag
+
+    @template_tag(
+        library,
+        tag="mytag",
+        end_tag="endmytag",
+        allowed_flags=["required"]
+    )
+    def mytag(node: BaseNode, context: Context, name: str, **kwargs) -> str:
+        print(node.contents)
+        return f"Hello, {name}!"
+    ```
+
+    And render it like so:
+
+    ```django
+    {% mytag name="John" %}
+        Hello, world!
+    {% endmytag %}
+    ```
+
+    Then, the `contents` attribute of the `BaseNode` instance will contain the string `"Hello, world!"`.
+
 #### Fix
 
 - Fix bug: Context processors data was being generated anew for each component. Now the data is correctly created once and reused across components with the same request ([#1165](https://github.com/django-components/django-components/issues/1165)).

--- a/docs/concepts/advanced/template_tags.md
+++ b/docs/concepts/advanced/template_tags.md
@@ -52,7 +52,7 @@ This will allow you to use the tag in your templates like this:
 
 ### Parameters
 
-The `@template_tag` decorator accepts the following parameters:
+The [`@template_tag`](../../../reference/api#django_components.template_tag) decorator accepts the following parameters:
 
 - `library`: The Django template library to register the tag with
 - `tag`: The name of the template tag (e.g. `"mytag"` for `{% mytag %}`)
@@ -61,7 +61,8 @@ The `@template_tag` decorator accepts the following parameters:
 
 ### Function signature
 
-The function decorated with `@template_tag` must accept at least two arguments:
+The function decorated with [`@template_tag`](../../../reference/api#django_components.template_tag)
+must accept at least two arguments:
 
 1. `node`: The node instance (we'll explain this in detail in the next section)
 2. `context`: The Django template context
@@ -150,15 +151,16 @@ GreetNode.register(library)
 
 ### Node properties
 
-When using `BaseNode`, you have access to several useful properties:
+When using [`BaseNode`](../../../reference/api#django_components.BaseNode), you have access to several useful properties:
 
 - `node_id`: A unique identifier for this node instance
 - `flags`: Dictionary of flag values (e.g. `{"required": True}`)
 - `params`: List of raw parameters passed to the tag
 - `nodelist`: The template nodes between the start and end tags
+- `contents`: The raw contents between the start and end tags
 - `active_flags`: List of flags that are currently set to True
 
-This is what the `node` parameter in the `@template_tag` decorator gives you access to - it's the instance of the node class that was automatically created for your template tag.
+This is what the `node` parameter in the [`@template_tag`](../../../reference/api#django_components.template_tag) decorator gives you access to - it's the instance of the node class that was automatically created for your template tag.
 
 ### Rendering content between tags
 

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -2888,8 +2888,9 @@ class ComponentNode(BaseNode):
         flags: Optional[Dict[str, bool]] = None,
         nodelist: Optional[NodeList] = None,
         node_id: Optional[str] = None,
+        contents: Optional[str] = None,
     ) -> None:
-        super().__init__(params=params, flags=flags, nodelist=nodelist, node_id=node_id)
+        super().__init__(params=params, flags=flags, nodelist=nodelist, node_id=node_id, contents=contents)
 
         self.name = name
         self.registry = registry

--- a/src/django_components/node.py
+++ b/src/django_components/node.py
@@ -313,11 +313,13 @@ class BaseNode(Node, metaclass=NodeMeta):
         flags: Optional[Dict[str, bool]] = None,
         nodelist: Optional[NodeList] = None,
         node_id: Optional[str] = None,
+        contents: Optional[str] = None,
     ):
         self.params = params
         self.flags = flags or {flag: False for flag in self.allowed_flags or []}
         self.nodelist = nodelist or NodeList()
         self.node_id = node_id or gen_id()
+        self.contents = contents
 
     def __repr__(self) -> str:
         return (
@@ -350,12 +352,13 @@ class BaseNode(Node, metaclass=NodeMeta):
 
         trace_node_msg("PARSE", cls.tag, tag_id)
 
-        body = tag.parse_body()
+        body, contents = tag.parse_body()
         node = cls(
             nodelist=body,
             node_id=tag_id,
             params=tag.params,
             flags=tag.flags,
+            contents=contents,
             **kwargs,
         )
 


### PR DESCRIPTION
Another part towards https://github.com/django-components/django-components/issues/1164.

This modifies our implementation of template tags so that the Node (well, `BaseNode`) class remembers what was the content of the body (the string between `{% tag %}` / `{% endtag %}`), and makes it accessible via `BaseNode.contents`.