### PR TITLE
refactor: simplify slot API

### DIFF
--- a/docs/concepts/advanced/component_caching.md
+++ b/docs/concepts/advanced/component_caching.md
@@ -131,7 +131,7 @@ MyComponent.render(
     ```py
     MyComponent.render(
         kwargs={"position": "left"},
-        slots={"content": lambda *a, **kwa: "Hello, Alice"}
+        slots={"content": lambda ctx: "Hello, Alice"}
     )
     ```
 

--- a/docs/concepts/fundamentals/rendering_components.md
+++ b/docs/concepts/fundamentals/rendering_components.md
@@ -513,7 +513,7 @@ Button.render(
         age=30,
     ),
     slots=Button.Slots(
-        footer=Slot(lambda *a, **kwa: "Click me!"),
+        footer=Slot(lambda ctx: "Click me!"),
     ),
 )
 ```

--- a/docs/concepts/fundamentals/typing_and_validation.md
+++ b/docs/concepts/fundamentals/typing_and_validation.md
@@ -128,7 +128,7 @@ Button.render(
         age=30,
     ),
     slots=Button.Slots(
-        footer=Slot(lambda *a, **kwa: "Click me!"),
+        footer=Slot(lambda ctx: "Click me!"),
     ),
 )
 ```
@@ -601,7 +601,7 @@ Button.render(
     },
     slots={
         "my_slot": "...",
-        "another_slot": Slot(lambda: ...),
+        "another_slot": Slot(lambda ctx: ...),
     },
 )
 ```
@@ -662,7 +662,7 @@ Button.render(
     ),
     slots=Button.Slots(
         my_slot="...",
-        another_slot=Slot(lambda: ...),
+        another_slot=Slot(lambda ctx: ...),
     ),
 )
 ```

--- a/src/django_components/__init__.py
+++ b/src/django_components/__init__.py
@@ -50,7 +50,16 @@ from django_components.extensions.defaults import ComponentDefaults, Default
 from django_components.extensions.view import ComponentView, get_component_url
 from django_components.library import TagProtectedError
 from django_components.node import BaseNode, template_tag
