### PR TITLE
feat: Pass Slots to {% fill %} with 'body' kwarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -574,6 +574,30 @@
     - If `Slot` was created from string via `Slot("...")`, `Slot.contents` will contain that string.
     - If `Slot` was created from a function, `Slot.contents` will contain that function.
 
+- `{% fill %}` tag now accepts `body` kwarg to pass a Slot instance to fill.
+
+    First pass a [`Slot`](../api#django_components.Slot) instance to the template
+    with the [`get_template_data()`](../api#django_components.Component.get_template_data)
+    method:
+
+    ```python
+    from django_components import component, Slot
+
+    class Table(Component):
+      def get_template_data(self, args, kwargs, slots, context):
+        return {
+            "my_slot": Slot(lambda ctx: "Hello, world!"),
+        }
+    ```
+
+    Then pass the slot to the `{% fill %}` tag:
+
+    ```django
+    {% component "table" %}
+      {% fill "pagination" body=my_slot / %}
+    {% endcomponent %}
+    ```
+
 - Component caching can now take slots into account, by setting `Component.Cache.include_slots` to `True`.
 
     ```py


### PR DESCRIPTION
This PR allows to pass `Slot` instances to `{% fill %}` tags. Basically a mechanism to render the Python-defined Slots in the template.

Closes https://github.com/django-components/django-components/issues/1171

In the discussion there were options for the kwarg name like `slot`, `contents`, or `with`.
- `slot` was confusing, and could not use `with`, because it's a Python keyword. And `contents` feels too long.
- So I set the kwarg name to `body`, as in "set the body of this fill tag"

So the final API looks like this:

```python
from django_components import component, Slot

class Table(Component):
  def get_template_data(self, args, kwargs, slots, context):
    return {
        "my_slot": Slot(lambda ctx: "Hello, world!"),
    }
```

Then pass the slot to the `{% fill %}` tag:

```django
{% component "table" %}
  {% fill "pagination" body=my_slot / %}
{% endcomponent %}
```