### PR TITLE
refactor: Rename `{% fill default=... %}` to `{% fill fallback=... %}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,9 +322,29 @@
             ctx.template_data["my_template_var"] = "my_value"
     ```
 
-**Miscellaneous**
+**Slots**
 
 - `SlotContent` was renamed to `SlotInput`. The old name is deprecated and will be removed in v1.
+
+- `SlotRef` was renamed to `SlotFallback`. The old name is deprecated and will be removed in v1.
+
+- The `default` kwarg in `{% fill %}` tag was renamed to `fallback`. The old name is deprecated and will be removed in v1.
+
+    Before:
+
+    ```django
+    {% fill "footer" default="footer" %}
+        {{ footer }}
+    {% endfill %}
+    ```
+
+    After:
+
+    ```django
+    {% fill "footer" fallback="footer" %}
+        {{ footer }}
+    {% endfill %}
+    ```
 
 #### Feat
 

--- a/src/django_components/__init__.py
+++ b/src/django_components/__init__.py
@@ -50,7 +50,7 @@ from django_components.extensions.defaults import ComponentDefaults, Default
 from django_components.extensions.view import ComponentView, get_component_url
 from django_components.library import TagProtectedError
 from django_components.node import BaseNode, template_tag
-from django_components.slots import Slot, SlotContent, SlotFunc, SlotInput, SlotRef, SlotResult
+from django_components.slots import Slot, SlotContent, SlotFallback, SlotFunc, SlotInput, SlotRef, SlotResult
 from django_components.tag_formatter import (
     ComponentFormatter,
     ShorthandComponentFormatter,
@@ -125,6 +125,7 @@ __all__ = [
     "ShorthandComponentFormatter",
     "Slot",
     "SlotContent",
+    "SlotFallback",
     "SlotFunc",
     "SlotInput",
     "SlotRef",

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -67,11 +67,11 @@ from django_components.perfutil.provide import register_provide_reference, unreg
 from django_components.provide import get_injected_context_var
 from django_components.slots import (
     Slot,
+    SlotFallback,
     SlotFunc,
     SlotInput,
     SlotIsFilled,
     SlotName,
-    SlotRef,
     SlotResult,
     _is_extracting_fill,
     resolve_fills,
@@ -2723,8 +2723,8 @@ class Component(metaclass=ComponentMeta):
             # so we can assign metadata to our internal copies.
             if not isinstance(content, Slot) or not content.escaped:
                 # We wrap the original function so we post-process it by escaping the result.
-                def content_fn(ctx: Context, slot_data: Dict, slot_ref: SlotRef) -> SlotResult:
-                    rendered = content(ctx, slot_data, slot_ref)
+                def content_fn(ctx: Context, slot_data: Dict, fallback: SlotFallback) -> SlotResult:
+                    rendered = content(ctx, slot_data, fallback)
                     return conditional_escape(rendered) if escape_content else rendered
 
                 content_func = cast(SlotFunc, content_fn)

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -12,7 +12,7 @@ from django.template.base import NodeList, TextNode
 from pytest_django.asserts import assertHTMLEqual
 
 from django_components import Component, register, types
-from django_components.slots import Slot, SlotRef
+from django_components.slots import Slot, SlotFallback
 
 from django_components.testing import djc_test
 from .testutils import PARAMETRIZE_CONTEXT_BEHAVIOR, setup_test_config
@@ -49,7 +49,7 @@ class TestSlot:
                     "kwargs": kwargs,
                 }
 
-        def first_slot(ctx: Context, slot_data: Dict, slot_ref: SlotRef):
+        def first_slot(ctx: Context, slot_data: Dict, slot_ref: SlotFallback):
             assert isinstance(ctx, Context)
             # NOTE: Since the slot has access to the Context object, it should behave
             # the same way as it does in templates - when in "isolated" mode, then the
@@ -72,7 +72,7 @@ class TestSlot:
             }
             assert slot_data_expected == slot_data
 
-            assert isinstance(slot_ref, SlotRef)
+            assert isinstance(slot_ref, SlotFallback)
             assert "SLOT_DEFAULT" == str(slot_ref).strip()
 
             return f"FROM_INSIDE_FIRST_SLOT | {slot_ref}"

--- a/tests/test_templatetags_templating.py
+++ b/tests/test_templatetags_templating.py
@@ -445,7 +445,7 @@ class TestSlotIteration:
             ["django", "isolated"],
         )
     )
