### PR TITLE
refactor: deprecate template caching, get_template_name, get_template, assoc template with Comp cls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,40 @@ Summary:
     )
     ```
 
+- `Component.template` no longer accepts a Template instance, only plain string.
+
+    Before:
+
+    ```py
+    class MyComponent(Component):
+        template = Template("{{ my_var }}")
+    ```
+
+    Instead, either:
+
+    1. Set `Component.template` to a plain string.
+
+        ```py
+        class MyComponent(Component):
+            template = "{{ my_var }}"
+        ```
+
+    2. Move the template to it's own HTML file and set `Component.template_file`.
+
+        ```py
+        class MyComponent(Component):
+            template_file = "my_template.html"
+        ```
+
+    3. Or, if you dynamically created the template, render the template inside `Component.on_render()`.
+
+        ```py
+        class MyComponent(Component):
+            def on_render(self, context, template):
+                dynamic_template = do_something_dynamic()
+                return dynamic_template.render(context)
+        ```
+
 - The `Component.Url` class was merged with `Component.View`.
 
     Instead of `Component.Url.public`, use `Component.View.public`.
@@ -403,6 +437,51 @@ Summary:
     to accept also slots and context.
 
     Since `get_context_data()` is widely used, it will remain available until v2.
+
+- `Component.get_template_name()` and `Component.get_template()` are now deprecated. Use `Component.template`,
+`Component.template_file` or `Component.on_render()` instead.
+
+    `Component.get_template_name()` and `Component.get_template()` will be removed in v1.
+
+    In v1, each Component will have at most one static template.
+    This is needed to enable support for Markdown, Pug, or other pre-processing of templates by extensions.
+
+    If you are using the deprecated methods to point to different templates, there's 2 ways to migrate:
+
+    1. Split the single Component into multiple Components, each with its own template. Then switch between them in `Component.on_render()`:
+
+        ```py
+        class MyComponentA(Component):
+            template_file = "a.html"
+
+        class MyComponentB(Component):
+            template_file = "b.html"
+
+        class MyComponent(Component):
+            def on_render(self, context, template):
+                if context["a"]:
+                    return MyComponentA.render(context)
+                else:
+                    return MyComponentB.render(context)
+        ```
+
+    2. Alternatively, use `Component.on_render()` with Django's `get_template()` to dynamically render different templates:
+
+        ```py
+        from django.template.loader import get_template
+
+        class MyComponent(Component):
+            def on_render(self, context, template):
+                if context["a"]:
+                    template_name = "a.html"
+                else:
+                    template_name = "b.html"
+
+                actual_template = get_template(template_name)
+                return actual_template.render(context)
+        ```
+
+    Read more in [django-components#1204](https://github.com/django-components/django-components/discussions/1204).
 
 - The `type` kwarg in `Component.render()` and `Component.render_to_response()` is now deprecated. Use `deps_strategy` instead. The `type` kwarg will be removed in v1.
 
@@ -651,6 +730,22 @@ Summary:
 
 **Miscellaneous**
 
+- Template caching with `cached_template()` helper and `template_cache_size` setting is deprecated.
+    These will be removed in v1.
+
+    This feature made sense if you were dynamically generating templates for components using
+    `Component.get_template_string()` and `Component.get_template()`.
+
+    However, in v1, each Component will have at most one static template. This static template
+    is cached internally per component class, and reused across renders.
+
+    This makes the template caching feature obsolete.
+
+    If you relied on `cached_template()`, you should either:
+
+    1. Wrap the templates as Components.
+    2. Manage the cache of Templates yourself.
+
 - The `debug_highlight_components` and `debug_highlight_slots` settings are deprecated.
     These will be removed in v1.
 
@@ -875,6 +970,13 @@ Summary:
 
     Then, the `contents` attribute of the `BaseNode` instance will contain the string `"Hello, world!"`.
 
+- The `BaseNode` class also has two new metadata attributes:
+
+    - `template_name` - the name of the template that rendered the node.
+    - `template_component` - the component class that the template belongs to.
+
+    This is useful for debugging purposes.
+
 - `Slot` class now has 3 new metadata fields:
 
     1. `Slot.contents` attribute contains the original contents:
@@ -1003,6 +1105,35 @@ Summary:
 - Component's "Render API" (args, kwargs, slots, context, inputs, request, context data, etc)
   can now be accessed also outside of the render call. So now its possible to take the component
   instance out of `get_template_data()` (although this is not recommended).
+
+- Components can now be defined without a template.
+
+    Previously, the following would raise an error:
+
+    ```py
+    class MyComponent(Component):
+        pass
+    ```
+
+    "Template-less" components can be used together with `Component.on_render()` to dynamically
+    pick what to render:
+
+    ```py
+    class TableNew(Component):
+        template_file = "table_new.html"
+
+    class TableOld(Component):
+        template_file = "table_old.html"
+
+    class Table(Component):
+        def on_render(self, context, template):
+            if self.kwargs.get("feat_table_new_ui"):
+                return TableNew.render(args=self.args, kwargs=self.kwargs, slots=self.slots)
+            else:
+                return TableOld.render(args=self.args, kwargs=self.kwargs, slots=self.slots)
+    ```
+
+    "Template-less" components can be also used as a base class for other components, or as mixins.
 
 - Passing `Slot` instance to `Slot` constructor raises an error.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -970,13 +970,6 @@ Summary:
 
     Then, the `contents` attribute of the `BaseNode` instance will contain the string `"Hello, world!"`.
 
-- The `BaseNode` class also has two new metadata attributes:
-
-    - `template_name` - the name of the template that rendered the node.
-    - `template_component` - the component class that the template belongs to.
-
-    This is useful for debugging purposes.
-
 - `Slot` class now has 3 new metadata fields:
 
     1. `Slot.contents` attribute contains the original contents:

--- a/docs/concepts/advanced/template_tags.md
+++ b/docs/concepts/advanced/template_tags.md
@@ -153,12 +153,14 @@ GreetNode.register(library)
 
 When using [`BaseNode`](../../../reference/api#django_components.BaseNode), you have access to several useful properties:
 
-- `node_id`: A unique identifier for this node instance
-- `flags`: Dictionary of flag values (e.g. `{"required": True}`)
-- `params`: List of raw parameters passed to the tag
-- `nodelist`: The template nodes between the start and end tags
-- `contents`: The raw contents between the start and end tags
-- `active_flags`: List of flags that are currently set to True
+- [`node_id`](../../../reference/api#django_components.BaseNode.node_id): A unique identifier for this node instance
+- [`flags`](../../../reference/api#django_components.BaseNode.flags): Dictionary of flag values (e.g. `{"required": True}`)
+- [`params`](../../../reference/api#django_components.BaseNode.params): List of raw parameters passed to the tag
+- [`nodelist`](../../../reference/api#django_components.BaseNode.nodelist): The template nodes between the start and end tags
+- [`contents`](../../../reference/api#django_components.BaseNode.contents): The raw contents between the start and end tags
+- [`active_flags`](../../../reference/api#django_components.BaseNode.active_flags): List of flags that are currently set to True
+- [`template_name`](../../../reference/api#django_components.BaseNode.template_name): The name of the `Template` instance inside which the node was defined
+- [`template_component`](../../../reference/api#django_components.BaseNode.template_component): The component class that the `Template` belongs to
 
 This is what the `node` parameter in the [`@template_tag`](../../../reference/api#django_components.template_tag) decorator gives you access to - it's the instance of the node class that was automatically created for your template tag.
 

--- a/docs/concepts/advanced/template_tags.md
+++ b/docs/concepts/advanced/template_tags.md
@@ -153,14 +153,12 @@ GreetNode.register(library)
 
 When using [`BaseNode`](../../../reference/api#django_components.BaseNode), you have access to several useful properties:
 
-- [`node_id`](../../../reference/api#django_components.BaseNode.node_id): A unique identifier for this node instance
-- [`flags`](../../../reference/api#django_components.BaseNode.flags): Dictionary of flag values (e.g. `{"required": True}`)
-- [`params`](../../../reference/api#django_components.BaseNode.params): List of raw parameters passed to the tag
-- [`nodelist`](../../../reference/api#django_components.BaseNode.nodelist): The template nodes between the start and end tags
-- [`contents`](../../../reference/api#django_components.BaseNode.contents): The raw contents between the start and end tags
-- [`active_flags`](../../../reference/api#django_components.BaseNode.active_flags): List of flags that are currently set to True
-- [`template_name`](../../../reference/api#django_components.BaseNode.template_name): The name of the `Template` instance inside which the node was defined
-- [`template_component`](../../../reference/api#django_components.BaseNode.template_component): The component class that the `Template` belongs to
+- `node_id`: A unique identifier for this node instance
+- `flags`: Dictionary of flag values (e.g. `{"required": True}`)
+- `params`: List of raw parameters passed to the tag
+- `nodelist`: The template nodes between the start and end tags
+- `contents`: The raw contents between the start and end tags
+- `active_flags`: List of flags that are currently set to True
 
 This is what the `node` parameter in the [`@template_tag`](../../../reference/api#django_components.template_tag) decorator gives you access to - it's the instance of the node class that was automatically created for your template tag.
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -461,8 +461,8 @@ ProjectDashboardAction    project.components.dashboard_action.ProjectDashboardAc
 ## `upgradecomponent`
 
 ```txt
-usage: upgradecomponent [-h] [--path PATH] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color]
-                        [--force-color] [--skip-checks]
+usage: upgradecomponent [-h] [--path PATH] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color]
+                        [--skip-checks]
 
 ```
 

--- a/docs/reference/template_tags.md
+++ b/docs/reference/template_tags.md
@@ -67,7 +67,7 @@ If you insert this tag multiple times, ALL JS scripts will be duplicately insert
 
 
 
-<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L3172" target="_blank">See source code</a>
+<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L3301" target="_blank">See source code</a>
 
 
 

--- a/sampleproject/sampleproject/settings.py
+++ b/sampleproject/sampleproject/settings.py
@@ -94,7 +94,6 @@ COMPONENTS = ComponentsSettings(
     dirs=[BASE_DIR / "components"],
     #    app_dirs=["components"],
     #    libraries=[],
-    #    template_cache_size=128,
     #    context_behavior="isolated",  # "django" | "isolated"
 )
 

--- a/src/django_components/app_settings.py
+++ b/src/django_components/app_settings.py
@@ -620,8 +620,11 @@ class ComponentsSettings(NamedTuple):
         ```
     """
 
+    # TODO_V1 - remove
     template_cache_size: Optional[int] = None
     """
+    DEPRECATED. Template caching will be removed in v1.
+
     Configure the maximum amount of Django templates to be cached.
 
     Defaults to `128`.

--- a/src/django_components/cache.py
+++ b/src/django_components/cache.py
@@ -6,13 +6,10 @@ from django.core.cache.backends.locmem import LocMemCache
 from django_components.app_settings import app_settings
 from django_components.util.cache import LRUCache
 
+# TODO_V1 - Remove, won't be needed once we remove `get_template_string()`, `get_template_name()`, `get_template()`
+#
 # This stores the parsed Templates. This is strictly local for now, as it stores instances.
 # NOTE: Lazily initialized so it can be configured based on user-defined settings.
-#
-# TODO: Once we handle whole template parsing ourselves, this could store just
-#       the parsed template AST (+metadata) instead of Template instances. In that case
-#       we could open this up to be stored non-locally and shared across processes.
-#       This would also allow us to remove our custom `LRUCache` implementation.
 template_cache: Optional[LRUCache] = None
 
 # This stores the inlined component JS and CSS files (e.g. `Component.js` and `Component.css`).
@@ -20,6 +17,7 @@ template_cache: Optional[LRUCache] = None
 component_media_cache: Optional[BaseCache] = None
 
 
+# TODO_V1 - Remove, won't be needed once we remove `get_template_string()`, `get_template_name()`, `get_template()`
 def get_template_cache() -> LRUCache:
     global template_cache
     if template_cache is None:

--- a/src/django_components/commands/upgrade.py
+++ b/src/django_components/commands/upgrade.py
@@ -6,7 +6,7 @@ from typing import Any
 from django.conf import settings
 from django.template.engine import Engine
 
-from django_components.template_loader import Loader
+from django_components.template_loader import DjcLoader
 from django_components.util.command import CommandArg, ComponentCommand
 
 
@@ -24,7 +24,7 @@ class UpgradeCommand(ComponentCommand):
 
     def handle(self, *args: Any, **options: Any) -> None:
         current_engine = Engine.get_default()
-        loader = Loader(current_engine)
+        loader = DjcLoader(current_engine)
         dirs = loader.get_dirs(include_apps=False)
 
         if settings.BASE_DIR:

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -1,5 +1,4 @@
 import sys
