### PR TITLE
docs: update docs on slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ class Calendar(Component):
   [`{% component %}`](https://django-components.github.io/django-components/latest/reference/template_tags#component) tag.
 - Compose them with [`{% slot %}`](https://django-components.github.io/django-components/latest/reference/template_tags#slot)
   and [`{% fill %}`](https://django-components.github.io/django-components/latest/reference/template_tags#fill) tags.
-- Vue-like slot system, including [scoped slots](https://django-components.github.io/django-components/latest/concepts/fundamentals/slots/#scoped-slots).
+- Vue-like slot system, including [scoped slots](https://django-components.github.io/django-components/latest/concepts/fundamentals/slots/#slot-data).
 
 ```django
 {% component "Layout"

--- a/docs/concepts/fundamentals/.nav.yml
+++ b/docs/concepts/fundamentals/.nav.yml
@@ -7,8 +7,8 @@ nav:
   - Component defaults: component_defaults.md
   - Render API: render_api.md
   - Rendering components: rendering_components.md
-  - Template tag syntax: template_tag_syntax.md
   - Slots: slots.md
+  - Template tag syntax: template_tag_syntax.md
   - HTML attributes: html_attributes.md
   - Component views and URLs: component_views_urls.md
   - HTTP Request: http_request.md

--- a/docs/concepts/fundamentals/slots.md
+++ b/docs/concepts/fundamentals/slots.md
@@ -1,46 +1,74 @@
-_New in version 0.26_:
+django-components has THE most extensive slot system of all the popular Python templating engines.
 
-- The `slot` tag now serves only to declare new slots inside the component template.
-  - To override the content of a declared slot, use the newly introduced `fill` tag instead.
-- Whereas unfilled slots used to raise a warning, filling a slot is now optional by default.
-  - To indicate that a slot must be filled, the new `required` option should be added at the end of the `slot` tag.
+The slot system is based on [Vue](https://vuejs.org/guide/components/slots.html), and works across both Django templates and Python code.
 
----
+## What are slots?
 
 Components support something called 'slots'.
-When a component is used inside another template, slots allow the parent template to override specific parts of the child component by passing in different content.
-This mechanism makes components more reusable and composable.
-This behavior is similar to [slots in Vue](https://vuejs.org/guide/components/slots.html).
 
-In the example below we introduce two block tags that work hand in hand to make this work. These are...
+When you write a component, you define its template. The template will always be
+the same each time you render the component.
 
-- `{% slot <name> %}`/`{% endslot %}`: Declares a new slot in the component template.
-- `{% fill <name> %}`/`{% endfill %}`: (Used inside a `{% component %}` tag pair.) Fills a declared slot with the specified content.
+However, sometimes you may want to customize the component slightly to change the
+content of the component. This is where slots come in.
 
-Let's update our calendar component to support more customization. We'll add `slot` tag pairs to its template, _template.html_.
+Slots allow you to insert parts of HTML into the component.
+This makes components more reusable and composable.
 
-```htmldjango
+```django
 <div class="calendar-component">
     <div class="header">
-        {% slot "header" %}Calendar header{% endslot %}
-    </div>
-    <div class="body">
-        {% slot "body" %}Today's date is <span>{{ date }}</span>{% endslot %}
+        {# This is where the component will insert the content #}
+        {% slot "header" / %}
     </div>
 </div>
 ```
 
-When using the component, you specify which slots you want to fill and where you want to use the defaults from the template. It looks like this:
+## Slot anatomy
+
+Slots consists of two parts:
+
+1. [`{% slot %}`](../../../reference/template_tags#slot) tag - Inside your component you decide where you want to insert the content.
+2. [`{% fill %}`](../../../reference/template_tags#fill) tag - In the parent template (outside the component) you decide what content to insert into the slot.
+   It "fills" the slot with the specified content.
+
+Let's look at an example:
+
+First, we define the component template. This component contains two slots, `header` and `body`.
+
+```htmldjango
+<!-- calendar.html -->
+<div class="calendar-component">
+    <div class="header">
+        {% slot "header" %}
+            Calendar header
+        {% endslot %}
+    </div>
+    <div class="body">
+        {% slot "body" %}
+            Today's date is <span>{{ date }}</span>
+        {% endslot %}
+    </div>
+</div>
+```
+
+Next, when using the component, we can insert our own content into the slots. It looks like this:
 
 ```htmldjango
 {% component "calendar" date="2020-06-06" %}
     {% fill "body" %}
-        Can you believe it's already <span>{{ date }}</span>??
+        Can you believe it's already
+        <span>{{ date }}</span>??
     {% endfill %}
 {% endcomponent %}
 ```
 
-Since the 'header' fill is unspecified, it's taken from the base template. If you put this in a template, and pass in `date=2020-06-06`, this is what gets rendered:
+Since the `'header'` fill is unspecified, it's [default value](#default-slot) is used.
+
+When rendered, notice that:
+
+- The body is filled with the content we specified,
+- The header is still the default value we defined in the component template.
 
 ```htmldjango
 <div class="calendar-component">
@@ -53,205 +81,772 @@ Since the 'header' fill is unspecified, it's taken from the base template. If yo
 </div>
 ```
 
-### Named slots
+## Slots overview
 
-As seen in the previouse section, you can use `{% fill slot_name %}` to insert content into a specific
-slot.
+### Slot definition
 
-You can define fills for multiple slot simply by defining them all within the `{% component %} {% endcomponent %}`
-tags:
+Slots are defined with the [`{% slot %}`](../../../reference/template_tags#slot) tag:
 
-```htmldjango
-{% component "calendar" date="2020-06-06" %}
-    {% fill "header" %}
-        Hi this is header!
+```django
+{% slot "name" %}
+    Default content
+{% endslot %}
+```
+
+Single component can have multiple slots:
+
+```django
+{% slot "name" %}
+    Default content
+{% endslot %}
+
+{% slot "other_name" / %}
+```
+
+And you can even define the same slot in multiple places:
+
+```django
+<div>
+    {% slot "name" %}
+        First content
+    {% endslot %}
+</div>
+<div>
+    {% slot "name" %}
+        Second content
+    {% endslot %}
+</div>
+```
+
+!!! info
+
+    If you define the same slot in multiple places, you must mark each slot individually
+    when setting `default` or `required` flags, e.g.:
+
+    ```htmldjango
+    <div class="calendar-component">
+        <div class="header">
+            {% slot "image" default required %}Image here{% endslot %}
+        </div>
+        <div class="body">
+            {% slot "image" default required %}Image here{% endslot %}
+        </div>
+    </div>
+    ```
+
+### Slot filling
+
+Fill can be defined with the [`{% fill %}`](../../../reference/template_tags#fill) tag:
+
+```django
+{% component "calendar" %}
+    {% fill "name" %}
+        Filled content
     {% endfill %}
-    {% fill "body" %}
-        Can you believe it's already <span>{{ date }}</span>??
+    {% fill "other_name" %}
+        Filled content
     {% endfill %}
 {% endcomponent %}
 ```
 
-You can also use `{% for %}`, `{% with %}`, or other non-component tags (even `{% include %}`)
-to construct the `{% fill %}` tags, **as long as these other tags do not leave any text behind!**
+Or in Python with the [`slots`](../../../reference/api#django_components.Component.render) argument:
 
-```django
-{% component "table" %}
-  {% for slot_name in slots %}
-    {% fill name=slot_name %}
-      {{ slot_name }}
-    {% endfill %}
-  {% endfor %}
-
-  {% with slot_name="abc" %}
-    {% fill name=slot_name %}
-      {{ slot_name }}
-    {% endfill %}
-  {% endwith %}
-{% endcomponent %}
+```py
+Calendar.render(
+    slots={
+        "name": "Filled content",
+        "other_name": "Filled content",
+    },
+)
 ```
 
 ### Default slot
 
-_Added in version 0.28_
+You can make the syntax shorter by marking the slot as [`default`](../../../reference/template_tags#slot):
 
-As you can see, component slots lets you write reusable containers that you fill in when you use a component. This makes for highly reusable components that can be used in different circumstances.
-
-It can become tedious to use `fill` tags everywhere, especially when you're using a component that declares only one slot. To make things easier, `slot` tags can be marked with an optional keyword: `default`.
-
-When added to the tag (as shown below), this option lets you pass filling content directly in the body of a `component` tag pair – without using a `fill` tag. Choose carefully, though: a component template may contain at most one slot that is marked as `default`. The `default` option can be combined with other slot options, e.g. `required`.
-
-Here's the same example as before, except with default slots and implicit filling.
-
-The template:
-
-```htmldjango
-<div class="calendar-component">
-    <div class="header">
-        {% slot "header" %}Calendar header{% endslot %}
-    </div>
-    <div class="body">
-        {% slot "body" default %}Today's date is <span>{{ date }}</span>{% endslot %}
-    </div>
-</div>
+```django
+{% slot "name" default %}
+    Default content
+{% endslot %}
 ```
 
-Including the component (notice how the `fill` tag is omitted):
+This allows you to fill the slot directly in the [`{% component %}`](../../../reference/template_tags#component) tag,
+omitting the `{% fill %}` tag:
 
-```htmldjango
-{% component "calendar" date="2020-06-06" %}
-    Can you believe it's already <span>{{ date }}</span>??
+```django
+{% component "calendar" %}
+    Filled content
 {% endcomponent %}
 ```
 
-The rendered result (exactly the same as before):
+To target the default slot in Python, you can use the `"default"` slot name:
 
-```html
-<div class="calendar-component">
-  <div class="header">Calendar header</div>
-  <div class="body">Can you believe it's already <span>2020-06-06</span>??</div>
-</div>
+```py
+Calendar.render(
+    slots={"default": "Filled content"},
+)
 ```
 
-You may be tempted to combine implicit fills with explicit `fill` tags. This will not work. The following component template will raise an error when rendered.
+!!! info "Accessing default slot in Python"
 
-```htmldjango
-{# DON'T DO THIS #}
-{% component "calendar" date="2020-06-06" %}
-    {% fill "header" %}Totally new header!{% endfill %}
-    Can you believe it's already <span>{{ date }}</span>??
-{% endcomponent %}
-```
+    Since the default slot is stored under the slot name `default`, you can access the default slot
+    in Python under the `"default"` key:
 
-Instead, you can use a named fill with name `default` to target the default fill:
+    ```py
+    class MyTable(Component):
+        def get_template_data(self, args, kwargs, slots, context):
+            default_slot = slots["default"]
+            return {
+                "default_slot": default_slot,
+            }
+    ```
 
-```htmldjango
-{# THIS WORKS #}
-{% component "calendar" date="2020-06-06" %}
-    {% fill "header" %}Totally new header!{% endfill %}
-    {% fill "default" %}
+!!! warning
+
+    Only one [`{% slot %}`](../../../reference/template_tags#slot) can be marked as `default`.
+    But you can have multiple slots with the same name all marked as `default`.
+
+    If you define multiple **different** slots as `default`, this will raise an error.
+
+    ❌ Don't do this
+
+    ```django
+    {% slot "name" default %}
+        Default content
+    {% endslot %}
+    {% slot "other_name" default %}
+        Default content
+    {% endslot %}
+    ```
+
+    ✅ Do this instead
+
+    ```django
+    {% slot "name" default %}
+        Default content
+    {% endslot %}
+    {% slot "name" default %}
+        Default content
+    {% endslot %}
+    ```
+
+!!! warning
+
+    Do NOT combine default fills with explicit named [`{% fill %}`](../../../reference/template_tags#fill) tags.
+
+    The following component template will raise an error when rendered:
+
+    ❌ Don't do this
+
+    ```django
+    {% component "calendar" date="2020-06-06" %}
+        {% fill "header" %}Totally new header!{% endfill %}
         Can you believe it's already <span>{{ date }}</span>??
+    {% endcomponent %}
+    ```
+
+    ✅ Do this instead
+
+    ```django
+    {% component "calendar" date="2020-06-06" %}
+        {% fill "header" %}Totally new header!{% endfill %}
+        {% fill "default" %}
+            Can you believe it's already <span>{{ date }}</span>??
+        {% endfill %}
+    {% endcomponent %}
+    ```
+
+!!! warning
+
+    You cannot double-fill a slot.
+
+    That is, if both `{% fill "default" %}` and `{% fill "header" %}` point to the same slot,
+    this will raise an error when rendered.
+
+### Required slot
+
+You can make the slot required by adding the [`required`](../../../reference/template_tags#slot) keyword:
+
+```django
+{% slot "name" required %}
+    Default content
+{% endslot %}
+```
+
+This will raise an error if the slot is not filled.
+
+### Access fills
+
+You can access the fills with the
+[`{{ component_vars.slots.<name> }}`](../../../reference/template_vars#slots) template variable:
+
+```django
+{% if component_vars.slots.my_slot %}
+    <div>
+        {% fill "my_slot" %}
+            Filled content
+        {% endfill %}
+    </div>
+{% endif %}
+```
+
+And in Python with the [`Component.slots`](../../../reference/api#django_components.Component.slots) property:
+
+```py
+class Calendar(Component):
+    # `get_template_data` receives the `slots` argument directly
+    def get_template_data(self, args, kwargs, slots, context):
+        if "my_slot" in slots:
+            content = "Filled content"
+        else:
+            content = "Default content"
+
+        return {
+            "my_slot": content,
+        }
+
+    # But in other methods you can still access the slots with `Component.slots`
+    def on_render_before(self, *args, **kwargs):
+        if "my_slot" in self.slots:
+            # Do something
+```
+
+### Dynamic fills
+
+The slot and fill names can be set as variables. This way you can fill slots dynamically:
+
+```django
+{% with "body" as slot_name %}
+    {% component "calendar" %}
+        {% fill slot_name %}
+            Filled content
+        {% endfill %}
+    {% endcomponent %}
+{% endwith %}
+```
+
+You can even use [`{% if %}`](https://docs.djangoproject.com/en/5.2/ref/templates/builtins/#std-templatetag-if)
+and [`{% for %}`](https://docs.djangoproject.com/en/5.2/ref/templates/builtins/#std-templatetag-for)
+tags inside the [`{% component %}`](../../../reference/template_tags#component) tag to fill slots with more control:
+
+```django
+{% component "calendar" %}
+    {% if condition %}
+        {% fill "name" %}
+            Filled content
+        {% endfill %}
+    {% endif %}
+
+    {% for item in items %}
+        {% fill item.name %}
+            Item: {{ item.value }}
+        {% endfill %}
+    {% endfor %}
+{% endcomponent %}
+```
+
+You can also use [`{% with %}`](https://docs.djangoproject.com/en/5.2/ref/templates/builtins/#std-templatetag-with)
+or even custom tags to generate the fills dynamically:
+
+```django
+{% component "calendar" %}
+    {% with item.name as name %}
+        {% fill name %}
+            Item: {{ item.value }}
+        {% endfill %}
+    {% endwith %}
+{% endcomponent %}
+```
+
+!!! warning
+
+    If you dynamically generate `{% fill %}` tags, be careful to render text only inside the `{% fill %}` tags.
+
+    Any text rendered outside `{% fill %}` tags will be considered a default fill and will raise an error
+    if combined with explicit fills. (See [Default slot](#default-slot))
+
+### Slot data
+
+Sometimes the slots need to access data from the component. Imagine an HTML table component
+which has a slot to configure how to render the rows. Each row has a different data, so you need
+to pass the data to the slot.
+
+Similarly to [Vue's scoped slots](https://vuejs.org/guide/components/slots#scoped-slots),
+you can pass data to the slot, and then access it in the fill.
+
+This consists of two steps:
+
+1. Passing data to [`{% slot %}`](../../../reference/template_tags#slot) tag
+2. Accessing data in [`{% fill %}`](../../../reference/template_tags#fill) tag
+
+The data is passed to the slot as extra keyword arguments. Below we set two extra arguments: `first_name` and `job`.
+
+```django
+{# Pass data to the slot #}
+{% slot "name" first_name="John" job="Developer" %}
+    {# Fallback implementation #}
+    Name: {{ first_name }}
+    Job: {{ job }}
+{% endslot %}
+```
+
+!!! note
+
+    `name` kwarg is already used for slot name, so you cannot pass it as slot data.
+
+To access the slot's data in the fill, use the [`data`](../../../reference/template_tags#fill) keyword. This sets the name
+of the variable that holds the data in the fill:
+
+```django
+{# Access data in the fill #}
+{% component "profile" %}
+    {% fill "name" data="d" %}
+        Hello, my name is <h1>{{ d.first_name }}</h1>
+        and I'm a <h2>{{ d.job }}</h2>
     {% endfill %}
 {% endcomponent %}
 ```
 
-NOTE: If you doubly-fill a slot, that is, that both `{% fill "default" %}` and `{% fill "header" %}`
-would point to the same slot, this will raise an error when rendered.
-
-#### Accessing default slot in Python
-
-Since the default slot is stored under the slot name `default`, you can access the default slot
-like so:
+To access the slot data in Python, use the `data` attribute in [slot functions](#slot-functions).
 
 ```py
-class MyTable(Component):
+def my_slot(ctx):
+    return f"""
+        Hello, my name is <h1>{ctx.data["first_name"]}</h1>
+        and I'm a <h2>{ctx.data["job"]}</h2>
+    """
+
+Profile.render(
+    slots={
+        "name": my_slot,
+    },
+)
+```
+
+Slot data can be set also when rendering a slot in Python:
+
+```py
+slot = Slot(lambda ctx: f"Hello, {ctx.data['name']}!")
+
+# Render the slot
+html = slot({"name": "John"})
+```
+
+!!! info
+
+    To access slot data on a [default slot](#default-slot), you have to explictly define the `{% fill %}` tags
+    with name `"default"`.
+
+    ```django
+    {% component "my_comp" %}
+        {% fill "default" data="slot_data" %}
+            {{ slot_data.input }}
+        {% endfill %}
+    {% endcomponent %}
+    ```
+
+!!! warning
+
+    You cannot set the `data` attribute and
+    [`fallback` attribute](#slot-fallback)
+    to the same name. This raises an error:
+
+    ```django
+    {% component "my_comp" %}
+        {% fill "content" data="slot_var" fallback="slot_var" %}
+            {{ slot_var.input }}
+        {% endfill %}
+    {% endcomponent %}
+    ```
+
+### Slot fallback
+
+The content between the `{% slot %}..{% endslot %}` tags is the *fallback* content that
+will be rendered if no fill is given for the slot.
+
+```django
+{% slot "name" %}
+    Hello, my name is {{ name }}  <!-- Fallback content -->
+{% endslot %}
+```
+
+Sometimes you may want to keep the fallback content, but only wrap it in some other content.
+
+To do so, you can access the fallback content via the [`fallback`](../../../reference/template_tags#fill) kwarg.
+This sets the name of the variable that holds the fallback content in the fill:
+
+```django
+{% component "profile" %}
+    {% fill "name" fallback="fb" %}
+        Original content:
+        <div>
+            {{ fb }}  <!-- fb = 'Hello, my name...' -->
+        </div>
+    {% endfill %}
+{% endcomponent %}
+```
+
+To access the fallback content in Python, use the [`fallback`](../../../reference/api#django_components.SlotContext.fallback)
+attribute in [slot functions](#slot-functions).
+
+The fallback value is rendered lazily. Coerce the fallback to a string to render it.
+
+```py
+def my_slot(ctx):
+    # Coerce the fallback to a string
+    fallback = str(ctx.fallback)
+    return f"Original content: " + fallback
+
+Profile.render(
+    slots={
+        "name": my_slot,
+    },
+)
+```
+
+Fallback can be set also when rendering a slot in Python:
+
+```py
+slot = Slot(lambda ctx: f"Hello, {ctx.data['name']}!")
+
+# Render the slot
+html = slot({"name": "John"}, fallback="Hello, world!")
+```
+
+!!! info
+
+    To access slot fallback on a [default slot](#default-slot), you have to explictly define the `{% fill %}` tags
+    with name `"default"`.
+
+    ```django
+    {% component "my_comp" %}
+        {% fill "default" fallback="fallback" %}
+            {{ fallback }}
+        {% endfill %}
+    {% endcomponent %}
+    ```
+
+!!! warning
+
+    You cannot set the [`data`](#slot-data) attribute and
+    `fallback` attribute
+    to the same name. This raises an error:
+
+    ```django
+    {% component "my_comp" %}
+        {% fill "content" data="slot_var" fallback="slot_var" %}
+            {{ slot_var.input }}
+        {% endfill %}
+    {% endcomponent %}
+    ```
+
+### Slot functions
+
+In Python code, slot fills can be defined as strings, functions, or
+[`Slot`](../../../reference/api#django_components.Slot) instances that wrap the two.
+Slot functions have access to slot [`data`](../../../reference/api#django_components.SlotContext.data),
+[`fallback`](../../../reference/api#django_components.SlotContext.fallback),
+and [`context`](../../../reference/api#django_components.SlotContext.context).
+
+```py
+def row_slot(ctx):
+    if ctx.data["disabled"]:
+        return ctx.fallback
+
+    item = ctx.data["item"]
+    if ctx.data["type"] == "table":
+        return f"<tr><td>{item}</td></tr>"
+    else:
+        return f"<li>{item}</li>"
+
+Table.render(
+    slots={
+        "prepend": "Ice cream selection:",
+        "append": Slot("© 2025"),
+        "row": row_slot,
+        "column_title": Slot(lambda ctx: f"<th>{ctx.data['name']}</th>"),
+    },
+)
+```
+
+Inside the component, these will all be normalized to [`Slot`](../../../reference/api#django_components.Slot) instances:
+
+```py
+class Table(Component):
     def get_template_data(self, args, kwargs, slots, context):
-        default_slot = slots["default"]
+        assert isinstance(slots["prepend"], Slot)
+        assert isinstance(slots["row"], Slot)
+        assert isinstance(slots["header"], Slot)
+        assert isinstance(slots["footer"], Slot)
+```
+
+You can render [`Slot`](../../../reference/api#django_components.Slot) instances by simply calling them with data:
+
+```py
+class Table(Component):
+    def get_template_data(self, args, kwargs, slots, context):
+        prepend_slot = slots["prepend"]
         return {
-            "default_slot": default_slot,
+            "prepend": prepend_slot({"item": "ice cream"}),
         }
 ```
 
-### Render fill in multiple places
+### Filling slots with functions
 
-_Added in version 0.70_
+You can "fill" slots by passing a string or
+[`Slot`](../../../reference/api#django_components.Slot) instance
+directly to the [`{% fill %}`](../../../reference/template_tags#fill) tag:
 
-You can render the same content in multiple places by defining multiple slots with
-identical names:
+```py
+class Table(Component):
+    def get_template_data(self, args, kwargs, slots, context):
+        def my_fill(ctx):
+            return f"Hello, {ctx.data['name']}!"
 
-```htmldjango
-<div class="calendar-component">
-    <div class="header">
-        {% slot "image" %}Image here{% endslot %}
-    </div>
-    <div class="body">
-        {% slot "image" %}Image here{% endslot %}
-    </div>
-</div>
+        return {
+            "my_fill": Slot(my_fill),
+        }
 ```
 
-So if used like:
-
-```htmldjango
-{% component "calendar" date="2020-06-06" %}
-    {% fill "image" %}
-        <img src="..." />
-    {% endfill %}
+```django
+{% component "table" %}
+    {% fill "name" body=my_fill / %}
 {% endcomponent %}
 ```
 
-This renders:
+!!! note
 
-```htmldjango
-<div class="calendar-component">
-    <div class="header">
-        <img src="..." />
-    </div>
-    <div class="body">
-        <img src="..." />
-    </div>
-</div>
+    Django automatically executes functions when it comes across them in templates.
+
+    Because of this you MUST wrap the function in [`Slot`](../../../reference/api#django_components.Slot)
+    instance to prevent it from being called.
+
+    Read more about Django's [`do_not_call_in_templates`](https://docs.djangoproject.com/en/5.2/ref/templates/api/#variables-and-lookups).
+
+## Slot class
+
+The [`Slot`](../../../reference/api#django_components.Slot) class is a wrapper around a function that can be used to fill a slot.
+
+```py
+from django_components import Component, Slot
+
+def footer(ctx):
+    return f"Hello, {ctx.data['name']}!"
+
+Table.render(
+    slots={
+        "footer": Slot(footer),
+    },
+)
 ```
 
-#### Default and required slots
+Slot class can be instantiated with a function, a string, or from another
+[`Slot`](../../../reference/api#django_components.Slot) instance:
 
-If you use a slot multiple times, you can still mark the slot as `default` or `required`.
-For that, you must mark each slot individually, e.g.:
-
-```htmldjango
-<div class="calendar-component">
-    <div class="header">
-        {% slot "image" default required %}Image here{% endslot %}
-    </div>
-    <div class="body">
-        {% slot "image" default required %}Image here{% endslot %}
-    </div>
-</div>
+```py
+slot1 = Slot(lambda ctx: f"Hello, {ctx.data['name']}!")
+slot2 = Slot("Hello, world!")
+slot3 = Slot(slot1)
 ```
 
-Which you can then use as regular default slot:
+### Rendering slots
 
-```htmldjango
-{% component "calendar" date="2020-06-06" %}
-    <img src="..." />
-{% endcomponent %}
+**Python**
+
+You can render a [`Slot`](../../../reference/api#django_components.Slot) instance by simply calling it with data:
+
+```py
+slot = Slot(lambda ctx: f"Hello, {ctx.data['name']}!")
+
+# Render the slot with data
+html = slot({"name": "John"})
 ```
 
-Since each slot is tagged individually, you can have multiple slots
+Optionally you can pass the [fallback](#slot-fallback) value to the slot. Fallback should be a string.
+
+```py
+html = slot({"name": "John"}, fallback="Hello, world!")
+```
+
+**Template**
+
+Alternatively, you can pass the [`Slot`](../../../reference/api#django_components.Slot) instance to the
+[`{% fill %}`](../../../reference/template_tags#fill) tag:
+
+```django
+{% fill "name" body=slot / %}
+```
+
+### Slot context
+
+If a slot function is rendered by the [`{% slot %}`](../../../reference/template_tags#slot) tag,
+you can access the current [Context](https://docs.djangoproject.com/en/5.2/ref/templates/api/#django.template.Context)
+using the `context` attribute.
+
+```py
+class Table(Component):
+    template = """
+        {% with "abc" as my_var %}
+            {% slot "name" %}
+                Hello!
+            {% endslot %}
+        {% endwith %}
+    """
+
+def slot_func(ctx):
+    return f"Hello, {ctx.context['my_var']}!"
+
+slot = Slot(slot_func)
+html = slot()
+```
+
+!!! warning
+
+    While available, try to avoid using the `context` attribute in slot functions.
+
+    Instead, prefer using the `data` and `fallback` attributes.
+
+    <!-- TODO_v2: Check if still applicable -->
+    Access to `context` may be removed in future versions (v2, v3).
+
+### Slot metadata
+
+When accessing slots from within [`Component`](../../../reference/api#django_components.Component) methods,
+the [`Slot`](../../../reference/api#django_components.Slot) instances are populated
+with extra metadata [`component_name`](../../../reference/api#django_components.Slot.component_name)
+and [`slot_name`](../../../reference/api#django_components.Slot.slot_name).
+
+These are used solely for debugging.
+
+In fact, you can set these fields too when creating new slots:
+
+```py
+# Either at slot creation
+slot = Slot(
+    lambda ctx: f"Hello, {ctx.data['name']}!",
+    component_name="table",
+    slot_name="name",
+)
+
+# Or later
+slot.component_name = "table"
+slot.slot_name = "name"
+```
+
+### Slot contents
+
+Whether you create a slot from a function, a string, or from the [`{% fill %}`](../../../reference/template_tags#fill) tags,
+the [`Slot`](../../../reference/api#django_components.Slot) class normalizes its contents to a function.
+
+Use [`Slot.contents`](../../../reference/api#django_components.Slot.contents) to access the original value that was passed to the Slot constructor.
+
+```py
+slot = Slot("Hello!")
+print(slot.contents)  # "Hello!"
+```
+
+If the slot was created from a string or from the [`{% fill %}`](../../../reference/template_tags#fill) tags,
+the contents will be accessible also as a Nodelist under [`Slot.nodelist`](../../../reference/api#django_components.Slot.nodelist).
+
+```py
+slot = Slot("Hello!")
+print(slot.nodelist)  # <django.template.Nodelist: ['Hello!']>
+```
+
+!!! info
+
+    If you pass a [`Slot`](../../../reference/api#django_components.Slot) instance to the constructor,
+    the inner slot will be "unwrapped" and its `Slot.contents` will be used instead.
+
+    ```py
+    slot = Slot("Hello")
+    print(slot.contents)  # "Hello"
+
+    slot2 = Slot(slot)
+    print(slot2.contents)  # "Hello"
+    ```
+
+### Escaping slots content
+
+Slots content are automatically escaped by default to prevent XSS attacks.
+
+In other words, it's as if you would be using Django's [`mark_safe()`](https://docs.djangoproject.com/en/5.2/ref/utils/#django.utils.safestring.mark_safe) function on the slot content:
+
+```python
+from django.utils.safestring import mark_safe
+
+class Calendar(Component):
+    template = """
+        <div>
+            {% slot "date" default date=date / %}
+        </div>
+    """
+
+Calendar.render(
+    slots={
+        "date": mark_safe("<b>Hello</b>"),
+    }
+)
+```
+
+To disable escaping, you can pass `escape_slots_content=False` to
+[`Component.render()`](../../../reference/api#django_components.Component.render)
+or [`Component.render_to_response()`](../../../reference/api#django_components.Component.render_to_response)
+methods.
+
+!!! warning
+
+    If you disable escaping, you should make sure that any content you pass to the slots is safe,
+    especially if it comes from user input!
+
+!!! info
+
+    If you're planning on passing an HTML string, check Django's use of
+    [`format_html`](https://docs.djangoproject.com/en/5.2/ref/utils/#django.utils.html.format_html)
+    and [`mark_safe`](https://docs.djangoproject.com/en/5.2/ref/utils/#django.utils.safestring.mark_safe).
+
+## Examples
+
+### Pass through all the slots
+
+You can dynamically pass all slots to a child component. This is similar to
+[passing all slots in Vue](https://vue-land.github.io/faq/forwarding-slots#passing-all-slots):
+
+```djc_py
+class MyTable(Component):
+    template = """
+        <div>
+          {% component "child" %}
+            {% for slot_name, slot in component_vars.slots.items %}
+              {% fill name=slot_name body=slot / %}
+            {% endfor %}
+          {% endcomponent %}
+        </div>
+    """
+```
+
+### Required and default slots
+
+Since each [`{% slot %}`](../../../reference/template_tags#slot) is tagged
+with [`required`](#required-slot) and [`default`](#default-slot) individually, you can have multiple slots
 with the same name but different conditions.
 
-E.g. in this example, we have a component that renders a user avatar - a small circular image with a profile picture or name initials.
+In this example, we have a component that renders a user avatar - a small circular image with a profile picture or name initials.
 
 If the component is given `image_src` or `name_initials` variables,
-the `image` slot is optional. But if neither of those are provided,
-you MUST fill the `image` slot.
+the `image` slot is optional.
+
+But if neither of those are provided, you MUST fill the `image` slot.
 
 ```htmldjango
 <div class="avatar">
+    {# Image given, so slot is optional #}
     {% if image_src %}
         {% slot "image" default %}
             <img src="{{ image_src }}" />
         {% endslot %}
+
+    {# Image not given, but we can make image from initials, so slot is optional #}    
     {% elif name_initials %}
         {% slot "image" default %}
             <div style="
@@ -263,323 +858,40 @@ you MUST fill the `image` slot.
                 {{ name_initials }}
             </div>
         {% endslot %}
+    
+    {# Neither image nor initials given, so slot is required #}
     {% else %}
         {% slot "image" default required / %}
     {% endif %}
 </div>
 ```
 
-### Accessing original content of slots
+### Dynamic slots in table component
 
-_Added in version 0.26_
+Sometimes you may want to generate slots based on the given input. One example of this is [Vuetify's table component](https://vuetifyjs.com/en/api/v-data-table/), which creates a header and an item slots for each user-defined column.
 
-> NOTE: In version 0.77, the syntax was changed from
->
-> ```django
-> {% fill "my_slot" as "alias" %} {{ alias.default }}
-> ```
->
-> to
->
-> ```django
-> {% fill "my_slot" default="slot_default" %} {{ slot_default }}
-> ```
-
-Sometimes you may want to keep the original slot, but only wrap or prepend/append content to it. To do so, you can access the default slot via the `default` kwarg.
-
-Similarly to the `data` attribute, you specify the variable name through which the default slot will be made available.
-
-For instance, let's say you're filling a slot called 'body'. To render the original slot, assign it to a variable using the `'default'` keyword. You then render this variable to insert the default content:
-
-```htmldjango
-{% component "calendar" date="2020-06-06" %}
-    {% fill "body" default="body_default" %}
-        {{ body_default }}. Have a great day!
-    {% endfill %}
-{% endcomponent %}
-```
-
-This produces:
-
-```htmldjango
-<div class="calendar-component">
-    <div class="header">
-        Calendar header
-    </div>
-    <div class="body">
-        Today's date is <span>2020-06-06</span>. Have a great day!
-    </div>
-</div>
-```
-
-To access the original content of a default slot, set the name to `default`:
-
-```htmldjango
-{% component "calendar" date="2020-06-06" %}
-    {% fill "default" default="slot_default" %}
-        {{ slot_default }}. Have a great day!
-    {% endfill %}
-{% endcomponent %}
-```
-
-### Conditional slots
-
-_Added in version 0.26._
-
-> NOTE: In version 0.70, `{% if_filled %}` tags were replaced with `{{ component_vars.is_filled }}` variables. If your slot name contained special characters, see the section [Accessing `is_filled` of slot names with special characters](#accessing-is_filled-of-slot-names-with-special-characters).
-
-In certain circumstances, you may want the behavior of slot filling to depend on
-whether or not a particular slot is filled.
-
-For example, suppose we have the following component template:
-
-```htmldjango
-<div class="frontmatter-component">
-    <div class="title">
-        {% slot "title" %}Title{% endslot %}
-    </div>
-    <div class="subtitle">
-        {% slot "subtitle" %}{# Optional subtitle #}{% endslot %}
-    </div>
-</div>
-```
-
-By default the slot named 'subtitle' is empty. Yet when the component is used without
-explicit fills, the div containing the slot is still rendered, as shown below:
-
-```html
-<div class="frontmatter-component">
-  <div class="title">Title</div>
-  <div class="subtitle"></div>
-</div>
-```
-
-This may not be what you want. What if instead the outer 'subtitle' div should only
-be included when the inner slot is in fact filled?
-
-The answer is to use the `{{ component_vars.is_filled.<name> }}` variable. You can use this together with Django's `{% if/elif/else/endif %}` tags to define a block whose contents will be rendered only if the component slot with
-the corresponding 'name' is filled.
-
-This is what our example looks like with `component_vars.is_filled`.
-
-```htmldjango
-<div class="frontmatter-component">
-    <div class="title">
-        {% slot "title" %}Title{% endslot %}
-    </div>
-    {% if component_vars.is_filled.subtitle %}
-    <div class="subtitle">
-        {% slot "subtitle" %}{# Optional subtitle #}{% endslot %}
-    </div>
-    {% endif %}
-</div>
-```
-
-Here's our example with more complex branching.
-
-```htmldjango
-<div class="frontmatter-component">
-    <div class="title">
-        {% slot "title" %}Title{% endslot %}
-    </div>
-    {% if component_vars.is_filled.subtitle %}
-    <div class="subtitle">
-        {% slot "subtitle" %}{# Optional subtitle #}{% endslot %}
-    </div>
-    {% elif component_vars.is_filled.title %}
-        ...
-    {% elif component_vars.is_filled.<name> %}
-        ...
-    {% endif %}
-</div>
-```
-
-Sometimes you're not interested in whether a slot is filled, but rather that it _isn't_.
-To negate the meaning of `component_vars.is_filled`, simply treat it as boolean and negate it with `not`:
-
-```htmldjango
-{% if not component_vars.is_filled.subtitle %}
-<div class="subtitle">
-    {% slot "subtitle" / %}
-</div>
-{% endif %}
-```
-
-#### Accessing `is_filled` of slot names with special characters
-
-To be able to access a slot name via `component_vars.is_filled`, the slot name needs to be composed of only alphanumeric characters and underscores (e.g. `this__isvalid_123`).
-
-However, you can still define slots with other special characters. In such case, the slot name in `component_vars.is_filled` is modified to replace all invalid characters into `_`.
-
-So a slot named `"my super-slot :)"` will be available as `component_vars.is_filled.my_super_slot___`.
-
-Same applies when you are accessing `is_filled` from within the Python, e.g.:
+So if you pass columns named `name` and `age` to the table component:
 
 ```py
-class MyTable(Component):
-    def on_render_before(self, context, template) -> None:
-        # ✅ Works
-        if self.is_filled["my_super_slot___"]:
-            # Do something
-
-        # ❌ Does not work
-        if self.is_filled["my super-slot :)"]:
-            # Do something
+[
+    {"key": "name", "title": "Name"},
+    {"key": "age", "title": "Age"},
+]
 ```
 
-### Conditional fills
-
-Similarly, you can use `{% if %}` and `{% for %}` when defining the `{% fill %}` tags, to conditionally fill the slots when using the componnet:
-
-In the example below, the `{% fill "footer" %}` fill is used only if the condition is true. If falsy, the fill is ignored, and so the `my_table` component will use its default content for the `footer` slot.
-
-```django_html
-{% component "my_table" %}
-    {% if editable %}
-        {% fill "footer" %}
-            <input name="name" />
-        {% endfill %}
-    {% endif %}
-{% endcomponent %}
-```
-
-You can even combine `{% if %}` and `{% for %}`:
-
-```django_html
-{% component "my_table" %}
-    {% for header in headers %}
-        {% if header != "hyperlink" %}
-            {# Generate fill name like `header.my_column` #}
-            {% fill name="header."|add:header" %}
-                <b>{{ header }}</b>
-            {% endfill %}
-        {% endif %}
-    {% endfor %}
-{% endcomponent %}
-```
-
-### Scoped slots
-
-_Added in version 0.76_:
-
-Consider a component with slot(s). This component may do some processing on the inputs, and then use the processed variable in the slot's default template:
-
-```djc_py
-@register("my_comp")
-class MyComp(Component):
-    template = """
-        <div>
-            {% slot "content" default %}
-                input: {{ input }}
-            {% endslot %}
-        </div>
-    """
-
-    def get_template_data(self, args, kwargs, slots, context):
-        processed_input = do_something(kwargs["input"])
-        return {"input": processed_input}
-```
-
-You may want to design a component so that users of your component can still access the `input` variable, so they don't have to recompute it.
-
-This behavior is called "scoped slots". This is inspired by [Vue scoped slots](https://vuejs.org/guide/components/slots.html#scoped-slots) and [scoped slots of django-web-components](https://github.com/Xzya/django-web-components/tree/master?tab=readme-ov-file#scoped-slots).
-
-Using scoped slots consists of two steps:
-
-1. Passing data to `slot` tag
-2. Accessing data in `fill` tag
-
-#### Passing data to slots
-
-To pass the data to the `slot` tag, simply pass them as keyword attributes (`key=value`):
-
-```djc_py
-@register("my_comp")
-class MyComp(Component):
-    template = """
-        <div>
-            {% slot "content" default input=input %}
-                input: {{ input }}
-            {% endslot %}
-        </div>
-    """
-
-    def get_template_data(self, args, kwargs, slots, context):
-        processed_input = do_something(kwargs["input"])
-        return {
-            "input": processed_input,
-        }
-```
-
-#### Accessing slot data in fill
-
-Next, we head over to where we define a fill for this slot. Here, to access the slot data
-we set the `data` attribute to the name of the variable through which we want to access
-the slot data. In the example below, we set it to `data`:
+Then the component will accept fills named `header-name` and `header-age` (among others):
 
 ```django
-{% component "my_comp" %}
-    {% fill "content" data="slot_data" %}
-        {{ slot_data.input }}
-    {% endfill %}
-{% endcomponent %}
+{% fill "header-name" data="data" %}
+    <b>{{ data.value }}</b>
+{% endfill %}
+
+{% fill "header-age" data="data" %}
+    <b>{{ data.value }}</b>
+{% endfill %}
 ```
 
-To access slot data on a default slot, you have to explictly define the `{% fill %}` tags.
-
-So this works:
-
-```django
-{% component "my_comp" %}
-    {% fill "content" data="slot_data" %}
-        {{ slot_data.input }}
-    {% endfill %}
-{% endcomponent %}
-```
-
-While this does not:
-
-```django
-{% component "my_comp" data="data" %}
-    {{ data.input }}
-{% endcomponent %}
-```
-
-Note: You cannot set the `data` attribute and
-[`default` attribute)](#accessing-original-content-of-slots)
-to the same name. This raises an error:
-
-```django
-{% component "my_comp" %}
-    {% fill "content" data="slot_var" default="slot_var" %}
-        {{ slot_var.input }}
-    {% endfill %}
-{% endcomponent %}
-```
-
-#### Slot data of default slots
-
-To access data of a default slot, you can specify `{% fill name="default" %}`:
-
-```htmldjango
-{% component "my_comp" %}
-    {% fill "default" data="slot_data" %}
-        {{ slot_data.input }}
-    {% endfill %}
-{% endcomponent %}
-```
-
-### Dynamic slots and fills
-
-Until now, we were declaring slot and fill names statically, as a string literal, e.g.
-
-```django
-{% slot "content" / %}
-```
-
-However, sometimes you may want to generate slots based on the given input. One example of this is [a table component like that of Vuetify](https://vuetifyjs.com/en/api/v-data-table/), which creates a header and an item slots for each user-defined column.
-
-In django_components you can achieve the same, simply by using a variable (or a [template expression](#use-template-tags-inside-component-inputs)) instead of a string literal:
+In django-components you can achieve the same, simply by using a variable or a [template expression](../template_tag_syntax#template-tags-inside-literal-strings) instead of a string literal:
 
 ```django
 <table>
@@ -599,9 +911,9 @@ When using the component, you can either set the fill explicitly:
 
 ```django
 {% component "table" headers=headers items=items %}
-  {% fill "header-name" data="data" %}
-    <b>{{ data.value }}</b>
-  {% endfill %}
+    {% fill "header-name" data="data" %}
+        <b>{{ data.value }}</b>
+    {% endfill %}
 {% endcomponent %}
 ```
 
@@ -609,16 +921,22 @@ Or also use a variable:
 
 ```django
 {% component "table" headers=headers items=items %}
-  {# Make only the active column bold #}
-  {% fill "header-{{ active_header_name }}" data="data" %}
-    <b>{{ data.value }}</b>
-  {% endfill %}
+    {% fill "header-{{ active_header_name }}" data="data" %}
+        <b>{{ data.value }}</b>
+    {% endfill %}
 {% endcomponent %}
 ```
 
-> NOTE: It's better to use static slot names whenever possible for clarity. The dynamic slot names should be reserved for advanced use only.
+!!! note
 
-Lastly, in rare cases, you can also pass the slot name via [the spread operator](#spread-operator). This is possible, because the slot name argument is actually a shortcut for a `name` keyword argument.
+    It's better to use literal slot names whenever possible for clarity.
+    The dynamic slot names should be reserved for advanced use only.
+
+### Spread operator
+
+Lastly, you can also pass the slot name through the [spread operator](../template_tag_syntax#spread-operator).
+
+When you define a slot name, it's actually a shortcut for a `name` keyword argument.
 
 So this:
 
@@ -639,66 +957,85 @@ So it's possible to define a `name` key on a dictionary, and then spread that on
 {% slot ...slot_props / %}
 ```
 
-### Pass through all the slots
-
-You can dynamically pass all slots to a child component. This is similar to
-[passing all slots in Vue](https://vue-land.github.io/faq/forwarding-slots#passing-all-slots):
+Full example:
 
 ```djc_py
 class MyTable(Component):
+    template = """
+        {% slot ...slot_props / %}
+    """
+
     def get_template_data(self, args, kwargs, slots, context):
         return {
-            "slots": slots,
+            "slot_props": {"name": "content", "extra_field": 123},
         }
-
-    template = """
-    <div>
-      {% component "child" %}
-        {% for slot_name in slots %}
-          {% fill name=slot_name data="data" %}
-            {% slot name=slot_name ...data / %}
-          {% endfill %}
-        {% endfor %}
-      {% endcomponent %}
-    </div>
-    """
 ```
-
-### Escaping slots content
-
-Slots content are automatically escaped by default to prevent XSS attacks.
-
-In other words, it's as if you would be using Django's [`mark_safe()`](https://docs.djangoproject.com/en/5.0/ref/utils/#django.utils.safestring.mark_safe) function on the slot content:
-
-```python
-from django.utils.safestring import mark_safe
-
-class Calendar(Component):
-    template = """
-        <div>
-            {% slot "date" default date=date / %}
-        </div>
-    """
-
-Calendar.render(
-    slots={
-        "date": mark_safe("<b>Hello</b>"),
-    }
-)
-```
-
-To disable escaping, you can pass `escape_slots_content=False` to
-[`Component.render()`](../../reference/api#django_components.Component.render)
-or [`Component.render_to_response()`](../../reference/api#django_components.Component.render_to_response)
-methods.
-
-!!! warning
-
-    If you disable escaping, you should make sure that any content you pass to the slots is safe,
-    especially if it comes from user input!
 
 !!! info
 
-    If you're planning on passing an HTML string, check Django's use of
-    [`format_html`](https://docs.djangoproject.com/en/5.0/ref/utils/#django.utils.html.format_html)
-    and [`mark_safe`](https://docs.djangoproject.com/en/5.0/ref/utils/#django.utils.safestring.mark_safe).
+    This applies for both [`{% slot %}`](../../../reference/template_tags#slot)
+    and [`{% fill %}`](../../../reference/template_tags#fill) tags.
+
+<!-- TODO_V1: Remove this section -->
+
+## Legacy conditional slots
+
+> Since version 0.70, you could check if a slot was filled with
+>
+> `{{ component_vars.is_filled.<name> }}`
+>
+> Since version 0.140, this has been deprecated and superseded with
+>
+> [`{% component_vars.slots.<name> %}`](../../../reference/template_vars#slots)
+>
+> The `component_vars.is_filled` variable is still available, but will be removed in v1.0.
+>
+> NOTE: `component_vars.slots` no longer escapes special characters in slot names.
+
+You can use `{{ component_vars.is_filled.<name> }}` together with Django's `{% if / elif / else / endif %}` tags
+to define a block whose contents will be rendered only if the component slot with the corresponding 'name' is filled.
+
+This is what our example looks like with `component_vars.is_filled`.
+
+```htmldjango
+<div class="frontmatter-component">
+    <div class="title">
+        {% slot "title" %}
+            Title
+        {% endslot %}
+    </div>
+    {% if component_vars.is_filled.subtitle %}
+        <div class="subtitle">
+            {% slot "subtitle" %}
+                {# Optional subtitle #}
+            {% endslot %}
+        </div>
+    {% elif component_vars.is_filled.title %}
+        ...
+    {% elif component_vars.is_filled.<name> %}
+        ...
+    {% endif %}
+</div>
+```
+
+### Accessing `is_filled` of slot names with special characters
+
+To be able to access a slot name via `component_vars.is_filled`, the slot name needs to be composed of only alphanumeric characters and underscores (e.g. `this__isvalid_123`).
+
+However, you can still define slots with other special characters. In such case, the slot name in `component_vars.is_filled` is modified to replace all invalid characters into `_`.
+
+So a slot named `"my super-slot :)"` will be available as `component_vars.is_filled.my_super_slot___`.
+
+Same applies when you are accessing `is_filled` from within the Python, e.g.:
+
+```py
+class MyTable(Component):
+    def on_render_before(self, context, template) -> None:
+        # ✅ Works
+        if self.is_filled["my_super_slot___"]:
+            # Do something
+
+        # ❌ Does not work
+        if self.is_filled["my super-slot :)"]:
+            # Do something
+```

--- a/docs/getting_started/adding_slots.md
+++ b/docs/getting_started/adding_slots.md
@@ -189,7 +189,8 @@ which is NOT the same as the `date` variable used inside Calendar's template.
 
 We want to use the same `date` variable that's used inside Calendar's template.
 
-Luckily, django-components allows passing data to the slot, also known as [Scoped slots](../../concepts/fundamentals/slots#scoped-slots).
+Luckily, django-components allows [passing data to slots](../../concepts/fundamentals/slots#slot-data),
+also known as [Scoped slots](https://vuejs.org/guide/components/slots#scoped-slots).
 
 This consists of two steps:
 

--- a/docs/getting_started/components_in_templates.md
+++ b/docs/getting_started/components_in_templates.md
@@ -102,7 +102,7 @@ and render the component inside a template:
 
 !!! info
 
-    Component tags should end with `/` if they do not contain any [Slot fills](../../concepts/fundamentals/slots#slot-fills).
+    Component tags should end with `/` if they do not contain any [Slot fills](../../concepts/fundamentals/slots).
     But you can also use `{% endcomponent %}` instead:
 
     ```htmldjango


### PR DESCRIPTION
Documents the recent changes to slots.

Here's preview of it. I've moved the video to Youtube, because Github has file limit 10mb, and the last time I tried to compress similar video, it ended up choppy as hell 😄 

https://youtu.be/x6yCEwt0rUk

- All the ways how to use slots / fills is now documented in consice overview.
- Added section on the Slot class
- `{{ component_vars.is_filled }}` was moved to the bottom as legacy section.

Closes https://github.com/django-components/django-components/issues/1095