-    def test_inner_slot_iteration_nested_with_slot_default(self, components_settings, expected):
+    def test_inner_slot_iteration_nested_with_slot_fallback(self, components_settings, expected):
         registry.register("slot_in_a_loop", self._get_component_simple_slot_in_a_loop())
 
         objects = [
@@ -458,7 +458,7 @@ class TestSlotIteration:
             {% component "slot_in_a_loop" objects=objects %}
                 {% fill "slot_inner" %}
                     {% component "slot_in_a_loop" objects=object.inner %}
-                        {% fill "slot_inner" default="super_slot_inner" %}
+                        {% fill "slot_inner" fallback="super_slot_inner" %}
                             {{ super_slot_inner }}
                         {% endfill %}
                     {% endcomponent %}
@@ -498,7 +498,7 @@ class TestSlotIteration:
             ["django", "isolated"],
         )
     )
-    def test_inner_slot_iteration_nested_with_slot_default_and_outer_scope_variable(
+    def test_inner_slot_iteration_nested_with_slot_fallback_and_outer_scope_variable(
         self,
         components_settings,
         expected,
@@ -516,7 +516,7 @@ class TestSlotIteration:
                 {% fill "slot_inner" %}
                     {{ outer_scope_variable_1 }}
                     {% component "slot_in_a_loop" objects=object.inner %}
-                        {% fill "slot_inner" default="super_slot_inner" %}
+                        {% fill "slot_inner" fallback="super_slot_inner" %}
                             {{ outer_scope_variable_2 }}
                             {{ super_slot_inner }}
                         {% endfill %}
@@ -537,7 +537,7 @@ class TestSlotIteration:
         assertHTMLEqual(rendered, expected)
 
     @djc_test(components_settings={"context_behavior": "isolated"})
-    def test_inner_slot_iteration_nested_with_slot_default_and_outer_scope_variable__isolated_2(
+    def test_inner_slot_iteration_nested_with_slot_fallback_and_outer_scope_variable__isolated_2(
         self,
     ):
         registry.register("slot_in_a_loop", self._get_component_simple_slot_in_a_loop())
@@ -556,7 +556,7 @@ class TestSlotIteration:
                 {% fill "slot_inner" %}
                     {{ outer_scope_variable_1|safe }}
                     {% component "slot_in_a_loop" objects=objects %}
-                        {% fill "slot_inner" default="super_slot_inner" %}
+                        {% fill "slot_inner" fallback="super_slot_inner" %}
                             {{ outer_scope_variable_2|safe }}
                             {{ super_slot_inner }}
                         {% endfill %}
@@ -959,14 +959,14 @@ class TestComponentNesting:
             ["django", "isolated"],
         )
     )
-    def test_component_nesting_component_with_slot_default(self, components_settings, expected):
+    def test_component_nesting_component_with_slot_fallback(self, components_settings, expected):
         registry.register("dashboard", self._get_dashboard_component())
         registry.register("calendar", self._get_calendar_component())
 
         template_str: types.django_html = """
             {% load component_tags %}
             {% component "dashboard" %}
-              {% fill "header" default="h" %} Hello! {{ h }} {% endfill %}
+              {% fill "header" fallback="h" %} Hello! {{ h }} {% endfill %}
             {% endcomponent %}
         """
         template = Template(template_str)


### PR DESCRIPTION
Renamed to avoid confusion between `{% slot default %}` and `{% fill default="..." %}`

The old kwarg `{% fill default="..." %}` is still avaialble with the plan to remove it in v1.

I didn't update the documentation page in ["concepts/fundamentals/slots"](https://django-components.github.io/django-components/0.139.1/concepts/fundamentals/slots/) in this PR, because there's could more PRs after this one, so then there is one PR that solely just updates the docs page.