### PR TITLE
feat: Component.args/kwargs/slots and {{ component_vars.args/kwargs/s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Summary:
 
 - Overhauled typing system
 - Middleware removed, no longer needed
-- `get_context_data()` is the new canonical way to define template data
+- `get_template_data()` is the new canonical way to define template data
 - Slots API polished and prepared for v1.
 - Merged `Component.Url` with `Component.View`
 - Added `Component.args`, `Component.kwargs`, `Component.slots`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ⚠️ Major release ⚠️ - Please test thoroughly before / after upgrading.
 
+Summary:
+
+- Overhauled typing system
+- Middleware removed, no longer needed
+- `get_context_data()` is the new canonical way to define template data
+- Slots API polished and prepared for v1.
+- Merged `Component.Url` with `Component.View`
+- Added `Component.args`, `Component.kwargs`, `Component.slots`
+- Added `{{ component_vars.args }}`, `{{ component_vars.kwargs }}`, `{{ component_vars.slots }}`
+- And lot more...
+
 #### 🚨📢 BREAKING CHANGES
 
 **Middleware**
@@ -68,7 +79,7 @@
             text: str
     ```
 
-    See [Migrating from generics to class attributes](https://django-components.github.io/django-components/latest/concepts/advanced/typing_and_validation/#migrating-from-generics-to-class-attributes) for more info.
+    See [Migrating from generics to class attributes](https://django-components.github.io/django-components/0.140/concepts/fundamentals/typing_and_validation/#migrating-from-generics-to-class-attributes) for more info.
 
 - Removed `EmptyTuple` and `EmptyDict` types. Instead, there is now a single `Empty` type.
 
@@ -434,6 +445,66 @@
     {% endfill %}
     ```
 
+- The template variable `{{ component_vars.is_filled }}` is now deprecated. Will be removed in v1. Use `{{ component_vars.slots }}` instead.
+
+    Before:
+
+    ```django
+    {% if component_vars.is_filled.footer %}
+        <div>
+            {% slot "footer" / %}
+        </div>
+    {% endif %}
+    ```
+
+    After:
+
+    ```django
+    {% if component_vars.slots.footer %}
+        <div>
+            {% slot "footer" / %}
+        </div>
+    {% endif %}
+    ```
+
+    NOTE: `component_vars.is_filled` automatically escaped slot names, so that even slot names that are
+    not valid python identifiers could be set as slot names. `component_vars.slots` no longer does that.
+
+- Component attribute `Component.is_filled` is now deprecated. Will be removed in v1. Use `Component.slots` instead.
+
+    Before:
+
+    ```py
+    class MyComponent(Component):
+        def get_template_data(self, args, kwargs, slots, context):
+            if self.is_filled.footer:
+                color = "red"
+            else:
+                color = "blue"
+
+            return {
+                "color": color,
+            }
+    ```
+
+    After:
+
+    ```py
+    class MyComponent(Component):
+        def get_template_data(self, args, kwargs, slots, context):
+            if "footer" in slots:
+                color = "red"
+            else:
+                color = "blue"
+
+            return {
+                "color": color,
+            }
+    ```
+
+    NOTE: `Component.is_filled` automatically escaped slot names, so that even slot names that are
+    not valid python identifiers could be set as slot names. `Component.slots` no longer does that.
+
 #### Feat
 
 - New method to render template variables - `get_template_data()`
@@ -476,7 +547,7 @@
     This practically brings back input validation, because the instantiation of the types
     will raise an error if the inputs are not valid.
 
-    Read more on [Typing and validation](https://django-components.github.io/django-components/latest/concepts/advanced/typing_and_validation/)
+    Read more on [Typing and validation](https://django-components.github.io/django-components/latest/concepts/fundamentals/typing_and_validation/)
 
 - Render emails or other non-browser HTML with new "dependencies strategies"
 
@@ -524,6 +595,57 @@
         - Used for inserting rendered HTML into other components.
 
     See [Dependencies rendering](https://django-components.github.io/django-components/0.140/concepts/advanced/rendering_js_css/) for more info.
+
+- New `Component.args`, `Component.kwargs`, `Component.slots` attributes available on the component class itself.
+
+    These attributes are the same as the ones available in `Component.get_template_data()`.
+
+    You can use these in other methods like `Component.on_render_before()` or `Component.on_render_after()`.
+
+    ```py
+    from django_components import Component, SlotInput
+
+    class Table(Component):
+        class Args(NamedTuple):
+            page: int
+
+        class Kwargs(NamedTuple):
+            per_page: int
+
+        class Slots(NamedTuple):
+            content: SlotInput
+
+        def on_render_before(self, context: Context, template: Template) -> None:
+            assert self.args.page == 123
+            assert self.kwargs.per_page == 10
+            content_html = self.slots.content()
+    ```
+
+    Same as with the parameters in `Component.get_template_data()`, they will be instances of the `Args`, `Kwargs`, `Slots` classes
+    if defined, or plain lists / dictionaries otherwise.
+
+- New template variables `{{ component_vars.args }}`, `{{ component_vars.kwargs }}`, `{{ component_vars.slots }}`
+
+    These attributes are the same as the ones available in `Component.get_template_data()`.
+
+    ```django
+    {# Typed #}
+    {% if component_vars.args.page == 123 %}
+        <div>
+            {% slot "content" / %}
+        </div>
+    {% endif %}
+
+    {# Untyped #}
+    {% if component_vars.args.0 == 123 %}
+        <div>
+            {% slot "content" / %}
+        </div>
+    {% endif %}
+    ```
+
+    Same as with the parameters in `Component.get_template_data()`, they will be instances of the `Args`, `Kwargs`, `Slots` classes
+    if defined, or plain lists / dictionaries otherwise.
 
 - `get_component_url()` now optionally accepts `query` and `fragment` arguments.
 

--- a/README.md
+++ b/README.md
@@ -237,9 +237,9 @@ class Table(Component):
         assert self.id == "djc1A2b3c"
 
         # Access component's inputs and slots
-        assert self.input.args == (123, "str")
-        assert self.input.kwargs == {"variable": "test", "another": 1}
-        footer_slot = self.input.slots["footer"]
+        assert self.args == [123, "str"]
+        assert self.kwargs == {"variable": "test", "another": 1}
+        footer_slot = self.slots["footer"]
         some_var = self.input.context["some_var"]
 
         # Access the request object and Django's context processors, if available
@@ -390,7 +390,7 @@ class Header(Component):
 
 ### Input validation and static type hints
 
-Avoid needless errors with [type hints and runtime input validation](https://django-components.github.io/django-components/latest/concepts/advanced/typing_and_validation/).
+Avoid needless errors with [type hints and runtime input validation](https://django-components.github.io/django-components/latest/concepts/fundamentals/typing_and_validation/).
 
 To opt-in to input validation, define types for component's args, kwargs, slots, and more:
 

--- a/docs/concepts/fundamentals/component_defaults.md
+++ b/docs/concepts/fundamentals/component_defaults.md
@@ -67,7 +67,7 @@ and so `selected_items` will be set to `[1, 2, 3]`.
 
 !!! warning
 
-    When [typing](../advanced/typing_and_validation.md) your components with [`Args`](../../../reference/api/#django_components.Component.Args),
+    When [typing](../fundamentals/typing_and_validation.md) your components with [`Args`](../../../reference/api/#django_components.Component.Args),
     [`Kwargs`](../../../reference/api/#django_components.Component.Kwargs),
     or [`Slots`](../../../reference/api/#django_components.Component.Slots) classes,
     you may be inclined to define the defaults in the classes.

--- a/docs/concepts/fundamentals/rendering_components.md
+++ b/docs/concepts/fundamentals/rendering_components.md
@@ -484,7 +484,7 @@ in component's [`Args`](../../../reference/api/#django_components.Component.Args
 [`Kwargs`](../../../reference/api/#django_components.Component.Kwargs),
 and [`Slots`](../../../reference/api/#django_components.Component.Slots) classes.
 
-Read more on [Typing and validation](../../advanced/typing_and_validation).
+Read more on [Typing and validation](../../fundamentals/typing_and_validation).
 
 ```python
 from typing import NamedTuple, Optional

--- a/docs/guides/other/troubleshooting.md
+++ b/docs/guides/other/troubleshooting.md
@@ -125,8 +125,8 @@ Thus, you can check where a slot was filled from by printing it out:
 
 ```python
 class MyComponent(Component):
-    def on_render_before(self):
-        print(self.input.slots)
+    def on_render_before(self, *args, **kwargs):
+        print(self.slots)
 ```
 
 might print:

--- a/docs/overview/welcome.md
+++ b/docs/overview/welcome.md
@@ -227,9 +227,9 @@ class Table(Component):
         assert self.id == "djc1A2b3c"
 
         # Access component's inputs and slots
-        assert self.input.args == (123, "str")
-        assert self.input.kwargs == {"variable": "test", "another": 1}
-        footer_slot = self.input.slots["footer"]
+        assert self.args == [123, "str"]
+        assert self.kwargs == {"variable": "test", "another": 1}
+        footer_slot = self.slots["footer"]
         some_var = self.input.context["some_var"]
 
         # Access the request object and Django's context processors, if available
@@ -380,9 +380,9 @@ class Header(Component):
 
 ### Input validation and static type hints
 
-Avoid needless errors with [type hints and runtime input validation](https://django-components.github.io/django-components/latest/concepts/advanced/typing_and_validation/).
+Avoid needless errors with [type hints and runtime input validation](https://django-components.github.io/django-components/latest/concepts/fundamentals/typing_and_validation/).
 
-To opt-in to input validation, define types for component's args, kwargs, slots, and more:
+To opt-in to input validation, define types for component's args, kwargs, slots:
 
 ```py
 from typing import NamedTuple, Optional

--- a/src/django_components/slots.py
+++ b/src/django_components/slots.py
@@ -400,17 +400,36 @@ class SlotFallback:
 SlotRef = SlotFallback
 
 
+name_escape_re = re.compile(r"[^\w]")
+
+
+# TODO_v1 - Remove, superseded by `Component.slots` and `component_vars.slots`
 class SlotIsFilled(dict):
     """
     Dictionary that returns `True` if the slot is filled (key is found), `False` otherwise.
     """
 
     def __init__(self, fills: Dict, *args: Any, **kwargs: Any) -> None:
-        escaped_fill_names = {_escape_slot_name(fill_name): True for fill_name in fills.keys()}
+        escaped_fill_names = {self._escape_slot_name(fill_name): True for fill_name in fills.keys()}
         super().__init__(escaped_fill_names, *args, **kwargs)
 
     def __missing__(self, key: Any) -> bool:
         return False
+
+    def _escape_slot_name(self, name: str) -> str:
+        """
+        Users may define slots with names which are invalid identifiers like 'my slot'.
+        But these cannot be used as keys in the template context, e.g. `{{ component_vars.is_filled.'my slot' }}`.
+        So as workaround, we instead use these escaped names which are valid identifiers.
+
+        So e.g. `my slot` should be escaped as `my_slot`.
+        """
+        # NOTE: Do a simple substitution where we replace all non-identifier characters with `_`.
+        # Identifiers consist of alphanum (a-zA-Z0-9) and underscores.
+        # We don't check if these escaped names conflict with other existing slots in the template,
+        # we leave this obligation to the user.
+        escaped_name = name_escape_re.sub("_", name)
+        return escaped_name
 
 
 class SlotNode(BaseNode):
@@ -795,7 +814,7 @@ class SlotNode(BaseNode):
             and _COMPONENT_CONTEXT_KEY in component_ctx.outer_context
         ):
             extra_context[_COMPONENT_CONTEXT_KEY] = component_ctx.outer_context[_COMPONENT_CONTEXT_KEY]
-            # This ensures that `component_vars.is_filled`is accessible in the fill
+            # This ensures that the ComponentVars API (e.g. `{{ component_vars.is_filled }}`) is accessible in the fill
             extra_context["component_vars"] = component_ctx.outer_context["component_vars"]
 
         # Irrespective of which context we use ("root" context or the one passed to this
@@ -1348,25 +1367,6 @@ def normalize_slot_fills(
         norm_fills[slot_name] = slot
 
     return norm_fills
-
-
-name_escape_re = re.compile(r"[^\w]")
-
-
-def _escape_slot_name(name: str) -> str:
-    """
-    Users may define slots with names which are invalid identifiers like 'my slot'.
-    But these cannot be used as keys in the template context, e.g. `{{ component_vars.is_filled.'my slot' }}`.
-    So as workaround, we instead use these escaped names which are valid identifiers.
-
-    So e.g. `my slot` should be escaped as `my_slot`.
-    """
-    # NOTE: Do a simple substitution where we replace all non-identifier characters with `_`.
-    # Identifiers consist of alphanum (a-zA-Z0-9) and underscores.
-    # We don't check if these escaped names conflict with other existing slots in the template,
-    # we leave this obligation to the user.
-    escaped_name = name_escape_re.sub("_", name)
-    return escaped_name
 
 
 def _nodelist_to_slot(

--- a/src/django_components/util/types.py
+++ b/src/django_components/util/types.py
@@ -24,7 +24,7 @@ class Empty(NamedTuple):
         pass
     ```
 
-    Read more about [Typing and validation](../../concepts/advanced/typing_and_validation).
+    Read more about [Typing and validation](../../concepts/fundamentals/typing_and_validation).
     """
 
     pass

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -959,6 +959,7 @@ class TestOuterContextProperty:
         assert "outer_value" in rendered
 
 
+# TODO_v1: Remove, superseded by `component_vars.slots`
 @djc_test
 class TestContextVarsIsFilled:
     class IsFilledVarsComponent(Component):


### PR DESCRIPTION
This is a preparation for https://github.com/django-components/django-components/issues/1186.

Before, to access the args / kwargs / slots that were passed to a component, one could either get them in `get_template_data()`, or access them via `self.input.args`, `self.input.kwargs`, etc.

```py
class MyTable(Component):
    def get_template_data(self, args, kwargs, slots, context):
        ...

    def on_render_before(self, context, template):
        self.input.args[0] == "Hello"
```

This PR adds `self.args`, `self.kwargs`, `self.slots`, which hold the same value as the `args`, `kwargs`, `slots` passed to `get_template_data()`.

```py
class MyTable(Component):
    def on_render_before(self, context, template):
        self.args[0] == "Hello"
```

This means that if user set the typing for args / kwargs / slots, then these `self.args` etc will be also of the corresponding instance:

```py
class MyTable(Component):
    class Args(NamedTuple):
        name: str

    def on_render_before(self, context, template):
        self.args.name == "John"
```

In this PR, the `Component.args` etc are handled as dynamic attributes with `@property`.

In https://github.com/django-components/django-components/issues/1186, these will become regular attributes of the component instance.

---

Next, I also exposed these `args`, `kwargs`, and `slots` to the template as:
- `{{ component_vars.args }}`,
- `{{ component_vars.kwargs }}`
- `{{ component_vars.slots }}`

This is to again bring our API closer to the ease of use of django-cotton. In other words, the `get_context_data()` / `get_template_data()` are now optional:

```py
@register("my_table")
class MyTable(Component):
    template = """
        Table: {{ component_vars.args.0 }}
	    <table>
          {% for item in component_vars.kwargs.items %}
             ...
          {% endfor %}
	    </table>
    """
```

The tradeoff is that one then has to prefix everything with lenghty `component_vars.kwargs` to access the inputs. But I think that's fine for v1.

---

Next, since both the component and the template can access slots (as `Component.slots` and `{{ component_vars.slots }}`, I marked the `is_filled` API as deprecated and to be removed in v1.

Background:
- Originally (AKA when I joined), there was a special template tag for checking if a slot is filled.
- I introduced the `{{ component_vars.is_filled }}` API as an alternative to that, so that we don't needlessly recreate the behaviour of `{% if %}` tag. Back then I also introduced `Component.is_filled` so that the same behaviour can be accessed from Python.
- So now, with a separate `Component.slots` and `{{ component_vars.slots }}` attributes, the `is_filled` attribute is no longer needed.