-from django_components.slots import Slot, SlotContent, SlotFallback, SlotFunc, SlotInput, SlotRef, SlotResult
+from django_components.slots import (
+    Slot,
+    SlotContent,
+    SlotContext,
+    SlotFallback,
+    SlotFunc,
+    SlotInput,
+    SlotRef,
+    SlotResult,
+)
 from django_components.tag_formatter import (
     ComponentFormatter,
     ShorthandComponentFormatter,
@@ -125,6 +134,7 @@ __all__ = [
     "ShorthandComponentFormatter",
     "Slot",
     "SlotContent",
+    "SlotContext",
     "SlotFallback",
     "SlotFunc",
     "SlotInput",

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -458,7 +458,7 @@ class Component(metaclass=ComponentMeta):
     Table.render(
         slots=Table.Slots(
             header="HELLO IM HEADER",
-            footer=Slot(lambda: ...),
+            footer=Slot(lambda ctx: ...),
         ),
     )
     ```
@@ -2132,8 +2132,8 @@ class Component(metaclass=ComponentMeta):
             Button.render(
                 slots={
                     "content": "Click me!"
-                    "content2": lambda *a, **kwa: "Click me!",
-                    "content3": Slot(lambda *a, **kwa: "Click me!"),
+                    "content2": lambda ctx: "Click me!",
+                    "content3": Slot(lambda ctx: "Click me!"),
                 },
             )
             ```
@@ -2260,7 +2260,7 @@ class Component(metaclass=ComponentMeta):
                 age=30,
             ),
             slots=Button.Slots(
-                footer=Slot(lambda *a, **kwa: "Click me!"),
+                footer=Slot(lambda ctx: "Click me!"),
             ),
         )
         ```

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -322,7 +322,8 @@ class TestComponentRenderAPI:
                 assert self.input.kwargs == {"variable": "test", "another": 1}
                 assert isinstance(self.input.context, Context)
                 assert list(self.input.slots.keys()) == ["my_slot"]
-                assert self.input.slots["my_slot"](Context(), None, None) == "MY_SLOT"
+                my_slot = self.input.slots["my_slot"]
+                assert my_slot() == "MY_SLOT"
 
                 return {
                     "variable": kwargs["variable"],
@@ -334,7 +335,8 @@ class TestComponentRenderAPI:
                 assert self.input.kwargs == {"variable": "test", "another": 1}
                 assert isinstance(self.input.context, Context)
                 assert list(self.input.slots.keys()) == ["my_slot"]
-                assert self.input.slots["my_slot"](Context(), None, None) == "MY_SLOT"
+                my_slot = self.input.slots["my_slot"]
+                assert my_slot() == "MY_SLOT"
 
                 template_str: types.django_html = """
                     {% load component_tags %}

--- a/tests/test_component_cache.py
+++ b/tests/test_component_cache.py
@@ -346,5 +346,5 @@ class TestComponentCache:
         ):
             TestComponent.render(
                 kwargs={"input": "cake"},
-                slots={"content": lambda *a, **kwa: "ONE"},
+                slots={"content": lambda ctx: "ONE"},
             )

--- a/tests/test_component_typing.py
+++ b/tests/test_component_typing.py
@@ -76,7 +76,7 @@ class TestComponentTyping:
             kwargs=Button.Kwargs(name="name", age=123),
             slots=Button.Slots(
                 header="HEADER",
-                footer=Slot(lambda ctx, slot_data, slot_ref: "FOOTER"),
+                footer=Slot(lambda ctx: "FOOTER"),
             ),
         )
 
@@ -124,7 +124,7 @@ class TestComponentTyping:
             kwargs={"name": "name", "age": 123},
             slots={
                 "header": "HEADER",
-                "footer": Slot(lambda ctx, slot_data, slot_ref: "FOOTER"),
+                "footer": Slot(lambda ctx: "FOOTER"),
             },
         )
 
@@ -206,7 +206,7 @@ class TestComponentTyping:
             kwargs={"name": "name", "age": 123},
             slots={
                 "header": "HEADER",
-                "footer": Slot(lambda ctx, slot_data, slot_ref: "FOOTER"),
+                "footer": Slot(lambda ctx: "FOOTER"),
             },
         )
 
@@ -314,7 +314,7 @@ class TestComponentTyping:
             kwargs={"name": "name", "age": 123},
             slots={
                 "header": "HEADER",
-                "footer": Slot(lambda ctx, slot_data, slot_ref: "FOOTER"),
+                "footer": Slot(lambda ctx: "FOOTER"),
             },
         )
 
@@ -397,7 +397,7 @@ class TestComponentTyping:
             kwargs=Button.Kwargs(name="name", age=123),
             slots=Button.Slots(
                 header="HEADER",
-                footer=Slot(lambda ctx, slot_data, slot_ref: "FOOTER"),
+                footer=Slot(lambda ctx: "FOOTER"),
             ),
         )
 
@@ -412,7 +412,7 @@ class TestComponentTyping:
                 kwargs=Button.Kwargs(name="name", age=123),
                 slots=Button.Slots(
                     header="HEADER",
-                    footer=Slot(lambda ctx, slot_data, slot_ref: "FOOTER"),
+                    footer=Slot(lambda ctx: "FOOTER"),
                 ),
             )
 
@@ -427,7 +427,7 @@ class TestComponentTyping:
                 kwargs=Button.Kwargs(age=123),  # type: ignore[call-arg]
                 slots=Button.Slots(
                     header="HEADER",
-                    footer=Slot(lambda ctx, slot_data, slot_ref: "FOOTER"),
+                    footer=Slot(lambda ctx: "FOOTER"),
                 ),
             )
 
@@ -438,7 +438,7 @@ class TestComponentTyping:
             args=Button.Args(arg1="arg1", arg2="arg2"),
             kwargs=Button.Kwargs(name="name", age=123),
             slots=Button.Slots(  # type: ignore[typeddict-item]
-                footer=Slot(lambda ctx, slot_data, slot_ref: "FOOTER"),  # Missing header
+                footer=Slot(lambda ctx: "FOOTER"),  # Missing header
             ),
         )
 

--- a/tests/test_templatetags_slot_fill.py
+++ b/tests/test_templatetags_slot_fill.py
@@ -2440,9 +2440,9 @@ class TestSlotInput:
 
         assert seen_slots == {}
 
-        header_slot: Slot = Slot(lambda *a, **kw: "HEADER_SLOT")
+        header_slot: Slot = Slot(lambda ctx: "HEADER_SLOT")
         main_slot_str = "MAIN_SLOT"
-        footer_slot_fn = lambda *a, **kw: "FOOTER_SLOT"  # noqa: E731
+        footer_slot_fn = lambda ctx: "FOOTER_SLOT"  # noqa: E731
 
         SlottedComponent.render(
             slots={


### PR DESCRIPTION
Breaking change to simplify the slot functions API:

- Defining slot functions:
	
    Before:
	
	```py
	def slot_fn(context: Context, data: Dict, slot_ref: SlotRef):
	    isinstance(context, Context)
	    isinstance(data, Dict)
	    isinstance(slot_ref, SlotRef)

	    return "CONTENT"
	```
	
	After:
	
	```py
	def slot_fn(ctx: SlotContext):
	    assert isinstance(ctx.context, Context) # May be None
	    assert isinstance(ctx.data, Dict)
        # Renamed `SlotRef`/`slot_ref` to `SlotFallback`/`fallack`
	    assert isinstance(ctx.fallback, SlotFallback) # May be None
	
	    return "CONTENT"
	```

- Calling slot functions:

    Before:

    ```py
    def slot_fn(context: Context, data: Dict, slot_ref: SlotRef):
        return "CONTENT"

    html = slot_fn(Context(), None, None)  # All inputs were required and all positional
	html = slot(Context(), {"data1": "abc", "data2": "hello"}, None)
	html = slot(Context(), {"data1": "abc", "data2": "hello"}, "FALLBACK")
    ```

    After:

    ```py
    def slot_fn(ctx: SlotContext):
        return "CONTENT"

    # Must be wrapped in Slot instance. We auto-wrap those slots passed to components
    # So users won't have to do do `Slot(slot_fn)` unless they are doing something custom
    slot = Slot(slot_fn)
    # Can be called with 0-3 inputs
    html = slot()
    html = slot({"data1": "abc", "data2": "hello"})
    html = slot({"data1": "abc", "data2": "hello"}, fallback="FALLBACK")
    ```

Closes #1096