-from contextlib import contextmanager
 from dataclasses import dataclass
 from types import MethodType
 from typing import (
@@ -7,7 +6,6 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
-    Generator,
     List,
     Mapping,
     NamedTuple,
@@ -19,12 +17,10 @@ from typing import (
 )
 from weakref import ReferenceType, WeakValueDictionary, finalize
 
-from django.core.exceptions import ImproperlyConfigured
 from django.forms.widgets import Media as MediaCls
 from django.http import HttpRequest, HttpResponse
-from django.template.base import NodeList, Origin, Parser, Template, Token
+from django.template.base import NodeList, Parser, Template, Token
 from django.template.context import Context, RequestContext
-from django.template.loader import get_template
 from django.template.loader_tags import BLOCK_CONTEXT_KEY, BlockContext
 from django.test.signals import template_rendered
 from django.views import View
@@ -72,12 +68,11 @@ from django_components.slots import (
     normalize_slot_fills,
     resolve_fills,
 )
-from django_components.template import cached_template
+from django_components.template import prepare_component_template
 from django_components.util.context import gen_context_processors_data, snapshot_context
-from django_components.util.django_monkeypatch import is_template_cls_patched
 from django_components.util.exception import component_error_message
 from django_components.util.logger import trace_component_msg
-from django_components.util.misc import default, gen_id, get_import_path, hash_comp_cls, to_dict
+from django_components.util.misc import default, gen_id, hash_comp_cls, to_dict
 from django_components.util.template_tag import TagAttr
 from django_components.util.weakref import cached_ref
 
@@ -412,7 +407,7 @@ class ComponentTemplateNameDescriptor:
 
 
 class ComponentMeta(ComponentMediaMeta):
-    def __new__(mcs, name: Any, bases: Tuple, attrs: Dict) -> Any:
+    def __new__(mcs, name: str, bases: Tuple[Type, ...], attrs: Dict) -> Type:
         # If user set `template_name` on the class, we instead set it to `template_file`,
         # because we want `template_name` to be the descriptor that proxies to `template_file`.
         if "template_name" in attrs:
@@ -646,25 +641,47 @@ class Component(metaclass=ComponentMeta):
 
     - Relative to the directory where the Component's Python file is defined.
     - Relative to one of the component directories, as set by
-      [`COMPONENTS.dirs`](../settings.md#django_components.app_settings.ComponentsSettings.dirs)
+      [`COMPONENTS.dirs`](../settings#django_components.app_settings.ComponentsSettings.dirs)
       or
-      [`COMPONENTS.app_dirs`](../settings.md#django_components.app_settings.ComponentsSettings.app_dirs)
+      [`COMPONENTS.app_dirs`](../settings#django_components.app_settings.ComponentsSettings.app_dirs)
       (e.g. `<root>/components/`).
     - Relative to the template directories, as set by Django's `TEMPLATES` setting (e.g. `<root>/templates/`).
 
-    Only one of [`template_file`](../api#django_components.Component.template_file),
-    [`get_template_name`](../api#django_components.Component.get_template_name),
-    [`template`](../api#django_components.Component.template)
-    or [`get_template`](../api#django_components.Component.get_template) must be defined.
+    !!! warning
+
+        Only one of [`template_file`](../api#django_components.Component.template_file),
+        [`get_template_name`](../api#django_components.Component.get_template_name),
+        [`template`](../api#django_components.Component.template)
+        or [`get_template`](../api#django_components.Component.get_template) must be defined.
 
     **Example:**
 
-    ```py
-    class MyComponent(Component):
-        template_file = "path/to/template.html"
+    Assuming this project layout:
 
-        def get_template_data(self, args, kwargs, slots, context):
-            return {"name": "World"}
+    ```txt
+    |- components/
+      |- table/
+        |- table.html
+        |- table.css
+        |- table.js
+    ```
+
+    Template name can be either relative to the python file (`components/table/table.py`):
+
+    ```python
+    class Table(Component):
+        template_file = "table.html"
+    ```
+
+    Or relative to one of the directories in
+    [`COMPONENTS.dirs`](../settings#django_components.app_settings.ComponentsSettings.dirs)
+    or
+    [`COMPONENTS.app_dirs`](../settings#django_components.app_settings.ComponentsSettings.app_dirs)
+    (`components/`):
+
+    ```python
+    class Table(Component):
+        template_file = "table/table.html"
     ```
     """
 
@@ -677,53 +694,142 @@ class Component(metaclass=ComponentMeta):
     For historical reasons, django-components used `template_name` to align with Django's
     [TemplateView](https://docs.djangoproject.com/en/5.2/ref/class-based-views/base/#django.views.generic.base.TemplateView).
 
-    `template_file` was introduced to align with `js/js_file` and `css/css_file`.
+    `template_file` was introduced to align with
+    [`js`](../api#django_components.Component.js)/[`js_file`](../api#django_components.Component.js_file)
+    and [`css`](../api#django_components.Component.css)/[`css_file`](../api#django_components.Component.css_file).
 
-    Setting and accessing this attribute is proxied to `template_file`.
+    Setting and accessing this attribute is proxied to
+    [`template_file`](../api#django_components.Component.template_file).
     """
 
+    # TODO_v1 - Remove
     def get_template_name(self, context: Context) -> Optional[str]:
         """
-        Filepath to the Django template associated with this component.
+        DEPRECATED: Use instead [`Component.template_file`](../api#django_components.Component.template_file),
+        [`Component.template`](../api#django_components.Component.template) or
+        [`Component.on_render()`](../api#django_components.Component.on_render).
+        Will be removed in v1.
 
-        The filepath must be relative to either the file where the component class was defined,
-        or one of the roots of `STATIFILES_DIRS`.
+        Same as [`Component.template_file`](../api#django_components.Component.template_file),
+        but allows to dynamically resolve the template name at render time.
 
-        Only one of [`template_file`](../api#django_components.Component.template_file),
-        [`get_template_name`](../api#django_components.Component.get_template_name),
-        [`template`](../api#django_components.Component.template)
-        or [`get_template`](../api#django_components.Component.get_template) must be defined.
+        See [`Component.template_file`](../api#django_components.Component.template_file)
+        for more info and examples.
+
+        !!! warning
+
+            The context is not fully populated at the point when this method is called.
+
+            If you need to access the context, either use
+            [`Component.on_render_before()`](../api#django_components.Component.on_render_before) or
+            [`Component.on_render()`](../api#django_components.Component.on_render).
+
+        !!! warning
+
+            Only one of
+            [`template_file`](../api#django_components.Component.template_file),
+            [`get_template_name()`](../api#django_components.Component.get_template_name),
+            [`template`](../api#django_components.Component.template)
+            or
+            [`get_template()`](../api#django_components.Component.get_template)
+            must be defined.
+
+        Args:
+            context (Context): The Django template\
+                [`Context`](https://docs.djangoproject.com/en/5.1/ref/templates/api/#django.template.Context)\
+                in which the component is rendered.
+
+        Returns:
+            Optional[str]: The filepath to the template.
         """
         return None
 
-    template: Optional[Union[str, Template]] = None
+    template: Optional[str] = None
     """
-    Inlined Django template associated with this component. Can be a plain string or a Template instance.
+    Inlined Django template (as a plain string) associated with this component.
 
-    Only one of [`template_file`](../api#django_components.Component.template_file),
-    [`get_template_name`](../api#django_components.Component.get_template_name),
-    [`template`](../api#django_components.Component.template)
-    or [`get_template`](../api#django_components.Component.get_template) must be defined.
+    !!! warning
+
+        Only one of
+        [`template_file`](../api#django_components.Component.template_file),
+        [`template`](../api#django_components.Component.template),
+        [`get_template_name()`](../api#django_components.Component.get_template_name),
+        or
+        [`get_template()`](../api#django_components.Component.get_template)
+        must be defined.
 
     **Example:**
 
-    ```py
-    class MyComponent(Component):
-        template = "Hello, {{ name }}!"
+    ```python
+    class Table(Component):
+        template = '''
+          <div>
+            {{ my_var }}
+          </div>
+        '''
+    ```
 
-        def get_template_data(self, args, kwargs, slots, context):
-            return {"name": "World"}
+    **Syntax highlighting**
+
+    When using the inlined template, you can enable syntax highlighting
+    with `django_components.types.django_html`.
+
+    Learn more about [syntax highlighting](../../concepts/fundamentals/single_file_components/#syntax-highlighting).
+
+    ```djc_py
+    from django_components import Component, types
+
+    class MyComponent(Component):
+        template: types.django_html = '''
+          <div>
+            {{ my_var }}
+          </div>
+        '''
     ```
     """
 
+    # TODO_v1 - Remove
     def get_template(self, context: Context) -> Optional[Union[str, Template]]:
         """
-        Inlined Django template associated with this component. Can be a plain string or a Template instance.
+        DEPRECATED: Use instead [`Component.template_file`](../api#django_components.Component.template_file),
+        [`Component.template`](../api#django_components.Component.template) or
+        [`Component.on_render()`](../api#django_components.Component.on_render).
+        Will be removed in v1.
 
-        Only one of [`template_file`](../api#django_components.Component.template_file),
-        [`get_template_name`](../api#django_components.Component.get_template_name),
-        [`template`](../api#django_components.Component.template)
-        or [`get_template`](../api#django_components.Component.get_template) must be defined.
+        Same as [`Component.template`](../api#django_components.Component.template),
+        but allows to dynamically resolve the template at render time.
+
+        The template can be either plain string or
+        a [`Template`](https://docs.djangoproject.com/en/5.1/topics/templates/#template) instance.
+
+        See [`Component.template`](../api#django_components.Component.template) for more info and examples.
+
+        !!! warning
+
+            Only one of
+            [`template`](../api#django_components.Component.template)
+            [`template_file`](../api#django_components.Component.template_file),
+            [`get_template_name()`](../api#django_components.Component.get_template_name),
+            or
+            [`get_template()`](../api#django_components.Component.get_template)
+            must be defined.
+
+        !!! warning
+
+            The context is not fully populated at the point when this method is called.
+
+            If you need to access the context, either use
+            [`Component.on_render_before()`](../api#django_components.Component.on_render_before) or
+            [`Component.on_render()`](../api#django_components.Component.on_render).
+
+        Args:
+            context (Context): The Django template\
+            [`Context`](https://docs.djangoproject.com/en/5.1/ref/templates/api/#django.template.Context)\
+            in which the component is rendered.
+
+        Returns:
+            Optional[Union[str, Template]]: The inlined Django template string or\
+            a [`Template`](https://docs.djangoproject.com/en/5.1/topics/templates/#template) instance.
         """
         return None
 
@@ -981,14 +1087,32 @@ class Component(metaclass=ComponentMeta):
     """
     Main JS associated with this component inlined as string.
 
-    Only one of [`js`](../api#django_components.Component.js) or
-    [`js_file`](../api#django_components.Component.js_file) must be defined.
+    !!! warning
+
+        Only one of [`js`](../api#django_components.Component.js) or
+        [`js_file`](../api#django_components.Component.js_file) must be defined.
 
     **Example:**
 
     ```py
     class MyComponent(Component):
         js = "console.log('Hello, World!');"
+    ```
+
+    **Syntax highlighting**
+
+    When using the inlined template, you can enable syntax highlighting
+    with `django_components.types.js`.
+
+    Learn more about [syntax highlighting](../../concepts/fundamentals/single_file_components/#syntax-highlighting).
+
+    ```djc_py
+    from django_components import Component, types
+
+    class MyComponent(Component):
+        js: types.js = '''
+          console.log('Hello, World!');
+        '''
     ```
     """
 
@@ -1000,9 +1124,9 @@ class Component(metaclass=ComponentMeta):
 
     - Relative to the directory where the Component's Python file is defined.
     - Relative to one of the component directories, as set by
-      [`COMPONENTS.dirs`](../settings.md#django_components.app_settings.ComponentsSettings.dirs)
+      [`COMPONENTS.dirs`](../settings#django_components.app_settings.ComponentsSettings.dirs)
       or
-      [`COMPONENTS.app_dirs`](../settings.md#django_components.app_settings.ComponentsSettings.app_dirs)
+      [`COMPONENTS.app_dirs`](../settings#django_components.app_settings.ComponentsSettings.app_dirs)
       (e.g. `<root>/components/`).
     - Relative to the staticfiles directories, as set by Django's `STATICFILES_DIRS` setting (e.g. `<root>/static/`).
 
@@ -1012,8 +1136,10 @@ class Component(metaclass=ComponentMeta):
        the path is resolved.
     2. The file is read and its contents is set to [`Component.js`](../api#django_components.Component.js).
 
-    Only one of [`js`](../api#django_components.Component.js) or
-    [`js_file`](../api#django_components.Component.js_file) must be defined.
+    !!! warning
+
+        Only one of [`js`](../api#django_components.Component.js) or
+        [`js_file`](../api#django_components.Component.js_file) must be defined.
 
     **Example:**
 
@@ -1244,18 +1370,38 @@ class Component(metaclass=ComponentMeta):
     """
     Main CSS associated with this component inlined as string.
 
-    Only one of [`css`](../api#django_components.Component.css) or
-    [`css_file`](../api#django_components.Component.css_file) must be defined.
+    !!! warning
+
+        Only one of [`css`](../api#django_components.Component.css) or
+        [`css_file`](../api#django_components.Component.css_file) must be defined.
 
     **Example:**
 
     ```py
     class MyComponent(Component):
         css = \"\"\"
-        .my-class {
-            color: red;
-        }
+            .my-class {
+                color: red;
+            }
         \"\"\"
+    ```
+
+    **Syntax highlighting**
+
+    When using the inlined template, you can enable syntax highlighting
+    with `django_components.types.css`.
+
+    Learn more about [syntax highlighting](../../concepts/fundamentals/single_file_components/#syntax-highlighting).
+
+    ```djc_py
+    from django_components import Component, types
+
+    class MyComponent(Component):
+        css: types.css = '''
+          .my-class {
+            color: red;
+          }
+        '''
     ```
     """
 
@@ -1267,9 +1413,9 @@ class Component(metaclass=ComponentMeta):
 
     - Relative to the directory where the Component's Python file is defined.
     - Relative to one of the component directories, as set by
-      [`COMPONENTS.dirs`](../settings.md#django_components.app_settings.ComponentsSettings.dirs)
+      [`COMPONENTS.dirs`](../settings#django_components.app_settings.ComponentsSettings.dirs)
       or
-      [`COMPONENTS.app_dirs`](../settings.md#django_components.app_settings.ComponentsSettings.app_dirs)
+      [`COMPONENTS.app_dirs`](../settings#django_components.app_settings.ComponentsSettings.app_dirs)
       (e.g. `<root>/components/`).
     - Relative to the staticfiles directories, as set by Django's `STATICFILES_DIRS` setting (e.g. `<root>/static/`).
 
@@ -1279,8 +1425,10 @@ class Component(metaclass=ComponentMeta):
        the path is resolved.
     2. The file is read and its contents is set to [`Component.css`](../api#django_components.Component.css).
 
-    Only one of [`css`](../api#django_components.Component.css) or
-    [`css_file`](../api#django_components.Component.css_file) must be defined.
+    !!! warning
+
+        Only one of [`css`](../api#django_components.Component.css) or
+        [`css_file`](../api#django_components.Component.css_file) must be defined.
 
     **Example:**
 
@@ -1632,7 +1780,7 @@ class Component(metaclass=ComponentMeta):
     # PUBLIC API - HOOKS (Configurable by users)
     # #####################################
 
-    def on_render_before(self, context: Context, template: Template) -> None:
+    def on_render_before(self, context: Context, template: Optional[Template]) -> None:
         """
         Hook that runs just before the component's template is rendered.
 
@@ -1640,7 +1788,7 @@ class Component(metaclass=ComponentMeta):
         """
         pass
 
-    def on_render_after(self, context: Context, template: Template, content: str) -> Optional[SlotResult]:
+    def on_render_after(self, context: Context, template: Optional[Template], content: str) -> Optional[SlotResult]:
         """
         Hook that runs just after the component's template was rendered.
         It receives the rendered output as the last argument.
@@ -1753,6 +1901,15 @@ class Component(metaclass=ComponentMeta):
         """Deprecated. Use `Component.class_id` instead."""
         return self.class_id
 
+    _template: Optional[Template] = None
+    """
+    Cached [`Template`](https://docs.djangoproject.com/en/5.2/ref/templates/api/#django.template.Template)
+    instance for the [`Component`](../api#django_components.Component),
+    created from
+    [`Component.template`](#django_components.Component.template) or
+    [`Component.template_file`](#django_components.Component.template_file).
+    """
+
     # TODO_v3 - Django-specific property to prevent calling the instance as a function.
     do_not_call_in_templates: ClassVar[bool] = True
     """
@@ -1849,6 +2006,9 @@ class Component(metaclass=ComponentMeta):
     def __init_subclass__(cls, **kwargs: Any) -> None:
         cls.class_id = hash_comp_cls(cls)
         comp_cls_id_mapping[cls.class_id] = cls
+
+        # Make sure that subclassed component will store it's own template, not the parent's.
+        cls._template = None
 
         ALL_COMPONENTS.append(cached_ref(cls))  # type: ignore[arg-type]
         extensions._init_component_class(cls)
@@ -2275,64 +2435,6 @@ class Component(metaclass=ComponentMeta):
     # #####################################
     # MISC
     # #####################################
-
-    # NOTE: We cache the Template instance. When the template is taken from a file
-    #       via `get_template_name`, then we leverage Django's template caching with `get_template()`.
-    #       Otherwise, we use our own `cached_template()` to cache the template.
-    #
-    #       This is important to keep in mind, because the implication is that we should
-    #       treat Templates AND their nodelists as IMMUTABLE.
-    def _get_template(self, context: Context, component_id: str) -> Template:
-        template_name = self.get_template_name(context)
-        # TODO_REMOVE_IN_V1 - Remove `self.get_template_string` in v1
-        template_getter = getattr(self, "get_template_string", self.get_template)
-        template_body = template_getter(context)
-
-        # `get_template_name()`, `get_template()`, and `template` are mutually exclusive
-        #
-        # Note that `template` and `template_name` are also mutually exclusive, but this
-        # is checked when lazy-loading the template from `template_name`. So if user specified
-        # `template_name`, then `template` will be populated with the content of that file.
-        if self.template is not None and template_name is not None:
-            raise ImproperlyConfigured(
-                "Received non-null value from both 'template/template_name' and 'get_template_name' in"
-                f" Component {type(self).__name__}. Only one of the two must be set."
-            )
-        if self.template is not None and template_body is not None:
-            raise ImproperlyConfigured(
-                "Received non-null value from both 'template/template_name' and 'get_template' in"
-                f" Component {type(self).__name__}. Only one of the two must be set."
-            )
-        if template_name is not None and template_body is not None:
-            raise ImproperlyConfigured(
-                "Received non-null value from both 'get_template_name' and 'get_template' in"
-                f" Component {type(self).__name__}. Only one of the two must be set."
-            )
-
-        if template_name is not None:
-            return get_template(template_name).template
-
-        template_body = template_body if template_body is not None else self.template
-        if template_body is not None:
-            # We got template string, so we convert it to Template
-            if isinstance(template_body, str):
-                trace_component_msg("COMP_LOAD", component_name=self.name, component_id=component_id, slot_name=None)
-                template: Template = cached_template(
-                    template_string=template_body,
-                    name=self.template_file or self.name,
-                    origin=Origin(
-                        name=self.template_file or get_import_path(self.__class__),
-                        template_name=self.template_file or self.name,
-                    ),
-                )
-            else:
-                template = template_body
-
-            return template
-
-        raise ImproperlyConfigured(
-            f"Either 'template_file' or 'template' must be set for Component {type(self).__name__}."
-        )
 
     def inject(self, key: str, default: Optional[Any] = None) -> Any:
         """
@@ -2886,7 +2988,7 @@ class Component(metaclass=ComponentMeta):
             template_name=None,
             # This field will be modified from within `SlotNodes.render()`:
             # - The `default_slot` will be set to the first slot that has the `default` attribute set.
-            #   If multiple slots have the `default` attribute set, yet have different name, then
+            # - If multiple slots have the `default` attribute set, yet have different name, then
             #   we will raise an error.
             default_slot=None,
             # NOTE: This is only a SNAPSHOT of the outer context.
@@ -2937,8 +3039,30 @@ class Component(metaclass=ComponentMeta):
         #       but instead can render one component at a time.
         #############################################################################
 
-        with _prepare_template(component, template_data) as template:
-            component_ctx.template_name = template.name
+        # TODO_v1 - Currently we have to pass `template_data` to `prepare_component_template()`,
+        #     so that `get_template_string()`, `get_template_name()`, and `get_template()`
+        #     have access to the data from `get_template_data()`.
+        #
+        #     Because of that there is one layer of `Context.update()` called inside `prepare_component_template()`.
+        #
+        #     Once `get_template_string()`, `get_template_name()`, and `get_template()` are removed,
+        #     we can remove that layer of `Context.update()`, and NOT pass `template_data`
+        #     to `prepare_component_template()`.
+        #
+        #     Then we can simply apply `template_data` to the context in the same layer
+        #     where we apply `context_processor_data` and `component_vars`.
+        with prepare_component_template(component, template_data) as template:
+            # Set `Template._djc_is_component_nested` based on whether we're currently INSIDE
+            # the `{% extends %}` tag.
+            # Part of fix for https://github.com/django-components/django-components/issues/508
+            # See django_monkeypatch.py
+            if template is not None:
+                template._djc_is_component_nested = bool(  # type: ignore[union-attr]
+                    context.render_context.get(BLOCK_CONTEXT_KEY)
+                )
+
+            # Capture the template name so we can print better error messages (currently used in slots)
+            component_ctx.template_name = template.name if template else None
 
             with context.update(
                 {
@@ -3089,26 +3213,31 @@ class Component(metaclass=ComponentMeta):
 
             # Emit signal that the template is about to be rendered
             template_rendered.send(sender=template, template=template, context=context)
-            # Get the component's HTML
-            html_content = template.render(context)
 
-            # Add necessary HTML attributes to work with JS and CSS variables
-            updated_html, child_components = set_component_attrs_for_js_and_css(
-                html_content=html_content,
-                component_id=render_id,
-                css_input_hash=css_input_hash,
-                css_scope_id=css_scope_id,
-                root_attributes=root_attributes,
-            )
+            if template is not None:
+                # Get the component's HTML
+                html_content = template.render(context)
 
-            # Prepend an HTML comment to instructs how and what JS and CSS scripts are associated with it.
-            updated_html = insert_component_dependencies_comment(
-                updated_html,
-                component_cls=component_cls,
-                component_id=render_id,
-                js_input_hash=js_input_hash,
-                css_input_hash=css_input_hash,
-            )
+                # Add necessary HTML attributes to work with JS and CSS variables
+                updated_html, child_components = set_component_attrs_for_js_and_css(
+                    html_content=html_content,
+                    component_id=render_id,
+                    css_input_hash=css_input_hash,
+                    css_scope_id=css_scope_id,
+                    root_attributes=root_attributes,
+                )
+
+                # Prepend an HTML comment to instructs how and what JS and CSS scripts are associated with it.
+                updated_html = insert_component_dependencies_comment(
+                    updated_html,
+                    component_cls=component_cls,
+                    component_id=render_id,
+                    js_input_hash=js_input_hash,
+                    css_input_hash=css_input_hash,
+                )
+            else:
+                updated_html = ""
+                child_components = {}
 
             trace_component_msg(
                 "COMP_RENDER_END",
@@ -3277,8 +3406,18 @@ class ComponentNode(BaseNode):
         nodelist: Optional[NodeList] = None,
         node_id: Optional[str] = None,
         contents: Optional[str] = None,
+        template_name: Optional[str] = None,
+        template_component: Optional[Type["Component"]] = None,
     ) -> None:
-        super().__init__(params=params, flags=flags, nodelist=nodelist, node_id=node_id, contents=contents)
+        super().__init__(
+            params=params,
+            flags=flags,
+            nodelist=nodelist,
+            node_id=node_id,
+            contents=contents,
+            template_name=template_name,
+            template_component=template_component,
+        )
 
         self.name = name
         self.registry = registry
@@ -3370,43 +3509,3 @@ def _get_parent_component_context(context: Context) -> Union[Tuple[None, None], 
 
     parent_comp_ctx = component_context_cache[parent_id]
     return parent_id, parent_comp_ctx
-
-
-@contextmanager
-def _maybe_bind_template(context: Context, template: Template) -> Generator[None, Any, None]:
-    if context.template is None:
-        with context.bind_template(template):
-            yield
-    else:
-        yield
-
-
-@contextmanager
-def _prepare_template(
-    component: Component,
-    template_data: Any,
-) -> Generator[Template, Any, None]:
-    context = component.context
-    with context.update(template_data):
-        # Associate the newly-created Context with a Template, otherwise we get
-        # an error when we try to use `{% include %}` tag inside the template?
-        # See https://github.com/django-components/django-components/issues/580
-        # And https://github.com/django-components/django-components/issues/634
-        template = component._get_template(context, component_id=component.id)
-
-        if not is_template_cls_patched(template):
-            raise RuntimeError(
-                "Django-components received a Template instance which was not patched."
-                "If you are using Django's Template class, check if you added django-components"
-                "to INSTALLED_APPS. If you are using a custom template class, then you need to"
-                "manually patch the class."
-            )
-
-        # Set `Template._djc_is_component_nested` based on whether we're currently INSIDE
-        # the `{% extends %}` tag.
-        # Part of fix for https://github.com/django-components/django-components/issues/508
-        # See django_monkeypatch.py
-        template._djc_is_component_nested = bool(context.render_context.get(BLOCK_CONTEXT_KEY))
-
-        with _maybe_bind_template(context, template):
-            yield template

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -2915,6 +2915,9 @@ class Component(metaclass=ComponentMeta):
         if not isinstance(context, (Context, RequestContext)):
             context = RequestContext(request, context) if request else Context(context)
 
+        # NOTE: Re-cast to fix type errors
+        context: Union[Context, RequestContext] = context  # type: ignore[no-redef]
+
         render_id = _gen_component_id()
 
         component = comp_cls(

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -3417,8 +3417,6 @@ class ComponentNode(BaseNode):
         nodelist: Optional[NodeList] = None,
         node_id: Optional[str] = None,
         contents: Optional[str] = None,
-        template_name: Optional[str] = None,
-        template_component: Optional[Type["Component"]] = None,
     ) -> None:
         super().__init__(
             params=params,
@@ -3426,8 +3424,6 @@ class ComponentNode(BaseNode):
             nodelist=nodelist,
             node_id=node_id,
             contents=contents,
-            template_name=template_name,
-            template_component=template_component,
         )
 
         self.name = name

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -2915,9 +2915,6 @@ class Component(metaclass=ComponentMeta):
         if not isinstance(context, (Context, RequestContext)):
             context = RequestContext(request, context) if request else Context(context)
 
-        # NOTE: Re-cast to fix type errors
-        context: Union[Context, RequestContext] = context  # type: ignore[no-redef]
-
         render_id = _gen_component_id()
 
         component = comp_cls(
@@ -2964,7 +2961,9 @@ class Component(metaclass=ComponentMeta):
 
         # Required for compatibility with Django's {% extends %} tag
         # See https://github.com/django-components/django-components/pull/859
-        context.render_context.push({BLOCK_CONTEXT_KEY: context.render_context.get(BLOCK_CONTEXT_KEY, BlockContext())})
+        context.render_context.push({  # type: ignore[union-attr]
+            BLOCK_CONTEXT_KEY: context.render_context.get(BLOCK_CONTEXT_KEY, BlockContext())  # type: ignore[union-attr]
+        })
 
         # We pass down the components the info about the component's parent.
         # This is used for correctly resolving slot fills, correct rendering order,
@@ -3069,14 +3068,14 @@ class Component(metaclass=ComponentMeta):
             # Part of fix for https://github.com/django-components/django-components/issues/508
             # See django_monkeypatch.py
             if template is not None:
-                template._djc_is_component_nested = bool(  # type: ignore[union-attr]
-                    context.render_context.get(BLOCK_CONTEXT_KEY)
+                template._djc_is_component_nested = bool(
+                    context.render_context.get(BLOCK_CONTEXT_KEY)  # type: ignore[union-attr]
                 )
 
             # Capture the template name so we can print better error messages (currently used in slots)
             component_ctx.template_name = template.name if template else None
 
-            with context.update(
+            with context.update(  # type: ignore[union-attr]
                 {
                     # Make data from context processors available inside templates
                     **component.context_processors_data,
@@ -3109,7 +3108,7 @@ class Component(metaclass=ComponentMeta):
                 context_snapshot = snapshot_context(context)
 
         # Cleanup
-        context.render_context.pop()
+        context.render_context.pop()  # type: ignore[union-attr]
 
         ######################################
         # 5. Render component

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -2961,9 +2961,9 @@ class Component(metaclass=ComponentMeta):
 
         # Required for compatibility with Django's {% extends %} tag
         # See https://github.com/django-components/django-components/pull/859
-        context.render_context.push({  # type: ignore[union-attr]
-            BLOCK_CONTEXT_KEY: context.render_context.get(BLOCK_CONTEXT_KEY, BlockContext())  # type: ignore
-        })
+        context.render_context.push(  # type: ignore[union-attr]
+            {BLOCK_CONTEXT_KEY: context.render_context.get(BLOCK_CONTEXT_KEY, BlockContext())}  # type: ignore
+        )
 
         # We pass down the components the info about the component's parent.
         # This is used for correctly resolving slot fills, correct rendering order,

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -2962,7 +2962,7 @@ class Component(metaclass=ComponentMeta):
         # Required for compatibility with Django's {% extends %} tag
         # See https://github.com/django-components/django-components/pull/859
         context.render_context.push({  # type: ignore[union-attr]
-            BLOCK_CONTEXT_KEY: context.render_context.get(BLOCK_CONTEXT_KEY, BlockContext())  # type: ignore[union-attr]
+            BLOCK_CONTEXT_KEY: context.render_context.get(BLOCK_CONTEXT_KEY, BlockContext())  # type: ignore
         })
 
         # We pass down the components the info about the component's parent.

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -2907,12 +2907,12 @@ class Component(metaclass=ComponentMeta):
         )
         # Use RequestContext if request is provided, so that child non-component template tags
         # can access the request object too.
-        context = context or (RequestContext(request) if request else Context())
+        context = context if context is not None else (RequestContext(request) if request else Context())
 
         # Allow to provide a dict instead of Context
         # NOTE: This if/else is important to avoid nested Contexts,
         # See https://github.com/django-components/django-components/issues/414
-        if not isinstance(context, Context):
+        if not isinstance(context, (Context, RequestContext)):
             context = RequestContext(request, context) if request else Context(context)
 
         render_id = _gen_component_id()

--- a/src/django_components/component_media.py
+++ b/src/django_components/component_media.py
@@ -239,6 +239,7 @@ class ComponentMediaInput(Protocol):
 class ComponentMedia:
     comp_cls: Type["Component"]
     resolved: bool = False
+    resolved_relative_files: bool = False
     Media: Optional[Type[ComponentMediaInput]] = None
     template: Optional[str] = None
     template_file: Optional[str] = None
@@ -737,6 +738,11 @@ def _resolve_component_relative_files(
     as the component class. If so, modify the attributes so the class Django's rendering
     will pick up these files correctly.
     """
+    if comp_media.resolved_relative_files:
+        return
+
+    comp_media.resolved_relative_files = True
+
     # First check if we even need to resolve anything. If the class doesn't define any
     # HTML/JS/CSS files, just skip.
     will_resolve_files = False

--- a/src/django_components/component_media.py
+++ b/src/django_components/component_media.py
@@ -26,10 +26,9 @@ from weakref import WeakKeyDictionary
 from django.contrib.staticfiles import finders
 from django.core.exceptions import ImproperlyConfigured
 from django.forms.widgets import Media as MediaCls
-from django.template import Template, TemplateDoesNotExist
-from django.template.loader import get_template
 from django.utils.safestring import SafeData
 
+from django_components.template import load_component_template
 from django_components.util.loader import get_component_dirs, resolve_file
 from django_components.util.logger import logger
 from django_components.util.misc import flatten, get_import_path, get_module_info, is_glob
@@ -953,27 +952,47 @@ def _get_asset(
     asset_content = getattr(comp_media, inlined_attr, None)
     asset_file = getattr(comp_media, file_attr, None)
 
-    if asset_file is not None:
-        # Check if the file is in one of the components' directories
-        full_path = resolve_file(asset_file, comp_dirs)
+    # No inlined content, nor file name
+    if asset_content is None and asset_file is None:
+        return None
 
-        if full_path is None:
-            # If not, check if it's in the static files
-            if type == "static":
-                full_path = finders.find(asset_file)
-            # Or in the templates
-            elif type == "template":
-                try:
-                    template: Template = get_template(asset_file)
-                    full_path = template.origin.name
-                except TemplateDoesNotExist:
-                    pass
+    if asset_content is not None and asset_file is not None:
+        raise ValueError(
+            f"Received both '{inlined_attr}' and '{file_attr}' in Component {comp_cls.__qualname__}."
+            " Only one of the two must be set."
+        )
 
-        if full_path is None:
-            # NOTE: The short name, e.g. `js` or `css` is used in the error message for convenience
-            raise ValueError(f"Could not find {inlined_attr} file {asset_file}")
+    # If the content was inlined into the component (e.g. `Component.template = "..."`)
+    # then there's nothing to resolve. Return as is.
+    if asset_content is not None:
+        return asset_content
 
-        # NOTE: Use explicit encoding for compat with Windows, see #1074
-        asset_content = Path(full_path).read_text(encoding="utf8")
+    # The rest of the code assumes that we were given only a file name
+    asset_file = cast(str, asset_file)
+
+    if type == "template":
+        # NOTE: While we return on the "source" (plain string) of the template,
+        #       by calling `load_component_template()`, we also cache the Template instance.
+        #       So later in Component's `render_impl()`, we don't have to re-compile the Template.
+        template = load_component_template(comp_cls, asset_file)
+        return template.source
+
+    # For static files, we have a few options:
+    # 1. Check if the file is in one of the components' directories
+    full_path = resolve_file(asset_file, comp_dirs)
+
+    # 2. If not, check if it's in the static files
+    if full_path is None:
+        full_path = finders.find(asset_file)
+
+    if full_path is None:
+        # NOTE: The short name, e.g. `js` or `css` is used in the error message for convenience
+        raise ValueError(f"Could not find {inlined_attr} file {asset_file}")
+
+    # NOTE: Use explicit encoding for compat with Windows, see #1074
+    asset_content = Path(full_path).read_text(encoding="utf8")
+
+    # TODO: Apply `extensions.on_js_preprocess()` and `extensions.on_css_preprocess()`
+    # NOTE: `on_template_preprocess()` is already applied inside `load_component_template()`
 
     return asset_content

--- a/src/django_components/component_media.py
+++ b/src/django_components/component_media.py
@@ -542,9 +542,13 @@ def _resolve_media(comp_cls: Type["Component"], comp_media: ComponentMedia) -> N
             assert isinstance(self.media, MyMedia)
     ```
     """
+    if comp_media.resolved:
+        return
+
+    comp_media.resolved = True
+
     # Do not resolve if this is a base class
-    if get_import_path(comp_cls) == "django_components.component.Component" or comp_media.resolved:
-        comp_media.resolved = True
+    if get_import_path(comp_cls) == "django_components.component.Component":
         return
 
     comp_dirs = get_component_dirs()
@@ -572,8 +576,6 @@ def _resolve_media(comp_cls: Type["Component"], comp_media: ComponentMedia) -> N
     comp_media.css = _get_asset(
         comp_cls, comp_media, inlined_attr="css", file_attr="css_file", comp_dirs=comp_dirs, type="static"
     )
-
-    comp_media.resolved = True
 
 
 def _normalize_media(media: Type[ComponentMediaInput]) -> None:

--- a/src/django_components/node.py
+++ b/src/django_components/node.py
@@ -1,7 +1,7 @@
 import functools
 import inspect
 import keyword
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, cast
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Optional, Tuple, Type, cast
 
 from django.template import Context, Library
 from django.template.base import Node, NodeList, Parser, Token
@@ -14,6 +14,9 @@ from django_components.util.template_tag import (
     resolve_params,
     validate_params,
 )
+
+if TYPE_CHECKING:
+    from django_components.component import Component
 
 
 # Normally, when `Node.render()` is called, it receives only a single argument `context`.
@@ -252,32 +255,77 @@ class BaseNode(Node, metaclass=NodeMeta):
     # PUBLIC API (Configurable by users)
     # #####################################
 
-    tag: str
+    tag: ClassVar[str]
     """
     The tag name.
 
     E.g. `"component"` or `"slot"` will make this class match
     template tags `{% component %}` or `{% slot %}`.
+
+    ```python
+    class SlotNode(BaseNode):
+        tag = "slot"
+        end_tag = "endslot"
+    ```
+
+    This will allow the template tag `{% slot %}` to be used like this:
+
+    ```django
+    {% slot %} ... {% endslot %}
+    ```
     """
 
-    end_tag: Optional[str] = None
+    end_tag: ClassVar[Optional[str]] = None
     """
     The end tag name.
 
     E.g. `"endcomponent"` or `"endslot"` will make this class match
     template tags `{% endcomponent %}` or `{% endslot %}`.
 
+    ```python
+    class SlotNode(BaseNode):
+        tag = "slot"
+        end_tag = "endslot"
+    ```
+
+    This will allow the template tag `{% slot %}` to be used like this:
+
+    ```django
+    {% slot %} ... {% endslot %}
+    ```
+
     If not set, then this template tag has no end tag.
 
     So instead of `{% component %} ... {% endcomponent %}`, you'd use only
     `{% component %}`.
+
+    ```python
+    class MyNode(BaseNode):
+        tag = "mytag"
+        end_tag = None
+    ```
     """
 
-    allowed_flags: Optional[List[str]] = None
+    allowed_flags: ClassVar[Optional[List[str]]] = None
     """
-    The allowed flags for this tag.
+    The list of all *possible* flags for this tag.
 
     E.g. `["required"]` will allow this tag to be used like `{% slot required %}`.
+
+    ```python
+    class SlotNode(BaseNode):
+        tag = "slot"
+        end_tag = "endslot"
+        allowed_flags = ["required", "default"]
+    ```
+
+    This will allow the template tag `{% slot %}` to be used like this:
+
+    ```django
+    {% slot required %} ... {% endslot %}
+    {% slot default %} ... {% endslot %}
+    {% slot required default %} ... {% endslot %}
+    ```
     """
 
     def render(self, context: Context, *args: Any, **kwargs: Any) -> str:
@@ -304,6 +352,133 @@ class BaseNode(Node, metaclass=NodeMeta):
         return self.nodelist.render(context)
 
     # #####################################
+    # Attributes
+    # #####################################
+
+    params: List[TagAttr]
+    """
+    The parameters to the tag in the template.
+
+    A single param represents an arg or kwarg of the template tag.
+
+    E.g. the following tag:
+
+    ```django
+    {% component "my_comp" key=val key2='val2 two' %}
+    ```
+
+    Has 3 params:
+
+    - Posiitonal arg `"my_comp"`
+    - Keyword arg `key=val`
+    - Keyword arg `key2='val2 two'`
+    """
+
+    flags: Dict[str, bool]
+    """
+    Dictionary of all [`allowed_flags`](../api#django_components.BaseNode.allowed_flags)
+    that were set on the tag.
+
+    Flags that were set are `True`, and the rest are `False`.
+
+    E.g. the following tag:
+
+    ```python
+    class SlotNode(BaseNode):
+        tag = "slot"
+        end_tag = "endslot"
+        allowed_flags = ["default", "required"]
+    ```
+
+    ```django
+    {% slot "content" default %}
+    ```
+
+    Has 2 flags, `default` and `required`, but only `default` was set.
+
+    The `flags` dictionary will be:
+
+    ```python
+    {
+        "default": True,
+        "required": False,
+    }
+    ```
+
+    You can check if a flag is set by doing:
+
+    ```python
+    if node.flags["default"]:
+        ...
+    ```
+    """
+
+    nodelist: NodeList
+    """
+    The nodelist of the tag.
+
+    This is the text between the opening and closing tags, e.g.
+
+    ```django
+    {% slot "content" default required %}
+      <div>
+        ...
+      </div>
+    {% endslot %}
+    ```
+
+    The `nodelist` will contain the `<div> ... </div>` part.
+
+    Unlike [`contents`](../api#django_components.BaseNode.contents),
+    the `nodelist` contains the actual Nodes, not just the text.
+    """
+
+    contents: Optional[str]
+    """
+    The contents of the tag.
+
+    This is the text between the opening and closing tags, e.g.
+
+    ```django
+    {% slot "content" default required %}
+      <div>
+        ...
+      </div>
+    {% endslot %}
+    ```
+
+    The `contents` will be `"<div> ... </div>"`.
+    """
+
+    node_id: str
+    """
+    The unique ID of the node.
+
+    Extensions can use this ID to store additional information.
+    """
+
+    template_name: Optional[str]
+    """
+    The name of the [`Template`](https://docs.djangoproject.com/en/5.2/ref/templates/api/#django.template.Template)
+    that contains this node.
+
+    The template name is set by Django's
+    [template loaders](https://docs.djangoproject.com/en/5.2/topics/templates/#loaders).
+
+    For example, the filesystem template loader will set this to the absolute path of the template file.
+
+    ```
+    "/home/user/project/templates/my_template.html"
+    ```
+    """
+
+    template_component: Optional[Type["Component"]]
+    """
+    If the template that contains this node belongs to a [`Component`](../api#django_components.Component),
+    then this will be the [`Component`](../api#django_components.Component) class.
+    """
+
+    # #####################################
     # MISC
     # #####################################
 
@@ -314,12 +489,16 @@ class BaseNode(Node, metaclass=NodeMeta):
         nodelist: Optional[NodeList] = None,
         node_id: Optional[str] = None,
         contents: Optional[str] = None,
+        template_name: Optional[str] = None,
+        template_component: Optional[Type["Component"]] = None,
     ):
         self.params = params
         self.flags = flags or {flag: False for flag in self.allowed_flags or []}
         self.nodelist = nodelist or NodeList()
         self.node_id = node_id or gen_id()
         self.contents = contents
+        self.template_name = template_name
+        self.template_component = template_component
 
     def __repr__(self) -> str:
         return (
@@ -329,7 +508,21 @@ class BaseNode(Node, metaclass=NodeMeta):
 
     @property
     def active_flags(self) -> List[str]:
-        """Flags that were set for this specific instance."""
+        """
+        Flags that were set for this specific instance as a list of strings.
+
+        E.g. the following tag:
+
+        ```django
+        {% slot "content" default required / %}
+        ```
+
+        Will have the following flags:
+
+        ```python
+        ["default", "required"]
+        ```
+        """
         flags = []
         for flag, value in self.flags.items():
             if value:
@@ -347,6 +540,9 @@ class BaseNode(Node, metaclass=NodeMeta):
 
         To register the tag, you can use [`BaseNode.register()`](../api#django_components.BaseNode.register).
         """
+        # NOTE: Avoids circular import
+        from django_components.template import _get_origin_component
+
         tag_id = gen_id()
         tag = parse_template_tag(cls.tag, cls.end_tag, cls.allowed_flags, parser, token)
 
@@ -359,6 +555,8 @@ class BaseNode(Node, metaclass=NodeMeta):
             params=tag.params,
             flags=tag.flags,
             contents=contents,
+            template_name=parser.origin.name if parser.origin else None,
+            template_component=_get_origin_component(parser.origin) if parser.origin else None,
             **kwargs,
         )
 

--- a/src/django_components/node.py
+++ b/src/django_components/node.py
@@ -541,7 +541,7 @@ class BaseNode(Node, metaclass=NodeMeta):
         To register the tag, you can use [`BaseNode.register()`](../api#django_components.BaseNode.register).
         """
         # NOTE: Avoids circular import
-        from django_components.template import get_origin_component
+        from django_components.template import get_component_from_origin
 
         tag_id = gen_id()
         tag = parse_template_tag(cls.tag, cls.end_tag, cls.allowed_flags, parser, token)
@@ -556,7 +556,7 @@ class BaseNode(Node, metaclass=NodeMeta):
             flags=tag.flags,
             contents=contents,
             template_name=parser.origin.name if parser.origin else None,
-            template_component=get_origin_component(parser.origin) if parser.origin else None,
+            template_component=get_component_from_origin(parser.origin) if parser.origin else None,
             **kwargs,
         )
 

--- a/src/django_components/node.py
+++ b/src/django_components/node.py
@@ -1,7 +1,7 @@
 import functools
 import inspect
 import keyword
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Optional, Tuple, Type, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, cast
 
 from django.template import Context, Library
 from django.template.base import Node, NodeList, Parser, Token
@@ -14,9 +14,6 @@ from django_components.util.template_tag import (
     resolve_params,
     validate_params,
 )
-
-if TYPE_CHECKING:
-    from django_components.component import Component
 
 
 # Normally, when `Node.render()` is called, it receives only a single argument `context`.
@@ -255,77 +252,32 @@ class BaseNode(Node, metaclass=NodeMeta):
     # PUBLIC API (Configurable by users)
     # #####################################
 
-    tag: ClassVar[str]
+    tag: str
     """
     The tag name.
 
     E.g. `"component"` or `"slot"` will make this class match
     template tags `{% component %}` or `{% slot %}`.
-
-    ```python
-    class SlotNode(BaseNode):
-        tag = "slot"
-        end_tag = "endslot"
-    ```
-
-    This will allow the template tag `{% slot %}` to be used like this:
-
-    ```django
-    {% slot %} ... {% endslot %}
-    ```
     """
 
-    end_tag: ClassVar[Optional[str]] = None
+    end_tag: Optional[str] = None
     """
     The end tag name.
 
     E.g. `"endcomponent"` or `"endslot"` will make this class match
     template tags `{% endcomponent %}` or `{% endslot %}`.
 
-    ```python
-    class SlotNode(BaseNode):
-        tag = "slot"
-        end_tag = "endslot"
-    ```
-
-    This will allow the template tag `{% slot %}` to be used like this:
-
-    ```django
-    {% slot %} ... {% endslot %}
-    ```
-
     If not set, then this template tag has no end tag.
 
     So instead of `{% component %} ... {% endcomponent %}`, you'd use only
     `{% component %}`.
-
-    ```python
-    class MyNode(BaseNode):
-        tag = "mytag"
-        end_tag = None
-    ```
     """
 
-    allowed_flags: ClassVar[Optional[List[str]]] = None
+    allowed_flags: Optional[List[str]] = None
     """
-    The list of all *possible* flags for this tag.
+    The allowed flags for this tag.
 
     E.g. `["required"]` will allow this tag to be used like `{% slot required %}`.
-
-    ```python
-    class SlotNode(BaseNode):
-        tag = "slot"
-        end_tag = "endslot"
-        allowed_flags = ["required", "default"]
-    ```
-
-    This will allow the template tag `{% slot %}` to be used like this:
-
-    ```django
-    {% slot required %} ... {% endslot %}
-    {% slot default %} ... {% endslot %}
-    {% slot required default %} ... {% endslot %}
-    ```
     """
 
     def render(self, context: Context, *args: Any, **kwargs: Any) -> str:
@@ -352,133 +304,6 @@ class BaseNode(Node, metaclass=NodeMeta):
         return self.nodelist.render(context)
 
     # #####################################
-    # Attributes
-    # #####################################
-
-    params: List[TagAttr]
-    """
-    The parameters to the tag in the template.
-
-    A single param represents an arg or kwarg of the template tag.
-
-    E.g. the following tag:
-
-    ```django
-    {% component "my_comp" key=val key2='val2 two' %}
-    ```
-
-    Has 3 params:
-
-    - Posiitonal arg `"my_comp"`
-    - Keyword arg `key=val`
-    - Keyword arg `key2='val2 two'`
-    """
-
-    flags: Dict[str, bool]
-    """
-    Dictionary of all [`allowed_flags`](../api#django_components.BaseNode.allowed_flags)
-    that were set on the tag.
-
-    Flags that were set are `True`, and the rest are `False`.
-
-    E.g. the following tag:
-
-    ```python
-    class SlotNode(BaseNode):
-        tag = "slot"
-        end_tag = "endslot"
-        allowed_flags = ["default", "required"]
-    ```
-
-    ```django
-    {% slot "content" default %}
-    ```
-
-    Has 2 flags, `default` and `required`, but only `default` was set.
-
-    The `flags` dictionary will be:
-
-    ```python
-    {
-        "default": True,
-        "required": False,
-    }
-    ```
-
-    You can check if a flag is set by doing:
-
-    ```python
-    if node.flags["default"]:
-        ...
-    ```
-    """
-
-    nodelist: NodeList
-    """
-    The nodelist of the tag.
-
-    This is the text between the opening and closing tags, e.g.
-
-    ```django
-    {% slot "content" default required %}
-      <div>
-        ...
-      </div>
-    {% endslot %}
-    ```
-
-    The `nodelist` will contain the `<div> ... </div>` part.
-
-    Unlike [`contents`](../api#django_components.BaseNode.contents),
-    the `nodelist` contains the actual Nodes, not just the text.
-    """
-
-    contents: Optional[str]
-    """
-    The contents of the tag.
-
-    This is the text between the opening and closing tags, e.g.
-
-    ```django
-    {% slot "content" default required %}
-      <div>
-        ...
-      </div>
-    {% endslot %}
-    ```
-
-    The `contents` will be `"<div> ... </div>"`.
-    """
-
-    node_id: str
-    """
-    The unique ID of the node.
-
-    Extensions can use this ID to store additional information.
-    """
-
-    template_name: Optional[str]
-    """
-    The name of the [`Template`](https://docs.djangoproject.com/en/5.2/ref/templates/api/#django.template.Template)
-    that contains this node.
-
-    The template name is set by Django's
-    [template loaders](https://docs.djangoproject.com/en/5.2/topics/templates/#loaders).
-
-    For example, the filesystem template loader will set this to the absolute path of the template file.
-
-    ```
-    "/home/user/project/templates/my_template.html"
-    ```
-    """
-
-    template_component: Optional[Type["Component"]]
-    """
-    If the template that contains this node belongs to a [`Component`](../api#django_components.Component),
-    then this will be the [`Component`](../api#django_components.Component) class.
-    """
-
-    # #####################################
     # MISC
     # #####################################
 
@@ -489,16 +314,12 @@ class BaseNode(Node, metaclass=NodeMeta):
         nodelist: Optional[NodeList] = None,
         node_id: Optional[str] = None,
         contents: Optional[str] = None,
-        template_name: Optional[str] = None,
-        template_component: Optional[Type["Component"]] = None,
     ):
         self.params = params
         self.flags = flags or {flag: False for flag in self.allowed_flags or []}
         self.nodelist = nodelist or NodeList()
         self.node_id = node_id or gen_id()
         self.contents = contents
-        self.template_name = template_name
-        self.template_component = template_component
 
     def __repr__(self) -> str:
         return (
@@ -508,21 +329,7 @@ class BaseNode(Node, metaclass=NodeMeta):
 
     @property
     def active_flags(self) -> List[str]:
-        """
-        Flags that were set for this specific instance as a list of strings.
-
-        E.g. the following tag:
-
-        ```django
-        {% slot "content" default required / %}
-        ```
-
-        Will have the following flags:
-
-        ```python
-        ["default", "required"]
-        ```
-        """
+        """Flags that were set for this specific instance."""
         flags = []
         for flag, value in self.flags.items():
             if value:
@@ -540,9 +347,6 @@ class BaseNode(Node, metaclass=NodeMeta):
 
         To register the tag, you can use [`BaseNode.register()`](../api#django_components.BaseNode.register).
         """
-        # NOTE: Avoids circular import
-        from django_components.template import get_component_from_origin
-
         tag_id = gen_id()
         tag = parse_template_tag(cls.tag, cls.end_tag, cls.allowed_flags, parser, token)
 
@@ -555,8 +359,6 @@ class BaseNode(Node, metaclass=NodeMeta):
             params=tag.params,
             flags=tag.flags,
             contents=contents,
-            template_name=parser.origin.name if parser.origin else None,
-            template_component=get_component_from_origin(parser.origin) if parser.origin else None,
             **kwargs,
         )
 

--- a/src/django_components/node.py
+++ b/src/django_components/node.py
@@ -541,7 +541,7 @@ class BaseNode(Node, metaclass=NodeMeta):
         To register the tag, you can use [`BaseNode.register()`](../api#django_components.BaseNode.register).
         """
         # NOTE: Avoids circular import
-        from django_components.template import _get_origin_component
+        from django_components.template import get_origin_component
 
         tag_id = gen_id()
         tag = parse_template_tag(cls.tag, cls.end_tag, cls.allowed_flags, parser, token)
@@ -556,7 +556,7 @@ class BaseNode(Node, metaclass=NodeMeta):
             flags=tag.flags,
             contents=contents,
             template_name=parser.origin.name if parser.origin else None,
-            template_component=_get_origin_component(parser.origin) if parser.origin else None,
+            template_component=get_origin_component(parser.origin) if parser.origin else None,
             **kwargs,
         )
 

--- a/src/django_components/slots.py
+++ b/src/django_components/slots.py
@@ -1605,7 +1605,7 @@ def _nodelist_to_slot(
         if index_of_last_component_layer is None:
             index_of_last_component_layer = 0
 
-        # TODO: Currently there's one more layer before the `_COMPONENT_CONTEXT_KEY` layer, which is
+        # TODO_V1: Currently there's one more layer before the `_COMPONENT_CONTEXT_KEY` layer, which is
         #       pushed in `_prepare_template()` in `component.py`.
         #       That layer should be removed when `Component.get_template()` is removed, after which
         #       the following line can be removed.

--- a/src/django_components/template.py
+++ b/src/django_components/template.py
@@ -174,7 +174,6 @@ def load_component_template(component_cls: Type["Component"], filepath: str) -> 
     if component_cls._template is not None:
         return component_cls._template
 
-    global loading_components
     loading_components.append(ref(component_cls))
 
     # Use Django's `get_template()` to load the template

--- a/src/django_components/template.py
+++ b/src/django_components/template.py
@@ -1,12 +1,22 @@
-from typing import Any, Optional, Type
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Type, Union, cast
 
-from django.template import Origin, Template
+from django.core.exceptions import ImproperlyConfigured
+from django.template import Context, Origin, Template, TemplateDoesNotExist
+from django.template.loader import get_template as django_get_template
 
 from django_components.cache import get_template_cache
-from django_components.util.misc import get_import_path
+from django_components.template_loader import DjcLoader
+from django_components.util.django_monkeypatch import is_template_cls_patched
+from django_components.util.logger import trace_component_msg
+from django_components.util.misc import get_import_path, get_module_info
+
+if TYPE_CHECKING:
+    from django_components.component import Component
 
 
-# Central logic for creating Templates from string, so we can cache the results
+# TODO_V1 - Remove, won't be needed once we remove `get_template_string()`, `get_template_name()`, `get_template()`
+# Legacy logic for creating Templates from string
 def cached_template(
     template_string: str,
     template_cls: Optional[Type[Template]] = None,
@@ -15,6 +25,8 @@ def cached_template(
     engine: Optional[Any] = None,
 ) -> Template:
     """
+    DEPRECATED. Template caching will be removed in v1.
+
     Create a Template instance that will be cached as per the
     [`COMPONENTS.template_cache_size`](../settings#django_components.app_settings.ComponentsSettings.template_cache_size)
     setting.
@@ -62,3 +74,268 @@ def cached_template(
         template = maybe_cached_template
 
     return template
+
+
+@contextmanager
+def prepare_component_template(
+    component: "Component",
+    template_data: Any,
+) -> Generator[Optional[Template], Any, None]:
+    context = component.context
+    with context.update(template_data):
+        template = _get_component_template(component)
+
+        if template is None:
+            # If template is None, then the component is "template-less",
+            # and we skip template processing.
+            yield template
+            return
+
+        if not is_template_cls_patched(template):
+            raise RuntimeError(
+                "Django-components received a Template instance which was not patched."
+                "If you are using Django's Template class, check if you added django-components"
+                "to INSTALLED_APPS. If you are using a custom template class, then you need to"
+                "manually patch the class."
+            )
+
+        with _maybe_bind_template(context, template):
+            yield template
+
+
+def load_component_template(component_cls: Type["Component"], filepath: str) -> Template:
+    if component_cls._template is not None:
+        return component_cls._template
+
+    # First try to load the filepath using our `DjcLoader`,
+    # so we can pass in the component class to `DjcLoader` and so associate
+    # the template with the component class via the `Origin` instance.
+    #
+    # If the template is NOT found, then we assume that the template
+    # is to be loaded with other loaders, and hence we don't consider
+    # this template to belong to any component.
+    #
+    # NOTE: This practically means that for some extension hooks like `on_template_preprocess()`
+    #       to work, users MUST either:
+    #       - Inline the template within the component class as `Component.template`
+    #       - Set `Component.template_file` to filepath that is within our `COMPONENTS.dirs` / `COMPONENTS.app_dirs`
+    #         and is thus is loaded by DjcLoader.
+    #
+    #       If users don't do this, then we don't know if the given template does or does not
+    #       belong to a component, and thus we don't pre-process it.
+    djc_loader = DjcLoader(None)
+    try:
+        template = djc_loader.get_template(filepath, component_cls=component_cls)
+    except TemplateDoesNotExist:
+        template = None
+
+    # Otherwise, use Django's `get_template()` to load the template
+    if template is None:
+        template = _load_django_template(filepath)
+
+    component_cls._template = template
+
+    return template
+
+
+# `_maybe_bind_template()` handles two problems:
+#
+# 1. Initially, the binding the template was needed for the context processor data
+#    to work when using `RequestContext` (See `RequestContext.bind_template()` in e.g. Django v4.2 or v5.1).
+#    But as of djc v0.140 (possibly earlier) we generate and apply the context processor data
+#    ourselves in `Component._render_impl()`.
+#
+#    Now, we still want to "bind the template" by setting the `Context.template` attribute.
+#    This is for compatibility with Django, because we don't know if there isn't some code that relies
+#    on the `Context.template` attribute being set.
+#
+#    But we don't call `context.bind_template()` explicitly. If we did, then we would
+#    be generating and applying the context processor data twice if the context was `RequestContext`.
+#    Instead, we only run the same logic as `Context.bind_template()` but inlined.
+#
+#    The downstream effect of this is that if the user or some third-party library
+#    uses custom subclass of `Context` with custom logic for `Context.bind_template()`,
+#    then this custom logic will NOT be applied. In such case they should open an issue.
+#
+#    See https://github.com/django-components/django-components/issues/580
+#    and https://github.com/django-components/django-components/issues/634
+#
+# 2. Not sure if I (Juro) remember right, but I think that with the binding of templates
+#    there was also an issue that in *some* cases the template was already bound to the context
+#    by the time we got to rendering the component. This is why we need to check if `context.template`
+#    is already set.
+#
+#    The cause of this may have been compatibility with Django's `{% extends %}` tag, or
+#    maybe when using the "isolated" context behavior. But not sure.
+@contextmanager
+def _maybe_bind_template(context: Context, template: Template) -> Generator[None, Any, None]:
+    if context.template is not None:
+        yield
+        return
+
+    # This code is taken from `Context.bind_template()` from Django v5.1
+    context.template = template
+    try:
+        yield
+    finally:
+        context.template = None
+
+
+def _get_component_template(component: "Component") -> Optional[Template]:
+    trace_component_msg("COMP_LOAD", component_name=component.name, component_id=component.id, slot_name=None)
+
+    # TODO_V1 - Remove, not needed once we remove `get_template_string()`, `get_template_name()`, `get_template()`
+    template_sources: Dict[str, Optional[Union[str, Template]]] = {}
+
+    # TODO_V1 - Remove `get_template_name()` in v1
+    template_sources["get_template_name"] = component.get_template_name(component.context)
+
+    # TODO_V1 - Remove `get_template_string()` in v1
+    if hasattr(component, "get_template_string"):
+        template_string_getter = getattr(component, "get_template_string")
+        template_body_from_getter = template_string_getter(component.context)
+    else:
+        template_body_from_getter = None
+    template_sources["get_template_string"] = template_body_from_getter
+
+    # TODO_V1 - Remove `get_template()` in v1
+    template_sources["get_template"] = component.get_template(component.context)
+
+    # NOTE: `component.template` should be populated whether user has set `template` or `template_file`
+    #       so we discern between the two cases by checking `component.template_file`
+    if component.template_file is not None:
+        template_sources["template_file"] = component.template_file
+    else:
+        template_sources["template"] = component.template
+
+    # TODO_V1 - Remove this check in v1
+    # Raise if there are multiple sources for the component template
+    sources_with_values = [k for k, v in template_sources.items() if v is not None]
+    if len(sources_with_values) > 1:
+        raise ImproperlyConfigured(
+            f"Component template was set multiple times in Component {component.name}."
+            f"Sources: {sources_with_values}"
+        )
+
+    # Load the template based on the source
+    if template_sources["get_template_name"]:
+        template_name = template_sources["get_template_name"]
+        template: Optional[Template] = _load_django_template(template_name)
+        template_string: Optional[str] = None
+    elif template_sources["get_template_string"]:
+        template_string = template_sources["get_template_string"]
+        template = None
+    elif template_sources["get_template"]:
+        # `Component.get_template()` returns either string or Template instance
+        if hasattr(template_sources["get_template"], "render"):
+            template = template_sources["get_template"]
+            template_string = None
+        else:
+            template = None
+            template_string = template_sources["get_template"]
+    elif component.template or component.template_file:
+        # If the template was loaded from `Component.template_file`, then the Template
+        # instance was already created and cached in `Component._template`.
+        #
+        # NOTE: This is important to keep in mind, because the implication is that we should
+        # treat Templates AND their nodelists as IMMUTABLE.
+        if component.__class__._template is not None:
+            template = component.__class__._template
+            template_string = None
+        # Otherwise user have set `Component.template` as string and we still need to
+        # create the instance.
+        else:
+            template = _create_template_from_string(
+                component,
+                # NOTE: We can't reach this branch if `Component.template` is None
+                cast(str, component.template),
+                is_component_template=True,
+            )
+            template_string = None
+    # No template
+    else:
+        template = None
+        template_string = None
+
+    # We already have a template instance, so we can return it
+    if template is not None:
+        return template
+    # Create the template from the string
+    elif template_string is not None:
+        return _create_template_from_string(component, template_string)
+
+    # Otherwise, Component has no template - this is valid, as it may be instead rendered
+    # via `Component.on_render()`
+    return None
+
+
+def _create_template_from_string(
+    component: "Component",
+    template_string: str,
+    is_component_template: bool = False,
+) -> Template:
+    # Generate a valid Origin instance.
+    # When an Origin instance is created by Django when using Django's loaders, it looks like this:
+    # ```
+    # {
+    #   'name': '/path/to/project/django-components/sampleproject/calendarapp/templates/calendarapp/calendar.html',
+    #   'template_name': 'calendarapp/calendar.html',
+    #   'loader': <django.template.loaders.app_directories.Loader object at 0x10b441d90>
+    # }
+    # ```
+    #
+    # Since our template is inlined, we will format as `filepath::ComponentName`
+    #
+    # ```
+    # /path/to/project/django-components/src/calendarapp/calendar.html::Calendar
+    # ```
+    #
+    # See https://docs.djangoproject.com/en/5.2/howto/custom-template-backend/#template-origin-api
+    _, _, module_filepath = get_module_info(component.__class__)
+    origin = Origin(
+        name=f"{module_filepath}::{component.__class__.__name__}",
+        template_name=None,
+        loader=None,
+    )
+
+    _set_origin_component(origin, component.__class__)
+
+    if is_component_template:
+        template = Template(template_string, name=origin.template_name, origin=origin)
+        component.__class__._template = template
+    else:
+        # TODO_V1 - `cached_template()` won't be needed as there will be only 1 template per component
+        #           so we will be able to instead use `template_cache` to store the template
+        template = cached_template(
+            template_string=template_string,
+            name=origin.template_name,
+            origin=origin,
+        )
+
+    return template
+
+
+# When loading a template, use Django's `get_template()` to ensure it triggers Django template loaders
+# See https://github.com/django-components/django-components/issues/901
+#
+# This may raise `TemplateDoesNotExist` if the template doesn't exist.
+# See https://docs.djangoproject.com/en/5.2/ref/templates/api/#template-loaders
+# And https://docs.djangoproject.com/en/5.2/ref/templates/api/#custom-template-loaders
+#
+# TODO_v3 - Instead of loading templates with Django's `get_template()`,
+#       we should simply read the files directly (same as we do for JS and CSS).
+#       This has the implications that:
+#       - We would no longer support Django's template loaders
+#       - Instead if users are using template loaders, they should re-create them as djc extensions
+#       - We would no longer need to set `TEMPLATES.OPTIONS.loaders` to include
+#         `django_components.template_loader.Loader`
+def _load_django_template(template_name: str) -> Template:
+    return django_get_template(template_name).template
+
+
+def _set_origin_component(origin: Origin, component_cls: Type["Component"]) -> None:
+    origin.component_cls = component_cls
+
+
+def _get_origin_component(origin: Origin) -> Optional[Type["Component"]]:
+    return getattr(origin, "component_cls", None)

--- a/src/django_components/template_loader.py
+++ b/src/django_components/template_loader.py
@@ -3,14 +3,20 @@ Template loader that loads templates from each Django app's "components" directo
 """
 
 from pathlib import Path
-from typing import List
+from typing import TYPE_CHECKING, Generator, List, Optional, Type
 
+from django.core.exceptions import SuspiciousFileOperation
+from django.template import Origin, Template, TemplateDoesNotExist
 from django.template.loaders.filesystem import Loader as FilesystemLoader
+from django.utils._os import safe_join
 
 from django_components.util.loader import get_component_dirs
 
+if TYPE_CHECKING:
+    from django_components.component import Component
 
-class Loader(FilesystemLoader):
+
+class DjcLoader(FilesystemLoader):
     def get_dirs(self, include_apps: bool = True) -> List[Path]:
         """
         Prepare directories that may contain component files:
@@ -26,3 +32,82 @@ class Loader(FilesystemLoader):
         `BASE_DIR` setting is required.
         """
         return get_component_dirs(include_apps)
+
+    # Same as `FilesystemLoader.get_template()` from Django v5.1, except optionally
+    # accepts a Component class that the template belongs to.
+    # This is used by `load_component_template()` to associate the template with the component class.
+    def get_template(
+        self,
+        template_name: str,
+        skip: Optional[List[Origin]] = None,
+        component_cls: Optional[Type["Component"]] = None,
+    ) -> Template:
+        tried = []
+
+        for origin in self.get_template_sources(template_name, component_cls=component_cls):
+            if skip is not None and origin in skip:
+                tried.append((origin, "Skipped to avoid recursion"))
+                continue
+
+            try:
+                contents = self.get_contents(origin)
+            except TemplateDoesNotExist:
+                tried.append((origin, "Source does not exist"))
+                continue
+            else:
+                return Template(
+                    contents,
+                    origin,
+                    origin.template_name,
+                    self.engine,
+                )
+
+        raise TemplateDoesNotExist(template_name, tried=tried)
+
+    # Same as `FilesystemLoader.get_template_sources()` from Django v5.1, except optionally
+    # accepts a Component class that the template belongs to.
+    # This is used by `load_component_template()` to associate the template with the component class.
+    def get_template_sources(
+        self,
+        template_name: str,
+        component_cls: Optional[Type["Component"]] = None,
+    ) -> Generator[Origin, None, None]:
+        for template_dir in self.get_dirs():
+            try:
+                name = safe_join(template_dir, template_name)
+            except SuspiciousFileOperation:
+                # The joined path was located outside of this template_dir
+                # (it might be inside another one, so this isn't fatal).
+                continue
+
+            origin = Origin(
+                name=name,
+                template_name=template_name,
+                loader=self,
+            )
+
+            if component_cls:
+                from django_components.template import _set_origin_component
+
+                _set_origin_component(origin, component_cls)
+
+            yield origin
+
+    # Same as `FilesystemLoader.get_contents()` from Django v5.1, except that it defaults
+    # to `file_charset` UTF-8 if engine is not set.
+    # This is used by `load_component_template()` so we don't need an instance of Django's `Engine`
+    # to call `DjcLoader.get_template()`.
+    def get_contents(self, origin: Origin) -> str:
+        encoding = self.engine.file_charset if self.engine else "utf-8"
+        try:
+            with open(origin.name, encoding=encoding) as fp:
+                return fp.read()
+        except FileNotFoundError:
+            raise TemplateDoesNotExist(origin)
+
+
+# NOTE: Django's template loaders have the pattern of using the `Loader` class name.
+#       However, this then makes it harder to track and distinguish between different loaders.
+#       So internally we use the name `DjcLoader` instead.
+#       But for public API we use the name `Loader` to match Django.
+Loader = DjcLoader

--- a/src/django_components/template_loader.py
+++ b/src/django_components/template_loader.py
@@ -3,17 +3,11 @@ Template loader that loads templates from each Django app's "components" directo
 """
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Generator, List, Optional, Type
+from typing import List
 
-from django.core.exceptions import SuspiciousFileOperation
-from django.template import Origin, Template, TemplateDoesNotExist
 from django.template.loaders.filesystem import Loader as FilesystemLoader
-from django.utils._os import safe_join
 
 from django_components.util.loader import get_component_dirs
-
-if TYPE_CHECKING:
-    from django_components.component import Component
 
 
 class DjcLoader(FilesystemLoader):
@@ -32,78 +26,6 @@ class DjcLoader(FilesystemLoader):
         `BASE_DIR` setting is required.
         """
         return get_component_dirs(include_apps)
-
-    # Same as `FilesystemLoader.get_template()` from Django v5.1, except optionally
-    # accepts a Component class that the template belongs to.
-    # This is used by `load_component_template()` to associate the template with the component class.
-    def get_template(
-        self,
-        template_name: str,
-        skip: Optional[List[Origin]] = None,
-        component_cls: Optional[Type["Component"]] = None,
-    ) -> Template:
-        tried = []
-
-        for origin in self.get_template_sources(template_name, component_cls=component_cls):
-            if skip is not None and origin in skip:
-                tried.append((origin, "Skipped to avoid recursion"))
-                continue
-
-            try:
-                contents = self.get_contents(origin)
-            except TemplateDoesNotExist:
-                tried.append((origin, "Source does not exist"))
-                continue
-            else:
-                return Template(
-                    contents,
-                    origin,
-                    origin.template_name,
-                    self.engine,
-                )
-
-        raise TemplateDoesNotExist(template_name, tried=tried)
-
-    # Same as `FilesystemLoader.get_template_sources()` from Django v5.1, except optionally
-    # accepts a Component class that the template belongs to.
-    # This is used by `load_component_template()` to associate the template with the component class.
-    def get_template_sources(
-        self,
-        template_name: str,
-        component_cls: Optional[Type["Component"]] = None,
-    ) -> Generator[Origin, None, None]:
-        for template_dir in self.get_dirs():
-            try:
-                name = safe_join(template_dir, template_name)
-            except SuspiciousFileOperation:
-                # The joined path was located outside of this template_dir
-                # (it might be inside another one, so this isn't fatal).
-                continue
-
-            origin = Origin(
-                name=name,
-                template_name=template_name,
-                loader=self,
-            )
-
-            if component_cls:
-                from django_components.template import _set_origin_component
-
-                _set_origin_component(origin, component_cls)
-
-            yield origin
-
-    # Same as `FilesystemLoader.get_contents()` from Django v5.1, except that it defaults
-    # to `file_charset` UTF-8 if engine is not set.
-    # This is used by `load_component_template()` so we don't need an instance of Django's `Engine`
-    # to call `DjcLoader.get_template()`.
-    def get_contents(self, origin: Origin) -> str:
-        encoding = self.engine.file_charset if self.engine else "utf-8"
-        try:
-            with open(origin.name, encoding=encoding) as fp:
-                return fp.read()
-        except FileNotFoundError:
-            raise TemplateDoesNotExist(origin)
 
 
 # NOTE: Django's template loaders have the pattern of using the `Loader` class name.

--- a/tests/test_benchmark_django.py
+++ b/tests/test_benchmark_django.py
@@ -66,7 +66,6 @@ if not settings.configured:
             }
         ],
         COMPONENTS={
-            "template_cache_size": 128,
             "autodiscover": False,
             "context_behavior": CONTEXT_MODE,
         },

--- a/tests/test_benchmark_django_small.py
+++ b/tests/test_benchmark_django_small.py
@@ -37,7 +37,6 @@ if not settings.configured:
             }
         ],
         COMPONENTS={
-            "template_cache_size": 128,
             "autodiscover": False,
             "context_behavior": CONTEXT_MODE,
         },

--- a/tests/test_benchmark_djc.py
+++ b/tests/test_benchmark_djc.py
@@ -66,7 +66,6 @@ if not settings.configured:
             }
         ],
         COMPONENTS={
-            "template_cache_size": 128,
             "autodiscover": False,
             "context_behavior": CONTEXT_MODE,
         },

--- a/tests/test_benchmark_djc_small.py
+++ b/tests/test_benchmark_djc_small.py
@@ -37,7 +37,6 @@ if not settings.configured:
             }
         ],
         COMPONENTS={
-            "template_cache_size": 128,
             "autodiscover": False,
             "context_behavior": CONTEXT_MODE,
         },

--- a/tests/test_component_media.py
+++ b/tests/test_component_media.py
@@ -840,40 +840,46 @@ class TestMediaStaticfiles:
 
 @djc_test
 class TestMediaRelativePath:
-    class ParentComponent(Component):
-        template: types.django_html = """
-            {% load component_tags %}
-            <div>
-                <h1>Parent content</h1>
-                {% component "variable_display" shadowing_variable='override' new_variable='unique_val' %}
-                {% endcomponent %}
-            </div>
-            <div>
-                {% slot 'content' %}
-                    <h2>Slot content</h2>
-                    {% component "variable_display" shadowing_variable='slot_default_override' new_variable='slot_default_unique' %}
+    def _gen_parent_component(self):
+        class ParentComponent(Component):
+            template: types.django_html = """
+                {% load component_tags %}
+                <div>
+                    <h1>Parent content</h1>
+                    {% component "variable_display" shadowing_variable='override' new_variable='unique_val' %}
                     {% endcomponent %}
-                {% endslot %}
-            </div>
-        """  # noqa
+                </div>
+                <div>
+                    {% slot 'content' %}
+                        <h2>Slot content</h2>
+                        {% component "variable_display" shadowing_variable='slot_default_override' new_variable='slot_default_unique' %}
+                        {% endcomponent %}
+                    {% endslot %}
+                </div>
+            """  # noqa
 
-        def get_template_data(self, args, kwargs, slots, context):
-            return {"shadowing_variable": "NOT SHADOWED"}
+            def get_template_data(self, args, kwargs, slots, context):
+                return {"shadowing_variable": "NOT SHADOWED"}
 
-    class VariableDisplay(Component):
-        template: types.django_html = """
-            {% load component_tags %}
-            <h1>Shadowing variable = {{ shadowing_variable }}</h1>
-            <h1>Uniquely named variable = {{ unique_variable }}</h1>
-        """
+        return ParentComponent
 
-        def get_template_data(self, args, kwargs, slots, context):
-            context = {}
-            if kwargs["shadowing_variable"] is not None:
-                context["shadowing_variable"] = kwargs["shadowing_variable"]
-            if kwargs["new_variable"] is not None:
-                context["unique_variable"] = kwargs["new_variable"]
-            return context
+    def _gen_variable_display_component(self):
+        class VariableDisplay(Component):
+            template: types.django_html = """
+                {% load component_tags %}
+                <h1>Shadowing variable = {{ shadowing_variable }}</h1>
+                <h1>Uniquely named variable = {{ unique_variable }}</h1>
+            """
+
+            def get_template_data(self, args, kwargs, slots, context):
+                context = {}
+                if kwargs["shadowing_variable"] is not None:
+                    context["shadowing_variable"] = kwargs["shadowing_variable"]
+                if kwargs["new_variable"] is not None:
+                    context["unique_variable"] = kwargs["new_variable"]
+                return context
+
+        return VariableDisplay
 
     # Settings required for autodiscover to work
     @djc_test(
@@ -885,8 +891,8 @@ class TestMediaRelativePath:
         }
     )
     def test_component_with_relative_media_paths(self):
-        registry.register(name="parent_component", component=self.ParentComponent)
-        registry.register(name="variable_display", component=self.VariableDisplay)
+        registry.register(name="parent_component", component=self._gen_parent_component())
+        registry.register(name="variable_display", component=self._gen_variable_display_component())
 
         # Ensure that the module is executed again after import in autodiscovery
         if "tests.components.relative_file.relative_file" in sys.modules:
@@ -937,8 +943,8 @@ class TestMediaRelativePath:
         }
     )
     def test_component_with_relative_media_paths_as_subcomponent(self):
-        registry.register(name="parent_component", component=self.ParentComponent)
-        registry.register(name="variable_display", component=self.VariableDisplay)
+        registry.register(name="parent_component", component=self._gen_parent_component())
+        registry.register(name="variable_display", component=self._gen_variable_display_component())
 
         # Ensure that the module is executed again after import in autodiscovery
         if "tests.components.relative_file.relative_file" in sys.modules:
@@ -984,8 +990,8 @@ class TestMediaRelativePath:
 
         https://github.com/django-components/django-components/issues/522#issuecomment-2173577094
         """
-        registry.register(name="parent_component", component=self.ParentComponent)
-        registry.register(name="variable_display", component=self.VariableDisplay)
+        registry.register(name="parent_component", component=self._gen_parent_component())
+        registry.register(name="variable_display", component=self._gen_variable_display_component())
 
         # Ensure that the module is executed again after import in autodiscovery
         if "tests.components.relative_file_pathobj.relative_file_pathobj" in sys.modules:

--- a/tests/test_component_media.py
+++ b/tests/test_component_media.py
@@ -210,17 +210,6 @@ class TestMainMedia:
         assert AppLvlCompComponent._component_media.js == 'console.log("JS file");\n'  # type: ignore[attr-defined]
         assert AppLvlCompComponent._component_media.js_file == "app_lvl_comp/app_lvl_comp.js"  # type: ignore[attr-defined]
 
-    def test_html_variable(self):
-        class VariableHTMLComponent(Component):
-            def get_template(self, context):
-                return Template("<div class='variable-html'>{{ variable }}</div>")
-
-        rendered = VariableHTMLComponent.render(context=Context({"variable": "Dynamic Content"}))
-        assertHTMLEqual(
-            rendered,
-            '<div class="variable-html" data-djc-id-ca1bc3e>Dynamic Content</div>',
-        )
-
     def test_html_variable_filtered(self):
         class FilteredComponent(Component):
             template: types.django_html = """

--- a/tests/test_component_media.py
+++ b/tests/test_component_media.py
@@ -1061,7 +1061,7 @@ class TestSubclassingMedia:
                 js = "grandparent.js"
 
         class ParentComponent(GrandParentComponent):
-            Media = None
+            Media = None  # type: ignore[assignment]
 
         class ChildComponent(ParentComponent):
             class Media:
@@ -1144,7 +1144,7 @@ class TestSubclassingMedia:
                 js = "parent1.js"
 
         class Parent2Component(GrandParent3Component, GrandParent4Component):
-            Media = None
+            Media = None  # type: ignore[assignment]
 
         class ChildComponent(Parent1Component, Parent2Component):
             template: types.django_html = """

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,15 +1,12 @@
 import inspect
-import os
 import re
-from typing import cast
-
 import pytest
 from django.template import Context, Template
 from django.template.base import TextNode, VariableNode
 from django.template.defaulttags import IfNode, LoremNode
 from django.template.exceptions import TemplateSyntaxError
 
-from django_components import Component, types
+from django_components import types
 from django_components.node import BaseNode, template_tag
 from django_components.templatetags import component_tags
 from django_components.util.tag_parser import TagAttr
@@ -852,14 +849,7 @@ class TestSignatureBasedValidation:
             @force_signature_validation
             def render(self, context: Context, name: str, **kwargs) -> str:
                 nonlocal captured
-                captured = (
-                    self.params,
-                    self.nodelist,
-                    self.node_id,
-                    self.contents,
-                    self.template_name,
-                    self.template_component,
-                )
+                captured = self.params, self.nodelist, self.node_id, self.contents
                 return f"Hello, {name}!"
 
         # Case 1 - Node with end tag and NOT self-closing
@@ -874,7 +864,7 @@ class TestSignatureBasedValidation:
         template1 = Template(template_str1)
         template1.render(Context({}))
 
-        params1, nodelist1, node_id1, contents1, template_name1, template_component1 = captured  # type: ignore
+        params1, nodelist1, node_id1, contents1 = captured  # type: ignore
         assert len(params1) == 1
         assert isinstance(params1[0], TagAttr)
         # NOTE: The comment node is not included in the nodelist
@@ -889,8 +879,6 @@ class TestSignatureBasedValidation:
         assert isinstance(nodelist1[7], TextNode)
         assert contents1 == "\n              INSIDE TAG {{ my_var }} {# comment #} {% lorem 1 w %} {% if True %} henlo {% endif %}\n            "  # noqa: E501
         assert node_id1 == "a1bc3e"
-        assert template_name1 == '<unknown source>'
-        assert template_component1 is None
 
         captured = None  # Reset captured
 
@@ -902,14 +890,12 @@ class TestSignatureBasedValidation:
         template2 = Template(template_str2)
         template2.render(Context({}))
 
-        params2, nodelist2, node_id2, contents2, template_name2, template_component2 = captured  # type: ignore
+        params2, nodelist2, node_id2, contents2 = captured  # type: ignore
         assert len(params2) == 1  # type: ignore
         assert isinstance(params2[0], TagAttr)  # type: ignore
         assert len(nodelist2) == 0  # type: ignore
         assert contents2 is None  # type: ignore
         assert node_id2 == "a1bc3f"  # type: ignore
-        assert template_name2 == '<unknown source>'  # type: ignore
-        assert template_component2 is None  # type: ignore
 
         captured = None  # Reset captured
 
@@ -920,7 +906,7 @@ class TestSignatureBasedValidation:
             @force_signature_validation
             def render(self, context: Context, name: str, **kwargs) -> str:
                 nonlocal captured
-                captured = self.params, self.nodelist, self.node_id, self.contents, self.template_name, self.template_component  # noqa: E501
+                captured = self.params, self.nodelist, self.node_id, self.contents
                 return f"Hello, {name}!"
 
         TestNodeWithoutEndTag.register(component_tags.register)
@@ -932,38 +918,12 @@ class TestSignatureBasedValidation:
         template3 = Template(template_str3)
         template3.render(Context({}))
 
-        params3, nodelist3, node_id3, contents3, template_name3, template_component3 = captured  # type: ignore
+        params3, nodelist3, node_id3, contents3 = captured  # type: ignore
         assert len(params3) == 1  # type: ignore
         assert isinstance(params3[0], TagAttr)  # type: ignore
         assert len(nodelist3) == 0  # type: ignore
         assert contents3 is None  # type: ignore
         assert node_id3 == "a1bc40"  # type: ignore
-        assert template_name3 == '<unknown source>'  # type: ignore
-        assert template_component3 is None  # type: ignore
-
-        # Case 4 - Node nested in Component end tag
-        class TestComponent(Component):
-            template = """
-                {% load component_tags %}
-                {% mytag2 'John' %}
-            """
-
-        TestComponent.render(Context({}))
-
-        params4, nodelist4, node_id4, contents4, template_name4, template_component4 = captured  # type: ignore
-        assert len(params4) == 1  # type: ignore
-        assert isinstance(params4[0], TagAttr)  # type: ignore
-        assert len(nodelist4) == 0  # type: ignore
-        assert contents4 is None  # type: ignore
-        assert node_id4 == "a1bc42"  # type: ignore
-
-        if os.name == 'nt':
-            assert cast(str, template_name4).endswith("\\tests\\test_node.py::TestComponent")  # type: ignore
-        else:
-            assert cast(str, template_name4).endswith("/tests/test_node.py::TestComponent")  # type: ignore
-
-        assert template_name4 == f"{__file__}::TestComponent"  # type: ignore
-        assert template_component4 is TestComponent  # type: ignore
 
         # Cleanup
         TestNodeWithEndTag.unregister(component_tags.register)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,8 +1,9 @@
 import inspect
+import os
 import re
-import pytest
 from typing import cast
 
+import pytest
 from django.template import Context, Template
 from django.template.base import TextNode, VariableNode
 from django.template.defaulttags import IfNode, LoremNode
@@ -955,7 +956,12 @@ class TestSignatureBasedValidation:
         assert len(nodelist4) == 0
         assert contents4 is None
         assert node_id4 == "a1bc42"
-        assert cast(str, template_name4).endswith("/tests/test_node.py::TestComponent")
+
+        if os.name == 'nt':
+            assert cast(str, template_name4).endswith("\\tests\\test_node.py::TestComponent")
+        else:
+            assert cast(str, template_name4).endswith("/tests/test_node.py::TestComponent")
+
         assert template_name4 == f"{__file__}::TestComponent"
         assert template_component4 is TestComponent
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,12 +1,14 @@
 import inspect
 import re
 import pytest
+from typing import cast
+
 from django.template import Context, Template
 from django.template.base import TextNode, VariableNode
 from django.template.defaulttags import IfNode, LoremNode
 from django.template.exceptions import TemplateSyntaxError
 
-from django_components import types
+from django_components import Component, types
 from django_components.node import BaseNode, template_tag
 from django_components.templatetags import component_tags
 from django_components.util.tag_parser import TagAttr
@@ -849,7 +851,14 @@ class TestSignatureBasedValidation:
             @force_signature_validation
             def render(self, context: Context, name: str, **kwargs) -> str:
                 nonlocal captured
-                captured = self.params, self.nodelist, self.node_id, self.contents
+                captured = (
+                    self.params,
+                    self.nodelist,
+                    self.node_id,
+                    self.contents,
+                    self.template_name,
+                    self.template_component,
+                )
                 return f"Hello, {name}!"
 
         # Case 1 - Node with end tag and NOT self-closing
@@ -864,7 +873,7 @@ class TestSignatureBasedValidation:
         template1 = Template(template_str1)
         template1.render(Context({}))
 
-        params1, nodelist1, node_id1, contents1 = captured  # type: ignore
+        params1, nodelist1, node_id1, contents1, template_name1, template_component1 = captured  # type: ignore
         assert len(params1) == 1
         assert isinstance(params1[0], TagAttr)
         # NOTE: The comment node is not included in the nodelist
@@ -879,6 +888,8 @@ class TestSignatureBasedValidation:
         assert isinstance(nodelist1[7], TextNode)
         assert contents1 == "\n              INSIDE TAG {{ my_var }} {# comment #} {% lorem 1 w %} {% if True %} henlo {% endif %}\n            "  # noqa: E501
         assert node_id1 == "a1bc3e"
+        assert template_name1 == '<unknown source>'
+        assert template_component1 is None
 
         captured = None  # Reset captured
 
@@ -890,12 +901,14 @@ class TestSignatureBasedValidation:
         template2 = Template(template_str2)
         template2.render(Context({}))
 
-        params2, nodelist2, node_id2, contents2 = captured  # type: ignore
+        params2, nodelist2, node_id2, contents2, template_name2, template_component2 = captured  # type: ignore
         assert len(params2) == 1  # type: ignore
         assert isinstance(params2[0], TagAttr)  # type: ignore
         assert len(nodelist2) == 0  # type: ignore
         assert contents2 is None  # type: ignore
         assert node_id2 == "a1bc3f"  # type: ignore
+        assert template_name2 == '<unknown source>'  # type: ignore
+        assert template_component2 is None  # type: ignore
 
         captured = None  # Reset captured
 
@@ -906,7 +919,7 @@ class TestSignatureBasedValidation:
             @force_signature_validation
             def render(self, context: Context, name: str, **kwargs) -> str:
                 nonlocal captured
-                captured = self.params, self.nodelist, self.node_id, self.contents
+                captured = self.params, self.nodelist, self.node_id, self.contents, self.template_name, self.template_component  # noqa: E501
                 return f"Hello, {name}!"
 
         TestNodeWithoutEndTag.register(component_tags.register)
@@ -918,12 +931,33 @@ class TestSignatureBasedValidation:
         template3 = Template(template_str3)
         template3.render(Context({}))
 
-        params3, nodelist3, node_id3, contents3 = captured  # type: ignore
+        params3, nodelist3, node_id3, contents3, template_name3, template_component3 = captured  # type: ignore
         assert len(params3) == 1
         assert isinstance(params3[0], TagAttr)
         assert len(nodelist3) == 0
         assert contents3 is None
         assert node_id3 == "a1bc40"
+        assert template_name3 == '<unknown source>'
+        assert template_component3 is None
+
+        # Case 4 - Node nested in Component end tag
+        class TestComponent(Component):
+            template = """
+                {% load component_tags %}
+                {% mytag2 'John' %}
+            """
+
+        TestComponent.render(Context({}))
+
+        params4, nodelist4, node_id4, contents4, template_name4, template_component4 = captured  # type: ignore
+        assert len(params4) == 1
+        assert isinstance(params4[0], TagAttr)
+        assert len(nodelist4) == 0
+        assert contents4 is None
+        assert node_id4 == "a1bc42"
+        assert cast(str, template_name4).endswith("/tests/test_node.py::TestComponent")
+        assert template_name4 == f"{__file__}::TestComponent"
+        assert template_component4 is TestComponent
 
         # Cleanup
         TestNodeWithEndTag.unregister(component_tags.register)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -933,13 +933,13 @@ class TestSignatureBasedValidation:
         template3.render(Context({}))
 
         params3, nodelist3, node_id3, contents3, template_name3, template_component3 = captured  # type: ignore
-        assert len(params3) == 1
-        assert isinstance(params3[0], TagAttr)
-        assert len(nodelist3) == 0
-        assert contents3 is None
-        assert node_id3 == "a1bc40"
-        assert template_name3 == '<unknown source>'
-        assert template_component3 is None
+        assert len(params3) == 1  # type: ignore
+        assert isinstance(params3[0], TagAttr)  # type: ignore
+        assert len(nodelist3) == 0  # type: ignore
+        assert contents3 is None  # type: ignore
+        assert node_id3 == "a1bc40"  # type: ignore
+        assert template_name3 == '<unknown source>'  # type: ignore
+        assert template_component3 is None  # type: ignore
 
         # Case 4 - Node nested in Component end tag
         class TestComponent(Component):
@@ -951,19 +951,19 @@ class TestSignatureBasedValidation:
         TestComponent.render(Context({}))
 
         params4, nodelist4, node_id4, contents4, template_name4, template_component4 = captured  # type: ignore
-        assert len(params4) == 1
-        assert isinstance(params4[0], TagAttr)
-        assert len(nodelist4) == 0
-        assert contents4 is None
-        assert node_id4 == "a1bc42"
+        assert len(params4) == 1  # type: ignore
+        assert isinstance(params4[0], TagAttr)  # type: ignore
+        assert len(nodelist4) == 0  # type: ignore
+        assert contents4 is None  # type: ignore
+        assert node_id4 == "a1bc42"  # type: ignore
 
         if os.name == 'nt':
-            assert cast(str, template_name4).endswith("\\tests\\test_node.py::TestComponent")
+            assert cast(str, template_name4).endswith("\\tests\\test_node.py::TestComponent")  # type: ignore
         else:
-            assert cast(str, template_name4).endswith("/tests/test_node.py::TestComponent")
+            assert cast(str, template_name4).endswith("/tests/test_node.py::TestComponent")  # type: ignore
 
-        assert template_name4 == f"{__file__}::TestComponent"
-        assert template_component4 is TestComponent
+        assert template_name4 == f"{__file__}::TestComponent"  # type: ignore
+        assert template_component4 is TestComponent  # type: ignore
 
         # Cleanup
         TestNodeWithEndTag.unregister(component_tags.register)

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -10,10 +10,6 @@ from .testutils import PARAMETRIZE_CONTEXT_BEHAVIOR, setup_test_config
 setup_test_config({"autodiscover": False})
 
 
-class SlottedComponent(Component):
-    template_file = "slotted_template.html"
-
-
 #######################
 # TESTS
 #######################

--- a/tests/test_templatetags_component.py
+++ b/tests/test_templatetags_component.py
@@ -551,7 +551,7 @@ class TestMultiComponent:
                 <main>Default main</main>
                 <footer>Default footer</footer>
             </custom-template>
-            <custom-template data-djc-id-ca1bc44>
+            <custom-template data-djc-id-ca1bc47>
                 <header>
                     Default header
                 </header>
@@ -588,7 +588,7 @@ class TestMultiComponent:
                 <main>Default main</main>
                 <footer>Default footer</footer>
             </custom-template>
-            <custom-template data-djc-id-ca1bc46>
+            <custom-template data-djc-id-ca1bc49>
                 <header>
                     <div>Slot #2</div>
                 </header>
@@ -624,7 +624,7 @@ class TestMultiComponent:
                 <main>Default main</main>
                 <footer>Default footer</footer>
             </custom-template>
-            <custom-template data-djc-id-ca1bc45>
+            <custom-template data-djc-id-ca1bc48>
                 <header>
                     Default header
                 </header>
@@ -660,7 +660,7 @@ class TestMultiComponent:
                 <main>Default main</main>
                 <footer>Default footer</footer>
             </custom-template>
-            <custom-template data-djc-id-ca1bc45>
+            <custom-template data-djc-id-ca1bc48>
                 <header>
                     <div>Slot #2</div>
                 </header>

--- a/tests/test_templatetags_component.py
+++ b/tests/test_templatetags_component.py
@@ -12,22 +12,28 @@ from .testutils import PARAMETRIZE_CONTEXT_BEHAVIOR, setup_test_config
 setup_test_config({"autodiscover": False})
 
 
-class SlottedComponent(Component):
-    template_file = "slotted_template.html"
+def gen_slotted_component():
+    class SlottedComponent(Component):
+        template_file = "slotted_template.html"
+
+    return SlottedComponent
 
 
-class SlottedComponentWithContext(Component):
-    template: types.django_html = """
-        {% load component_tags %}
-        <custom-template>
-            <header>{% slot "header" %}Default header{% endslot %}</header>
-            <main>{% slot "main" %}Default main{% endslot %}</main>
-            <footer>{% slot "footer" %}Default footer{% endslot %}</footer>
-        </custom-template>
-    """
+def gen_slotted_component_with_context():
+    class SlottedComponentWithContext(Component):
+        template: types.django_html = """
+            {% load component_tags %}
+            <custom-template>
+                <header>{% slot "header" %}Default header{% endslot %}</header>
+                <main>{% slot "main" %}Default main{% endslot %}</main>
+                <footer>{% slot "footer" %}Default footer{% endslot %}</footer>
+            </custom-template>
+        """
 
-    def get_template_data(self, args, kwargs, slots, context):
-        return {"variable": kwargs["variable"]}
+        def get_template_data(self, args, kwargs, slots, context):
+            return {"variable": kwargs["variable"]}
+
+    return SlottedComponentWithContext
 
 
 #######################
@@ -522,8 +528,8 @@ class TestDynamicComponentTemplateTag:
 class TestMultiComponent:
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_both_components_render_correctly_with_no_slots(self, components_settings):
-        registry.register("first_component", SlottedComponent)
-        registry.register("second_component", SlottedComponentWithContext)
+        registry.register("first_component", gen_slotted_component())
+        registry.register("second_component", gen_slotted_component_with_context())
 
         template_str: types.django_html = """
             {% load component_tags %}
@@ -545,7 +551,7 @@ class TestMultiComponent:
                 <main>Default main</main>
                 <footer>Default footer</footer>
             </custom-template>
-            <custom-template data-djc-id-ca1bc47>
+            <custom-template data-djc-id-ca1bc44>
                 <header>
                     Default header
                 </header>
@@ -557,8 +563,8 @@ class TestMultiComponent:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_both_components_render_correctly_with_slots(self, components_settings):
-        registry.register("first_component", SlottedComponent)
-        registry.register("second_component", SlottedComponentWithContext)
+        registry.register("first_component", gen_slotted_component())
+        registry.register("second_component", gen_slotted_component_with_context())
 
         template_str: types.django_html = """
             {% load component_tags %}
@@ -582,7 +588,7 @@ class TestMultiComponent:
                 <main>Default main</main>
                 <footer>Default footer</footer>
             </custom-template>
-            <custom-template data-djc-id-ca1bc49>
+            <custom-template data-djc-id-ca1bc46>
                 <header>
                     <div>Slot #2</div>
                 </header>
@@ -594,8 +600,8 @@ class TestMultiComponent:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_both_components_render_correctly_when_only_first_has_slots(self, components_settings):
-        registry.register("first_component", SlottedComponent)
-        registry.register("second_component", SlottedComponentWithContext)
+        registry.register("first_component", gen_slotted_component())
+        registry.register("second_component", gen_slotted_component_with_context())
 
         template_str: types.django_html = """
             {% load component_tags %}
@@ -618,7 +624,7 @@ class TestMultiComponent:
                 <main>Default main</main>
                 <footer>Default footer</footer>
             </custom-template>
-            <custom-template data-djc-id-ca1bc48>
+            <custom-template data-djc-id-ca1bc45>
                 <header>
                     Default header
                 </header>
@@ -630,8 +636,8 @@ class TestMultiComponent:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_both_components_render_correctly_when_only_second_has_slots(self, components_settings):
-        registry.register("first_component", SlottedComponent)
-        registry.register("second_component", SlottedComponentWithContext)
+        registry.register("first_component", gen_slotted_component())
+        registry.register("second_component", gen_slotted_component_with_context())
 
         template_str: types.django_html = """
             {% load component_tags %}
@@ -654,7 +660,7 @@ class TestMultiComponent:
                 <main>Default main</main>
                 <footer>Default footer</footer>
             </custom-template>
-            <custom-template data-djc-id-ca1bc48>
+            <custom-template data-djc-id-ca1bc45>
                 <header>
                     <div>Slot #2</div>
                 </header>
@@ -667,19 +673,19 @@ class TestMultiComponent:
 
 @djc_test
 class TestComponentIsolation:
-    class SlottedComponent(Component):
-        template: types.django_html = """
-            {% load component_tags %}
-            <custom-template>
-                <header>{% slot "header" %}Default header{% endslot %}</header>
-                <main>{% slot "main" %}Default main{% endslot %}</main>
-                <footer>{% slot "footer" %}Default footer{% endslot %}</footer>
-            </custom-template>
-        """
-
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_instances_of_component_do_not_share_slots(self, components_settings):
-        registry.register("test", self.SlottedComponent)
+        @register("test")
+        class SlottedComponent(Component):
+            template: types.django_html = """
+                {% load component_tags %}
+                <custom-template>
+                    <header>{% slot "header" %}Default header{% endslot %}</header>
+                    <main>{% slot "main" %}Default main{% endslot %}</main>
+                    <footer>{% slot "footer" %}Default footer{% endslot %}</footer>
+                </custom-template>
+            """
+
         template_str: types.django_html = """
             {% load component_tags %}
             {% component "test" %}
@@ -791,7 +797,7 @@ class TestRecursiveComponent:
 class TestComponentTemplateSyntaxError:
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_variable_outside_fill_tag_compiles_w_out_error(self, components_settings):
-        registry.register("test", SlottedComponent)
+        registry.register("test", gen_slotted_component())
         # As of v0.28 this is valid, provided the component registered under "test"
         # contains a slot tag marked as 'default'. This is verified outside
         # template compilation time.
@@ -805,7 +811,7 @@ class TestComponentTemplateSyntaxError:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_text_outside_fill_tag_is_not_error_when_no_fill_tags(self, components_settings):
-        registry.register("test", SlottedComponent)
+        registry.register("test", gen_slotted_component())
         # As of v0.28 this is valid, provided the component registered under "test"
         # contains a slot tag marked as 'default'. This is verified outside
         # template compilation time.
@@ -819,7 +825,7 @@ class TestComponentTemplateSyntaxError:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_text_outside_fill_tag_is_error_when_fill_tags(self, components_settings):
-        registry.register("test", SlottedComponent)
+        registry.register("test", gen_slotted_component())
         template_str: types.django_html = """
             {% load component_tags %}
             {% component "test" %}
@@ -837,7 +843,7 @@ class TestComponentTemplateSyntaxError:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_unclosed_component_is_error(self, components_settings):
-        registry.register("test", SlottedComponent)
+        registry.register("test", gen_slotted_component())
         with pytest.raises(
             TemplateSyntaxError,
             match=re.escape("Unclosed tag on line 3: 'component'"),

--- a/tests/test_templatetags_extends.py
+++ b/tests/test_templatetags_extends.py
@@ -64,8 +64,8 @@ class TestExtendsCompat:
                 <body>
                     <main role="main">
                         <div class='container main-container'>
-                            <div data-djc-id-ca1bc40>BLOCK OVERRIDEN</div>
-                            <custom-template data-djc-id-ca1bc40>
+                            <div data-djc-id-ca1bc43>BLOCK OVERRIDEN</div>
+                            <custom-template data-djc-id-ca1bc43>
                                 <header>SLOT OVERRIDEN</header>
                                 <main>Default main</main>
                                 <footer>Default footer</footer>
@@ -114,14 +114,14 @@ class TestExtendsCompat:
                 <body>
                     <main role="main">
                         <div class='container main-container'>
-                            <div data-djc-id-ca1bc42>BLOCK OVERRIDEN</div>
-                            <custom-template data-djc-id-ca1bc42>
+                            <div data-djc-id-ca1bc45>BLOCK OVERRIDEN</div>
+                            <custom-template data-djc-id-ca1bc45>
                                 <header>SLOT OVERRIDEN</header>
                                 <main>Default main</main>
                                 <footer>Default footer</footer>
                             </custom-template>
-                            <div data-djc-id-ca1bc46>BLOCK OVERRIDEN</div>
-                            <custom-template data-djc-id-ca1bc46>
+                            <div data-djc-id-ca1bc49>BLOCK OVERRIDEN</div>
+                            <custom-template data-djc-id-ca1bc49>
                                 <header>SLOT OVERRIDEN 2</header>
                                 <main>Default main</main>
                                 <footer>Default footer</footer>
@@ -181,14 +181,14 @@ class TestExtendsCompat:
                 <body>
                     <main role="main">
                         <div class='container main-container'>
-                            <div data-djc-id-ca1bc42>BLOCK OVERRIDEN</div>
-                            <custom-template data-djc-id-ca1bc42>
+                            <div data-djc-id-ca1bc45>BLOCK OVERRIDEN</div>
+                            <custom-template data-djc-id-ca1bc45>
                                 <header>SLOT OVERRIDEN</header>
                                 <main>Default main</main>
                                 <footer>Default footer</footer>
                             </custom-template>
-                            <div data-djc-id-ca1bc46>BLOCK OVERRIDEN</div>
-                            <custom-template data-djc-id-ca1bc46>
+                            <div data-djc-id-ca1bc49>BLOCK OVERRIDEN</div>
+                            <custom-template data-djc-id-ca1bc49>
                                 <header>SLOT OVERRIDEN 2</header>
                                 <main>Default main</main>
                                 <footer>Default footer</footer>
@@ -198,7 +198,6 @@ class TestExtendsCompat:
                 </body>
             </html>
         """
-
         assertHTMLEqual(rendered, expected)
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
@@ -247,14 +246,14 @@ class TestExtendsCompat:
                 <body>
                     <main role="main">
                         <div class='container main-container'>
-                            <div data-djc-id-ca1bc42>BLOCK OVERRIDEN</div>
-                            <custom-template data-djc-id-ca1bc42>
+                            <div data-djc-id-ca1bc45>BLOCK OVERRIDEN</div>
+                            <custom-template data-djc-id-ca1bc45>
                                 <header>SLOT OVERRIDEN</header>
                                 <main>Default main</main>
                                 <footer>Default footer</footer>
                             </custom-template>
-                            <div data-djc-id-ca1bc46>BLOCK OVERRIDEN</div>
-                            <custom-template data-djc-id-ca1bc46>
+                            <div data-djc-id-ca1bc49>BLOCK OVERRIDEN</div>
+                            <custom-template data-djc-id-ca1bc49>
                                 <header>SLOT OVERRIDEN 2</header>
                                 <main>Default main</main>
                                 <footer>Default footer</footer>
@@ -352,8 +351,8 @@ class TestExtendsCompat:
                         <main>Default main</main>
                         <footer>Default footer</footer>
                     </custom-template>
-                    <div data-djc-id-ca1bc46>BLOCK OVERRIDEN</div>
-                    <custom-template data-djc-id-ca1bc46>
+                    <div data-djc-id-ca1bc49>BLOCK OVERRIDEN</div>
+                    <custom-template data-djc-id-ca1bc49>
                         <header>SLOT OVERRIDEN 2</header>
                         <main>Default main</main>
                         <footer>Default footer</footer>
@@ -400,11 +399,11 @@ class TestExtendsCompat:
                 <body>
                     <main role="main">
                         <div class='container main-container'>
-                            <custom-template data-djc-id-ca1bc42>
+                            <custom-template data-djc-id-ca1bc48>
                                 <header>Default header</header>
                                 <main>
-                                    <div data-djc-id-ca1bc46>BLOCK OVERRIDEN</div>
-                                    <custom-template data-djc-id-ca1bc46>
+                                    <div data-djc-id-ca1bc49>BLOCK OVERRIDEN</div>
+                                    <custom-template data-djc-id-ca1bc49>
                                         <header>SLOT OVERRIDEN</header>
                                         <main>Default main</main>
                                         <footer>Default footer</footer>
@@ -446,7 +445,7 @@ class TestExtendsCompat:
                     <main role="main">
                         <div class='container main-container'>
                             Variable: <strong></strong>
-                            Variable: <strong data-djc-id-ca1bc3f></strong>
+                            Variable: <strong data-djc-id-ca1bc45></strong>
                         </div>
                     </main>
                 </body>
@@ -456,7 +455,20 @@ class TestExtendsCompat:
 
         # second rendering after cache built
         rendered_2 = Template(template).render(Context({"DJC_DEPS_STRATEGY": "ignore"}))
-        expected_2 = expected.replace("data-djc-id-ca1bc3f", "data-djc-id-ca1bc41")
+
+        expected_2 = """
+            <!DOCTYPE html>
+            <html lang="en">
+                <body>
+                    <main role="main">
+                        <div class='container main-container'>
+                            Variable: <strong></strong>
+                            Variable: <strong data-djc-id-ca1bc47></strong>
+                        </div>
+                    </main>
+                </body>
+            </html>
+        """
         assertHTMLEqual(rendered_2, expected_2)
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
@@ -482,7 +494,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html data-djc-id-ca1bc40 lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc45>
+                <custom-template data-djc-id-ca1bc48>
                     <header></header>
                     <main>BODY_FROM_FILL</main>
                     <footer>Default footer</footer>
@@ -515,7 +527,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html data-djc-id-ca1bc40 lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc45>
+                <custom-template data-djc-id-ca1bc48>
                     <header></header>
                     <main>BODY_FROM_FILL</main>
                     <footer>Default footer</footer>
@@ -548,7 +560,7 @@ class TestExtendsCompat:
             <body>
                 <main role="main">
                     <div class='container main-container'>
-                        <custom-template data-djc-id-ca1bc42>
+                        <custom-template data-djc-id-ca1bc45>
                             <header></header>
                             <main>TEST</main>
                             <footer></footer>
@@ -577,7 +589,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc41>
+                <custom-template data-djc-id-ca1bc44>
                     <header></header>
                     <main>
                         <div> 58 giraffes and 2 pantaloons </div>
@@ -606,7 +618,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html data-djc-id-ca1bc3f lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc43>
+                <custom-template data-djc-id-ca1bc46>
                     <header></header>
                     <main>
                         <div> 58 giraffes and 2 pantaloons </div>
@@ -646,7 +658,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html data-djc-id-ca1bc40 lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc45>
+                <custom-template data-djc-id-ca1bc48>
                     <header></header>
                     <main>BODY_FROM_FILL</main>
                     <footer>Default footer</footer>
@@ -676,7 +688,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html data-djc-id-ca1bc3f lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc44>
+                <custom-template data-djc-id-ca1bc47>
                     <header></header>
                     <main>
                         Helloodiddoo
@@ -712,7 +724,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html data-djc-id-ca1bc3f lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc44>
+                <custom-template data-djc-id-ca1bc47>
                     <header></header>
                     <main>
                         Helloodiddoo
@@ -748,7 +760,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html data-djc-id-ca1bc40 lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc45>
+                <custom-template data-djc-id-ca1bc48>
                     <header></header>
                     <main>
                         Helloodiddoo
@@ -794,7 +806,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html data-djc-id-ca1bc41 lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc47>
+                <custom-template data-djc-id-ca1bc4a>
                     <header></header>
                     <main>
                         Helloodiddoo
@@ -834,7 +846,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc44>
+                <custom-template data-djc-id-ca1bc47>
                     <header></header>
                     <main>
                         <div data-djc-id-ca1bc48> injected: DepInject(hello='from_block') </div>

--- a/tests/test_templatetags_extends.py
+++ b/tests/test_templatetags_extends.py
@@ -11,21 +11,18 @@ from .testutils import PARAMETRIZE_CONTEXT_BEHAVIOR, setup_test_config
 setup_test_config({"autodiscover": False})
 
 
-class SlottedComponent(Component):
-    template_file = "slotted_template.html"
+def gen_slotted_component():
+    class SlottedComponent(Component):
+        template_file = "slotted_template.html"
+
+    return SlottedComponent
 
 
-class BlockedAndSlottedComponent(Component):
-    template_file = "blocked_and_slotted_template.html"
+def gen_blocked_and_slotted_component():
+    class BlockedAndSlottedComponent(Component):
+        template_file = "blocked_and_slotted_template.html"
 
-
-class RelativeFileComponentUsingTemplateFile(Component):
-    template_file = "relative_extends.html"
-
-
-class RelativeFileComponentUsingGetTemplateName(Component):
-    def get_template_name(self, context):
-        return "relative_extends.html"
+    return BlockedAndSlottedComponent
 
 
 #######################
@@ -37,7 +34,7 @@ class RelativeFileComponentUsingGetTemplateName(Component):
 class TestExtendsCompat:
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_double_extends_on_main_template_and_component_one_component(self, components_settings):
-        registry.register("blocked_and_slotted_component", BlockedAndSlottedComponent)
+        registry.register("blocked_and_slotted_component", gen_blocked_and_slotted_component())
 
         @register("extended_component")
         class _ExtendedComponent(Component):
@@ -82,7 +79,7 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_double_extends_on_main_template_and_component_two_identical_components(self, components_settings):
-        registry.register("blocked_and_slotted_component", BlockedAndSlottedComponent)
+        registry.register("blocked_and_slotted_component", gen_blocked_and_slotted_component())
 
         @register("extended_component")
         class _ExtendedComponent(Component):
@@ -139,7 +136,7 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_double_extends_on_main_template_and_component_two_different_components_same_parent(self, components_settings):  # noqa: E501
-        registry.register("blocked_and_slotted_component", BlockedAndSlottedComponent)
+        registry.register("blocked_and_slotted_component", gen_blocked_and_slotted_component())
 
         @register("extended_component")
         class _ExtendedComponent(Component):
@@ -206,7 +203,7 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_double_extends_on_main_template_and_component_two_different_components_different_parent(self, components_settings):  # noqa: E501
-        registry.register("blocked_and_slotted_component", BlockedAndSlottedComponent)
+        registry.register("blocked_and_slotted_component", gen_blocked_and_slotted_component())
 
         @register("extended_component")
         class _ExtendedComponent(Component):
@@ -271,7 +268,7 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_extends_on_component_one_component(self, components_settings):
-        registry.register("blocked_and_slotted_component", BlockedAndSlottedComponent)
+        registry.register("blocked_and_slotted_component", gen_blocked_and_slotted_component())
 
         @register("extended_component")
         class _ExtendedComponent(Component):
@@ -314,7 +311,7 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_extends_on_component_two_component(self, components_settings):
-        registry.register("blocked_and_slotted_component", BlockedAndSlottedComponent)
+        registry.register("blocked_and_slotted_component", gen_blocked_and_slotted_component())
 
         @register("extended_component")
         class _ExtendedComponent(Component):
@@ -368,8 +365,8 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_double_extends_on_main_template_and_nested_component(self, components_settings):
-        registry.register("slotted_component", SlottedComponent)
-        registry.register("blocked_and_slotted_component", BlockedAndSlottedComponent)
+        registry.register("slotted_component", gen_slotted_component())
+        registry.register("blocked_and_slotted_component", gen_blocked_and_slotted_component())
 
         @register("extended_component")
         class _ExtendedComponent(Component):
@@ -406,8 +403,8 @@ class TestExtendsCompat:
                             <custom-template data-djc-id-ca1bc42>
                                 <header>Default header</header>
                                 <main>
-                                    <div data-djc-id-ca1bc49>BLOCK OVERRIDEN</div>
-                                    <custom-template data-djc-id-ca1bc49>
+                                    <div data-djc-id-ca1bc46>BLOCK OVERRIDEN</div>
+                                    <custom-template data-djc-id-ca1bc46>
                                         <header>SLOT OVERRIDEN</header>
                                         <main>Default main</main>
                                         <footer>Default footer</footer>
@@ -425,8 +422,8 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_double_extends_on_main_template_and_nested_component_and_include(self, components_settings):
-        registry.register("slotted_component", SlottedComponent)
-        registry.register("blocked_and_slotted_component", BlockedAndSlottedComponent)
+        registry.register("slotted_component", gen_slotted_component())
+        registry.register("blocked_and_slotted_component", gen_blocked_and_slotted_component())
 
         @register("extended_component")
         class _ExtendedComponent(Component):
@@ -464,7 +461,7 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_slots_inside_extends(self, components_settings):
-        registry.register("slotted_component", SlottedComponent)
+        registry.register("slotted_component", gen_slotted_component())
 
         @register("slot_inside_extends")
         class SlotInsideExtendsComponent(Component):
@@ -497,7 +494,7 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_slots_inside_include(self, components_settings):
-        registry.register("slotted_component", SlottedComponent)
+        registry.register("slotted_component", gen_slotted_component())
 
         @register("slot_inside_include")
         class SlotInsideIncludeComponent(Component):
@@ -530,7 +527,7 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_component_inside_block(self, components_settings):
-        registry.register("slotted_component", SlottedComponent)
+        registry.register("slotted_component", gen_slotted_component())
         template: types.django_html = """
             {% extends "block.html" %}
             {% load component_tags %}
@@ -565,7 +562,7 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_block_inside_component(self, components_settings):
-        registry.register("slotted_component", SlottedComponent)
+        registry.register("slotted_component", gen_slotted_component())
 
         template: types.django_html = """
             {% extends "block_in_component.html" %}
@@ -594,7 +591,7 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_block_inside_component_parent(self, components_settings):
-        registry.register("slotted_component", SlottedComponent)
+        registry.register("slotted_component", gen_slotted_component())
 
         @register("block_in_component_parent")
         class BlockInCompParent(Component):
@@ -627,7 +624,7 @@ class TestExtendsCompat:
         Assert that when we call a component with `{% component %}`, that
         the `{% block %}` will NOT affect the inner component.
         """
-        registry.register("slotted_component", SlottedComponent)
+        registry.register("slotted_component", gen_slotted_component())
 
         @register("block_inside_slot_v1")
         class BlockInSlotInComponent(Component):
@@ -649,7 +646,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html data-djc-id-ca1bc40 lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc49>
+                <custom-template data-djc-id-ca1bc45>
                     <header></header>
                     <main>BODY_FROM_FILL</main>
                     <footer>Default footer</footer>
@@ -662,7 +659,7 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_slot_inside_block__slot_default_block_default(self, components_settings):
-        registry.register("slotted_component", SlottedComponent)
+        registry.register("slotted_component", gen_slotted_component())
 
         @register("slot_inside_block")
         class _SlotInsideBlockComponent(Component):
@@ -695,7 +692,7 @@ class TestExtendsCompat:
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_slot_inside_block__slot_default_block_override(self, components_settings):
         registry.clear()
-        registry.register("slotted_component", SlottedComponent)
+        registry.register("slotted_component", gen_slotted_component())
 
         @register("slot_inside_block")
         class _SlotInsideBlockComponent(Component):
@@ -730,7 +727,7 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_slot_inside_block__slot_overriden_block_default(self, components_settings):
-        registry.register("slotted_component", SlottedComponent)
+        registry.register("slotted_component", gen_slotted_component())
 
         @register("slot_inside_block")
         class _SlotInsideBlockComponent(Component):
@@ -766,7 +763,7 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_slot_inside_block__slot_overriden_block_overriden(self, components_settings):
-        registry.register("slotted_component", SlottedComponent)
+        registry.register("slotted_component", gen_slotted_component())
 
         @register("slot_inside_block")
         class _SlotInsideBlockComponent(Component):
@@ -812,7 +809,7 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_inject_inside_block(self, components_settings):
-        registry.register("slotted_component", SlottedComponent)
+        registry.register("slotted_component", gen_slotted_component())
 
         @register("injectee")
         class InjectComponent(Component):
@@ -840,7 +837,7 @@ class TestExtendsCompat:
                 <custom-template data-djc-id-ca1bc44>
                     <header></header>
                     <main>
-                        <div data-djc-id-ca1bc4b> injected: DepInject(hello='from_block') </div>
+                        <div data-djc-id-ca1bc48> injected: DepInject(hello='from_block') </div>
                     </main>
                     <footer>Default footer</footer>
                 </custom-template>
@@ -851,7 +848,9 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_component_using_template_file_extends_relative_file(self, components_settings):
-        registry.register("relative_file_component_using_template_file", RelativeFileComponentUsingTemplateFile)
+        @register("relative_file_component_using_template_file")
+        class RelativeFileComponentUsingTemplateFile(Component):
+            template_file = "relative_extends.html"
 
         template: types.django_html = """
             {% load component_tags %}
@@ -874,7 +873,10 @@ class TestExtendsCompat:
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_component_using_get_template_name_extends_relative_file(self, components_settings):
-        registry.register("relative_file_component_using_get_template_name", RelativeFileComponentUsingGetTemplateName)
+        @register("relative_file_component_using_get_template_name")
+        class RelativeFileComponentUsingGetTemplateName(Component):
+            def get_template_name(self, context):
+                return "relative_extends.html"
 
         template: types.django_html = """
             {% load component_tags %}

--- a/tests/test_templatetags_extends.py
+++ b/tests/test_templatetags_extends.py
@@ -64,8 +64,8 @@ class TestExtendsCompat:
                 <body>
                     <main role="main">
                         <div class='container main-container'>
-                            <div data-djc-id-ca1bc43>BLOCK OVERRIDEN</div>
-                            <custom-template data-djc-id-ca1bc43>
+                            <div data-djc-id-ca1bc40>BLOCK OVERRIDEN</div>
+                            <custom-template data-djc-id-ca1bc40>
                                 <header>SLOT OVERRIDEN</header>
                                 <main>Default main</main>
                                 <footer>Default footer</footer>
@@ -114,14 +114,14 @@ class TestExtendsCompat:
                 <body>
                     <main role="main">
                         <div class='container main-container'>
-                            <div data-djc-id-ca1bc45>BLOCK OVERRIDEN</div>
-                            <custom-template data-djc-id-ca1bc45>
+                            <div data-djc-id-ca1bc42>BLOCK OVERRIDEN</div>
+                            <custom-template data-djc-id-ca1bc42>
                                 <header>SLOT OVERRIDEN</header>
                                 <main>Default main</main>
                                 <footer>Default footer</footer>
                             </custom-template>
-                            <div data-djc-id-ca1bc49>BLOCK OVERRIDEN</div>
-                            <custom-template data-djc-id-ca1bc49>
+                            <div data-djc-id-ca1bc46>BLOCK OVERRIDEN</div>
+                            <custom-template data-djc-id-ca1bc46>
                                 <header>SLOT OVERRIDEN 2</header>
                                 <main>Default main</main>
                                 <footer>Default footer</footer>
@@ -131,7 +131,6 @@ class TestExtendsCompat:
                 </body>
             </html>
         """
-
         assertHTMLEqual(rendered, expected)
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
@@ -181,14 +180,14 @@ class TestExtendsCompat:
                 <body>
                     <main role="main">
                         <div class='container main-container'>
-                            <div data-djc-id-ca1bc45>BLOCK OVERRIDEN</div>
-                            <custom-template data-djc-id-ca1bc45>
+                            <div data-djc-id-ca1bc42>BLOCK OVERRIDEN</div>
+                            <custom-template data-djc-id-ca1bc42>
                                 <header>SLOT OVERRIDEN</header>
                                 <main>Default main</main>
                                 <footer>Default footer</footer>
                             </custom-template>
-                            <div data-djc-id-ca1bc49>BLOCK OVERRIDEN</div>
-                            <custom-template data-djc-id-ca1bc49>
+                            <div data-djc-id-ca1bc46>BLOCK OVERRIDEN</div>
+                            <custom-template data-djc-id-ca1bc46>
                                 <header>SLOT OVERRIDEN 2</header>
                                 <main>Default main</main>
                                 <footer>Default footer</footer>
@@ -246,14 +245,14 @@ class TestExtendsCompat:
                 <body>
                     <main role="main">
                         <div class='container main-container'>
-                            <div data-djc-id-ca1bc45>BLOCK OVERRIDEN</div>
-                            <custom-template data-djc-id-ca1bc45>
+                            <div data-djc-id-ca1bc42>BLOCK OVERRIDEN</div>
+                            <custom-template data-djc-id-ca1bc42>
                                 <header>SLOT OVERRIDEN</header>
                                 <main>Default main</main>
                                 <footer>Default footer</footer>
                             </custom-template>
-                            <div data-djc-id-ca1bc49>BLOCK OVERRIDEN</div>
-                            <custom-template data-djc-id-ca1bc49>
+                            <div data-djc-id-ca1bc46>BLOCK OVERRIDEN</div>
+                            <custom-template data-djc-id-ca1bc46>
                                 <header>SLOT OVERRIDEN 2</header>
                                 <main>Default main</main>
                                 <footer>Default footer</footer>
@@ -351,8 +350,8 @@ class TestExtendsCompat:
                         <main>Default main</main>
                         <footer>Default footer</footer>
                     </custom-template>
-                    <div data-djc-id-ca1bc49>BLOCK OVERRIDEN</div>
-                    <custom-template data-djc-id-ca1bc49>
+                    <div data-djc-id-ca1bc46>BLOCK OVERRIDEN</div>
+                    <custom-template data-djc-id-ca1bc46>
                         <header>SLOT OVERRIDEN 2</header>
                         <main>Default main</main>
                         <footer>Default footer</footer>
@@ -399,7 +398,7 @@ class TestExtendsCompat:
                 <body>
                     <main role="main">
                         <div class='container main-container'>
-                            <custom-template data-djc-id-ca1bc48>
+                            <custom-template data-djc-id-ca1bc42>
                                 <header>Default header</header>
                                 <main>
                                     <div data-djc-id-ca1bc49>BLOCK OVERRIDEN</div>
@@ -445,7 +444,7 @@ class TestExtendsCompat:
                     <main role="main">
                         <div class='container main-container'>
                             Variable: <strong></strong>
-                            Variable: <strong data-djc-id-ca1bc45></strong>
+                            Variable: <strong data-djc-id-ca1bc3f></strong>
                         </div>
                     </main>
                 </body>
@@ -463,7 +462,7 @@ class TestExtendsCompat:
                     <main role="main">
                         <div class='container main-container'>
                             Variable: <strong></strong>
-                            Variable: <strong data-djc-id-ca1bc47></strong>
+                            Variable: <strong data-djc-id-ca1bc41></strong>
                         </div>
                     </main>
                 </body>
@@ -494,7 +493,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html data-djc-id-ca1bc40 lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc48>
+                <custom-template data-djc-id-ca1bc45>
                     <header></header>
                     <main>BODY_FROM_FILL</main>
                     <footer>Default footer</footer>
@@ -527,7 +526,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html data-djc-id-ca1bc40 lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc48>
+                <custom-template data-djc-id-ca1bc45>
                     <header></header>
                     <main>BODY_FROM_FILL</main>
                     <footer>Default footer</footer>
@@ -560,7 +559,7 @@ class TestExtendsCompat:
             <body>
                 <main role="main">
                     <div class='container main-container'>
-                        <custom-template data-djc-id-ca1bc45>
+                        <custom-template data-djc-id-ca1bc42>
                             <header></header>
                             <main>TEST</main>
                             <footer></footer>
@@ -589,7 +588,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc44>
+                <custom-template data-djc-id-ca1bc41>
                     <header></header>
                     <main>
                         <div> 58 giraffes and 2 pantaloons </div>
@@ -618,7 +617,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html data-djc-id-ca1bc3f lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc46>
+                <custom-template data-djc-id-ca1bc43>
                     <header></header>
                     <main>
                         <div> 58 giraffes and 2 pantaloons </div>
@@ -658,7 +657,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html data-djc-id-ca1bc40 lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc48>
+                <custom-template data-djc-id-ca1bc49>
                     <header></header>
                     <main>BODY_FROM_FILL</main>
                     <footer>Default footer</footer>
@@ -688,7 +687,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html data-djc-id-ca1bc3f lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc47>
+                <custom-template data-djc-id-ca1bc44>
                     <header></header>
                     <main>
                         Helloodiddoo
@@ -724,7 +723,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html data-djc-id-ca1bc3f lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc47>
+                <custom-template data-djc-id-ca1bc44>
                     <header></header>
                     <main>
                         Helloodiddoo
@@ -760,7 +759,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html data-djc-id-ca1bc40 lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc48>
+                <custom-template data-djc-id-ca1bc45>
                     <header></header>
                     <main>
                         Helloodiddoo
@@ -806,7 +805,7 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html data-djc-id-ca1bc41 lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc4a>
+                <custom-template data-djc-id-ca1bc47>
                     <header></header>
                     <main>
                         Helloodiddoo
@@ -846,10 +845,10 @@ class TestExtendsCompat:
             <!DOCTYPE html>
             <html lang="en">
             <body>
-                <custom-template data-djc-id-ca1bc47>
+                <custom-template data-djc-id-ca1bc44>
                     <header></header>
                     <main>
-                        <div data-djc-id-ca1bc48> injected: DepInject(hello='from_block') </div>
+                        <div data-djc-id-ca1bc4b> injected: DepInject(hello='from_block') </div>
                     </main>
                     <footer>Default footer</footer>
                 </custom-template>

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -42,7 +42,6 @@ def setup_test_config(
             }
         ],
         "COMPONENTS": {
-            "template_cache_size": 128,
             **(components or {}),
         },
         "MIDDLEWARE": [],

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -37,7 +37,15 @@ def setup_test_config(
                 "OPTIONS": {
                     "builtins": [
                         "django_components.templatetags.component_tags",
-                    ]
+                    ],
+                    'loaders': [
+                        # Default Django loader
+                        'django.template.loaders.filesystem.Loader',
+                        # Including this is the same as APP_DIRS=True
+                        'django.template.loaders.app_directories.Loader',
+                        # Components loader
+                        'django_components.template_loader.Loader',
+                    ],
                 },
             }
         ],


### PR DESCRIPTION
Sorry for big PR, I already removed one part of it, but what remains is all too closely related.

Changes:

## Component template API

Changes that relate to how the component templates are loaded / created:

- `Component.template` no longer accepts a Template instance*, only plain string.
- `Component.get_template_name()` and `Component.get_template()` are now deprecated. 

In other words, the Template should now be specified as plain string (`Component.template`) or file (`Component.template_file`).

With these changes, we will have control over how the template string is compiled into `Template` instance, and will allow us (or our extensions) to pre-process the template. Thus we can implement Vue-like or django-cotton-like syntax as an extension.

As a side effect, we can also deprecate `template_cache_size` setting and `cached_template()` helper, since these were related to caching `Template` instances from those deprecated source above.

\* NOTE: This was something I introduced long time ago, but I don't think it was every properly documented.

## Associating Templates with Components

There's two use cases for which I need to be able to know if a loaded `Template` belongs to a component or not:

1. Pre-processing component templates
2. Know in which Component a `{% slot %}` tag was defined, so we can apply CSS scoping for that Component class.

Implementation:
 - To make it possible to write extensions for using Vue / django-cotton / markdown syntax instead of vanilla HTML + Django, I need to be able to modify the raw template string before Django compiles it into Template / NodeList.

 - When a template is inlined within Component as `Component.template = "<div>...<div>"`, this is easy, because we directly have the string available.
 - But when the template is loaded from file as `Component.template_file = "my_file.html"`, this is a problem, because it's Django who does both the file reading and template compiling.
 - I found a way to intercept this process by overriding the `Template.__init__()` method because this is when Django compiles the template (https://github.com/django-components/django-components/pull/1222/files#diff-6cad9d5565786c00d355ba20ae181e9ebc658eca28f7d762dd588172c0d6fdc6R26)
 - The problem, still was - even if I intercept calls to `Template.__init__()`, how do I know if the template that is being instantiated belongs to a Component?
 - The solution was hacky, but, well, it works (and most of the complexity is hidden away in the `template.py` file):
   1. When a Component class is defined, we remember if the component specified a file under `Component.template_file` (see https://github.com/django-components/django-components/pull/1222/files#diff-35c84ebceae50f7149f03bbcaf2b4f1289bc2984bf7859ca521b5dbe7960c396R423)
   3. When we get around to resolving and loading component's template (it's done lazily), we hand over to Django's `get_template()`, which uses template loaders to eventually instantiate `Template`.
   4. When `Template` is instantiated like this, it receives an `Origin` object, which describes the file name from which the string was read. This means that inside `Template.__init__()`, we can access this Origin to know where the template came from.
   5. We can thus compare this file path from the Origin against the `template_file` entries we remembered from the first step (see https://github.com/django-components/django-components/pull/1222/files#diff-6cad9d5565786c00d355ba20ae181e9ebc658eca28f7d762dd588172c0d6fdc6R46 and https://github.com/django-components/django-components/pull/1222/files#diff-bfd0b555c48797bfe54ed731d42c3ef507cfc992ed1f49359f806849c20f7a21R378).
   6. Thus we are able to say that if we have found a Component class for given template file path, then the Template belongs to that Component.
 - NOTE: There is more nuance to this implementation:
    - Multiple components may use the same `template_file` (e.g. when subclassing from same base). So there was a challenge of "how do I know to which Component does this `Template` instance belong to?"
      - Trick to that was to use a global state to store the Component class that we are currently loading (see https://github.com/django-components/django-components/pull/1222/files#diff-bfd0b555c48797bfe54ed731d42c3ef507cfc992ed1f49359f806849c20f7a21R169)
        - -> If it is set, that's the one
        - -> If not set, then the `Template` instance is NOT being created by us, and so we DON'T associate the Component class to it.
      - Another tricky part of multiple components with same `template_file` is that when you use cached loader, then the `Template` instance is reused. So we have to check for that and make `Template` copies. (see https://github.com/django-components/django-components/pull/1222/commits/0e6965d4dd75a4c025a62ed6bb6982acf4cad2ae)
    - This all has to be done lazily. Because if `Component.template_file` is defined relative to the Component's file, we need to resolve that first.

 - Maybe the best way to summarize this is through code (taken from [this test](https://github.com/django-components/django-components/pull/1222/files#diff-b35cc8d48a3ea2ddde0c3bc9de0b0b768c567f9e8f532dc4ca1b260fe06e4ac8R340)):

    ```py
    # Two unrelated components point to the same template
    class SimpleComponent1(Component):
        template_file = "simple_template.html"

    class SimpleComponent2(Component):
        template_file = "simple_template.html"

    # Each component has its own Template instance
    assert isinstance(SimpleComponent1._template, Template)
    assert isinstance(SimpleComponent2._template, Template)
    assert SimpleComponent1._template is not SimpleComponent2._template
    # But still point to the same file
    assert SimpleComponent1._template.source == SimpleComponent2._template.source

    # The Templates have different Origin instances
    assert SimpleComponent1._template.origin is not SimpleComponent2._template.origin

    # And these Origins point to the respective Component classes
    assert SimpleComponent1._template.origin.component_cls == SimpleComponent1
    assert SimpleComponent2._template.origin.component_cls == SimpleComponent2
    ```

Closes https://github.com/django-components/django-components/issues/901, closes https://github.com/django-components/django-components/issues/709