### PR TITLE
refecator: move defaults applying back to ext, raise on passing Slot to Slot, and docs cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ Summary:
   `get_context_data()` is now deprecated but will remain until v2.
 - Slots API polished and prepared for v1.
 - Merged `Component.Url` with `Component.View`
-- Added `Component.args`, `Component.kwargs`, `Component.slots`
+- Added `Component.args`, `Component.kwargs`, `Component.slots`, `Component.context`
 - Added `{{ component_vars.args }}`, `{{ component_vars.kwargs }}`, `{{ component_vars.slots }}`
+- You should no longer instantiate `Component` instances. Instead, call `Component.render()` or `Component.render_to_response()` directly.
+- Component caching can now consider slots (opt-in)
 - And lot more...
 
 #### 🚨📢 BREAKING CHANGES
@@ -866,6 +868,8 @@ Summary:
 - Component's "Render API" (args, kwargs, slots, context, inputs, request, context data, etc)
   can now be accessed also outside of the render call. So now its possible to take the component
   instance out of `get_template_data()` (although this is not recommended).
+
+- Passing `Slot` instance to `Slot` constructor raises an error.
 
 #### Fix
 

--- a/docs/concepts/fundamentals/slots.md
+++ b/docs/concepts/fundamentals/slots.md
@@ -640,14 +640,24 @@ Table.render(
 )
 ```
 
-Slot class can be instantiated with a function, a string, or from another
-[`Slot`](../../../reference/api#django_components.Slot) instance:
+Slot class can be instantiated with a function or a string:
 
 ```py
 slot1 = Slot(lambda ctx: f"Hello, {ctx.data['name']}!")
 slot2 = Slot("Hello, world!")
-slot3 = Slot(slot1)
 ```
+
+!!! warning
+
+    Pass a [`Slot`](../../../reference/api#django_components.Slot) instance to the `Slot`
+    constructor results in an error:
+
+    ```py
+    slot = Slot("Hello")
+
+    # Raises an error
+    slot2 = Slot(slot)
+    ```
 
 ### Rendering slots
 
@@ -713,12 +723,13 @@ html = slot()
 
 When accessing slots from within [`Component`](../../../reference/api#django_components.Component) methods,
 the [`Slot`](../../../reference/api#django_components.Slot) instances are populated
-with extra metadata [`component_name`](../../../reference/api#django_components.Slot.component_name)
-and [`slot_name`](../../../reference/api#django_components.Slot.slot_name).
+with extra metadata [`component_name`](../../../reference/api#django_components.Slot.component_name),
+[`slot_name`](../../../reference/api#django_components.Slot.slot_name), and
+[`nodelist`](../../../reference/api#django_components.Slot.nodelist).
 
-These are used solely for debugging.
+These are used for debugging, such as printing the path to the slot in the component tree.
 
-In fact, you can set these fields too when creating new slots:
+When you create a slot, you can set these fields too:
 
 ```py
 # Either at slot creation
@@ -752,19 +763,6 @@ the contents will be accessible also as a Nodelist under [`Slot.nodelist`](../..
 slot = Slot("Hello!")
 print(slot.nodelist)  # <django.template.Nodelist: ['Hello!']>
 ```
-
-!!! info
-
-    If you pass a [`Slot`](../../../reference/api#django_components.Slot) instance to the constructor,
-    the inner slot will be "unwrapped" and its `Slot.contents` will be used instead.
-
-    ```py
-    slot = Slot("Hello")
-    print(slot.contents)  # "Hello"
-
-    slot2 = Slot(slot)
-    print(slot2.contents)  # "Hello"
-    ```
 
 ### Escaping slots content
 

--- a/docs/concepts/fundamentals/slots.md
+++ b/docs/concepts/fundamentals/slots.md
@@ -649,7 +649,7 @@ slot2 = Slot("Hello, world!")
 
 !!! warning
 
-    Pass a [`Slot`](../../../reference/api#django_components.Slot) instance to the `Slot`
+    Passing a [`Slot`](../../../reference/api#django_components.Slot) instance to the `Slot`
     constructor results in an error:
 
     ```py

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -87,6 +87,14 @@
     options:
       show_if_no_docstring: true
 
+::: django_components.SlotContext
+    options:
+      show_if_no_docstring: true
+
+::: django_components.SlotFallback
+    options:
+      show_if_no_docstring: true
+
 ::: django_components.SlotFunc
     options:
       show_if_no_docstring: true

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2,7 +2,7 @@
 
 # Commands
 
-These are all the [Django management commands](https://docs.djangoproject.com/en/5.1/ref/django-admin)
+These are all the [Django management commands](https://docs.djangoproject.com/en/5.2/ref/django-admin)
 that will be added by installing `django_components`:
 
 
@@ -54,9 +54,7 @@ python manage.py components ext run <extension> <command>
 ## `components create`
 
 ```txt
-usage: python manage.py components create [-h] [--path PATH] [--js JS] [--css CSS] [--template TEMPLATE] [--force] [--verbose]
-              [--dry-run]
-              name
+usage: python manage.py components create [-h] [--path PATH] [--js JS] [--css CSS] [--template TEMPLATE] [--force] [--verbose] [--dry-run] name
 
 ```
 
@@ -238,7 +236,7 @@ List all extensions.
 - `--columns COLUMNS`
     - Comma-separated list of columns to show. Available columns: name. Defaults to `--columns name`.
 - `-s`, `--simple`
-    - Only show table data, without headers. Use this option for generating machine- readable output.
+    - Only show table data, without headers. Use this option for generating machine-readable output.
 
 
 
@@ -386,7 +384,7 @@ usage: python manage.py components list [-h] [--all] [--columns COLUMNS] [-s]
 
 
 
-<a href="https://github.com/django-components/django-components/tree/master/src/django_components/commands/list.py#L141" target="_blank">See source code</a>
+<a href="https://github.com/django-components/django-components/tree/master/src/django_components/commands/list.py#L89" target="_blank">See source code</a>
 
 
 
@@ -401,7 +399,7 @@ List all components created in this project.
 - `--columns COLUMNS`
     - Comma-separated list of columns to show. Available columns: name, full_name, path. Defaults to `--columns full_name,path`.
 - `-s`, `--simple`
-    - Only show table data, without headers. Use this option for generating machine- readable output.
+    - Only show table data, without headers. Use this option for generating machine-readable output.
 
 
 
@@ -463,9 +461,8 @@ ProjectDashboardAction    project.components.dashboard_action.ProjectDashboardAc
 ## `upgradecomponent`
 
 ```txt
-usage: upgradecomponent [-h] [--path PATH] [--version] [-v {0,1,2,3}] [--settings SETTINGS]
-                        [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color]
-                        [--skip-checks]
+usage: upgradecomponent [-h] [--path PATH] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color]
+                        [--force-color] [--skip-checks]
 
 ```
 
@@ -509,10 +506,8 @@ Deprecated. Use `components upgrade` instead.
 ## `startcomponent`
 
 ```txt
-usage: startcomponent [-h] [--path PATH] [--js JS] [--css CSS] [--template TEMPLATE] [--force]
-                      [--verbose] [--dry-run] [--version] [-v {0,1,2,3}] [--settings SETTINGS]
-                      [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color]
-                      [--skip-checks]
+usage: startcomponent [-h] [--path PATH] [--js JS] [--css CSS] [--template TEMPLATE] [--force] [--verbose] [--dry-run] [--version] [-v {0,1,2,3}]
+                      [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color] [--skip-checks]
                       name
 
 ```

--- a/docs/reference/extension_hooks.md
+++ b/docs/reference/extension_hooks.md
@@ -85,9 +85,9 @@ name | type | description
 `component` | [`Component`](../api#django_components.Component) | The Component instance that received the input and is being rendered
 `component_cls` | [`Type[Component]`](../api#django_components.Component) | The Component class
 `component_id` | `str` | The unique identifier for this component instance
-`context` | [`Context`](https://docs.djangoproject.com/en/5.1/ref/templates/api/#django.template.Context) | The Django template Context object
+`context` | [`Context`](https://docs.djangoproject.com/en/5.2/ref/templates/api/#django.template.Context) | The Django template Context object
 `kwargs` | `Dict` | Dictionary of keyword arguments passed to the component
-`slots` | `Dict` | Dictionary of slot definitions
+`slots` | `Dict[str, Slot]` | Dictionary of slot definitions
 
 ::: django_components.extension.ComponentExtension.on_component_registered
     options:
@@ -180,6 +180,30 @@ name | type | description
 name | type | description
 --|--|--
 `registry` | [`ComponentRegistry`](../api#django_components.ComponentRegistry) | The to-be-deleted ComponentRegistry instance
+
+::: django_components.extension.ComponentExtension.on_slot_rendered
+    options:
+      heading_level: 3
+      show_root_heading: true
+      show_signature: true
+      separate_signature: true
+      show_symbol_type_heading: false
+      show_symbol_type_toc: false
+      show_if_no_docstring: true
+      show_labels: false
+
+**Available data:**
+
+name | type | description
+--|--|--
+`component` | [`Component`](../api#django_components.Component) | The Component instance that contains the `{% slot %}` tag
+`component_cls` | [`Type[Component]`](../api#django_components.Component) | The Component class that contains the `{% slot %}` tag
+`component_id` | `str` | The unique identifier for this component instance
+`result` | `SlotResult` | The rendered result of the slot
+`slot` | `Slot` | The Slot instance that was rendered
+`slot_is_default` | `bool` | Whether the slot is default
+`slot_is_required` | `bool` | Whether the slot is required
+`slot_name` | `str` | The name of the `{% slot %}` tag
 
 ## Objects
 

--- a/docs/reference/signals.md
+++ b/docs/reference/signals.md
@@ -6,7 +6,7 @@ Below are the signals that are sent by or during the use of django-components.
 
 ## template_rendered
 
-Django's [`template_rendered`](https://docs.djangoproject.com/en/5.1/ref/signals/#template-rendered) signal.
+Django's [`template_rendered`](https://docs.djangoproject.com/en/5.2/ref/signals/#template-rendered) signal.
 This signal is sent when a template is rendered.
 
 Django-components triggers this signal when a component is rendered. If there are nested components,

--- a/docs/reference/template_vars.md
+++ b/docs/reference/template_vars.md
@@ -7,5 +7,11 @@ template and in [`on_render_before` / `on_render_after`](../concepts/advanced/ho
 hooks.
 
 
+::: django_components.component.ComponentVars.args
+
+::: django_components.component.ComponentVars.kwargs
+
+::: django_components.component.ComponentVars.slots
+
 ::: django_components.component.ComponentVars.is_filled
 

--- a/src/django_components/extension.py
+++ b/src/django_components/extension.py
@@ -92,7 +92,7 @@ class OnComponentInputContext(NamedTuple):
     """List of positional arguments passed to the component"""
     kwargs: Dict
     """Dictionary of keyword arguments passed to the component"""
-    slots: Dict
+    slots: Dict[str, "Slot"]
     """Dictionary of slot definitions"""
     context: Context
     """The Django template Context object"""
@@ -498,6 +498,19 @@ class ComponentExtension:
                 # Add extra kwarg to all components when they are rendered
                 ctx.kwargs["my_input"] = "my_value"
         ```
+
+        !!! warning
+
+            In this hook, the components' inputs are still mutable.
+
+            As such, if a component defines [`Args`](../api#django_components.Component.Args),
+            [`Kwargs`](../api#django_components.Component.Kwargs),
+            [`Slots`](../api#django_components.Component.Slots) types, these types are NOT yet instantiated.
+
+            Instead, component fields like [`Component.args`](../api#django_components.Component.args),
+            [`Component.kwargs`](../api#django_components.Component.kwargs),
+            [`Component.slots`](../api#django_components.Component.slots)
+            are plain `list` / `dict` objects.
         """
         pass
 

--- a/src/django_components/extensions/defaults.py
+++ b/src/django_components/extensions/defaults.py
@@ -3,7 +3,7 @@ from dataclasses import MISSING, Field, dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional, Type
 from weakref import WeakKeyDictionary
 
-from django_components.extension import ComponentExtension, OnComponentClassCreatedContext
+from django_components.extension import ComponentExtension, OnComponentClassCreatedContext, OnComponentInputContext
 
 if TYPE_CHECKING:
     from django_components.component import Component
@@ -99,7 +99,7 @@ def _extract_defaults(defaults: Optional[Type]) -> List[ComponentDefaultField]:
     return defaults_fields
 
 
-def apply_defaults(kwargs: Dict, defaults: List[ComponentDefaultField]) -> None:
+def _apply_defaults(kwargs: Dict, defaults: List[ComponentDefaultField]) -> None:
     """
     Apply the defaults from `Component.Defaults` to the given `kwargs`.
 
@@ -171,3 +171,11 @@ class DefaultsExtension(ComponentExtension):
     def on_component_class_created(self, ctx: OnComponentClassCreatedContext) -> None:
         defaults_cls = getattr(ctx.component_cls, "Defaults", None)
         defaults_by_component[ctx.component_cls] = _extract_defaults(defaults_cls)
+
+    # Apply defaults to missing or `None` values in `kwargs`
+    def on_component_input(self, ctx: OnComponentInputContext) -> None:
+        defaults = defaults_by_component.get(ctx.component_cls, None)
+        if defaults is None:
+            return
+
+        _apply_defaults(ctx.kwargs, defaults)

--- a/src/django_components/provide.py
+++ b/src/django_components/provide.py
@@ -30,7 +30,7 @@ class ProvideNode(BaseNode):
 
     Provide the "user_data" in parent component:
 
-    ```python
+    ```djc_py
     @register("parent")
     class Parent(Component):
         template = \"\"\"
@@ -50,7 +50,7 @@ class ProvideNode(BaseNode):
     Since the "child" component is used within the `{% provide %} / {% endprovide %}` tags,
     we can request the "user_data" using `Component.inject("user_data")`:
 
-    ```python
+    ```djc_py
     @register("child")
     class Child(Component):
         template = \"\"\"

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -116,6 +116,15 @@ class TestSlot:
             slots={"first": "SLOT_FN"},
         )
 
+    def test_render_raises_on_slot_instance_in_slot_constructor(self):
+        slot: Slot = Slot(lambda ctx: "SLOT_FN")
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Slot received another Slot instance as `contents`"),
+        ):
+            Slot(slot)
+
     def test_render_slot_in_python__minimal(self):
         def slot_fn(ctx: SlotContext):
             assert ctx.context is None


### PR DESCRIPTION
This PR makes is so that passing `Slot` instance to `Slot()` constructor raises an error. Other than that, it's then more documentation and a bit of moving stuff around.