### PR TITLE
refactor: Add Node metadata

### DIFF
--- a/docs/concepts/advanced/template_tags.md
+++ b/docs/concepts/advanced/template_tags.md
@@ -153,12 +153,14 @@ GreetNode.register(library)
 
 When using [`BaseNode`](../../../reference/api#django_components.BaseNode), you have access to several useful properties:
 
-- `node_id`: A unique identifier for this node instance
-- `flags`: Dictionary of flag values (e.g. `{"required": True}`)
-- `params`: List of raw parameters passed to the tag
-- `nodelist`: The template nodes between the start and end tags
-- `contents`: The raw contents between the start and end tags
-- `active_flags`: List of flags that are currently set to True
+- [`node_id`](../../../reference/api#django_components.BaseNode.node_id): A unique identifier for this node instance
+- [`flags`](../../../reference/api#django_components.BaseNode.flags): Dictionary of flag values (e.g. `{"required": True}`)
+- [`params`](../../../reference/api#django_components.BaseNode.params): List of raw parameters passed to the tag
+- [`nodelist`](../../../reference/api#django_components.BaseNode.nodelist): The template nodes between the start and end tags
+- [`contents`](../../../reference/api#django_components.BaseNode.contents): The raw contents between the start and end tags
+- [`active_flags`](../../../reference/api#django_components.BaseNode.active_flags): List of flags that are currently set to True
+- [`template_name`](../../../reference/api#django_components.BaseNode.template_name): The name of the `Template` instance inside which the node was defined
+- [`template_component`](../../../reference/api#django_components.BaseNode.template_component): The component class that the `Template` belongs to
 
 This is what the `node` parameter in the [`@template_tag`](../../../reference/api#django_components.template_tag) decorator gives you access to - it's the instance of the node class that was automatically created for your template tag.
 

--- a/docs/concepts/fundamentals/slots.md
+++ b/docs/concepts/fundamentals/slots.md
@@ -728,7 +728,7 @@ with extra metadata:
 - [`component_name`](../../../reference/api#django_components.Slot.component_name)
 - [`slot_name`](../../../reference/api#django_components.Slot.slot_name)
 - [`nodelist`](../../../reference/api#django_components.Slot.nodelist)
-- [`source`](../../../reference/api#django_components.Slot.source)
+- [`fill_node`](../../../reference/api#django_components.Slot.fill_node)
 - [`extra`](../../../reference/api#django_components.Slot.extra)
 
 These are populated the first time a slot is passed to a component.
@@ -738,10 +738,33 @@ still point to the first component that received the slot.
 
 You can use these for debugging, such as printing out the slot's component name and slot name.
 
-Extensions can use [`Slot.source`](../../../reference/api#django_components.Slot.source)
+**Fill node**
+
+Components or extensions can use [`Slot.fill_node`](../../../reference/api#django_components.Slot.fill_node)
 to handle slots differently based on whether the slot
-was defined in the template with [`{% fill %}`](../../../reference/template_tags#fill) tag
-or in the component's Python code. See an example in [Pass slot metadata](../../advanced/extensions#pass-slot-metadata).
+was defined in the template with [`{% fill %}`](../../../reference/template_tags#fill) and
+[`{% component %}`](../../../reference/template_tags#component) tags,
+or in the component's Python code.
+
+If the slot was created from a [`{% fill %}`](../../../reference/template_tags#fill) tag,
+this will be the [`FillNode`](../../../reference/api#django_components.FillNode) instance.
+
+If the slot was a default slot created from a [`{% component %}`](../../../reference/template_tags#component) tag,
+this will be the [`ComponentNode`](../../../reference/api#django_components.ComponentNode) instance.
+
+You can use this to find the [`Component`](../../../reference/api#django_components.Component) in whose
+template the [`{% fill %}`](../../../reference/template_tags#fill) tag was defined:
+
+```python
+class MyTable(Component):
+    def get_template_data(self, args, kwargs, slots, context):
+        footer_slot = slots.get("footer")
+        if footer_slot is not None and footer_slot.fill_node is not None:
+            owner_component = footer_slot.fill_node.template_component
+            # ...
+```
+
+**Extra**
 
 You can also pass any additional data along with the slot by setting it in [`Slot.extra`](../../../reference/api#django_components.Slot.extra):
 
@@ -761,7 +784,6 @@ slot = Slot(
     # Optional
     component_name="table",
     slot_name="name",
-    source="python",
     extra={},
 )
 
@@ -770,6 +792,8 @@ slot.component_name = "table"
 slot.slot_name = "name"
 slot.extra["foo"] = "bar"
 ```
+
+Read more in [Pass slot metadata](../../advanced/extensions#pass-slot-metadata).
 
 ### Slot contents
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -47,6 +47,10 @@
     options:
       show_if_no_docstring: true
 
+::: django_components.ComponentNode
+    options:
+      show_if_no_docstring: true
+
 ::: django_components.ComponentRegistry
     options:
       show_if_no_docstring: true
@@ -83,6 +87,14 @@
     options:
       show_if_no_docstring: true
 
+::: django_components.FillNode
+    options:
+      show_if_no_docstring: true
+
+::: django_components.ProvideNode
+    options:
+      show_if_no_docstring: true
+
 ::: django_components.RegistrySettings
     options:
       show_if_no_docstring: true
@@ -108,6 +120,10 @@
       show_if_no_docstring: true
 
 ::: django_components.SlotInput
+    options:
+      show_if_no_docstring: true
+
+::: django_components.SlotNode
     options:
       show_if_no_docstring: true
 

--- a/docs/reference/extension_hooks.md
+++ b/docs/reference/extension_hooks.md
@@ -204,6 +204,7 @@ name | type | description
 `slot_is_default` | `bool` | Whether the slot is default
 `slot_is_required` | `bool` | Whether the slot is required
 `slot_name` | `str` | The name of the `{% slot %}` tag
+`slot_node` | `SlotNode` | The node instance of the `{% slot %}` tag
 
 ## Objects
 

--- a/docs/reference/template_tags.md
+++ b/docs/reference/template_tags.md
@@ -67,7 +67,7 @@ If you insert this tag multiple times, ALL JS scripts will be duplicately insert
 
 
 
-<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L3301" target="_blank">See source code</a>
+<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L3350" target="_blank">See source code</a>
 
 
 
@@ -75,7 +75,7 @@ Renders one of the components that was previously registered with
 [`@register()`](./api.md#django_components.register)
 decorator.
 
-The `{% component %}` tag takes:
+The [`{% component %}`](../template_tags#component) tag takes:
 
 - Component's registered name as the first positional argument,
 - Followed by any number of positional and keyword arguments.
@@ -92,7 +92,8 @@ The component name must be a string literal.
 ### Inserting slot fills
 
 If the component defined any [slots](../concepts/fundamentals/slots.md), you can
-"fill" these slots by placing the [`{% fill %}`](#fill) tags within the `{% component %}` tag:
+"fill" these slots by placing the [`{% fill %}`](../template_tags#fill) tags
+within the [`{% component %}`](../template_tags#component) tag:
 
 ```django
 {% component "my_table" rows=rows headers=headers %}
@@ -102,7 +103,7 @@ If the component defined any [slots](../concepts/fundamentals/slots.md), you can
 {% endcomponent %}
 ```
 
-You can even nest [`{% fill %}`](#fill) tags within
+You can even nest [`{% fill %}`](../template_tags#fill) tags within
 [`{% if %}`](https://docs.djangoproject.com/en/5.2/ref/templates/builtins/#if),
 [`{% for %}`](https://docs.djangoproject.com/en/5.2/ref/templates/builtins/#for)
 and other tags:
@@ -141,7 +142,7 @@ COMPONENTS = {
 }
 ```
 
-### Omitting the `component` keyword
+### Omitting the component keyword
 
 If you would like to omit the `component` keyword, and simply refer to your
 components by their registered names:
@@ -169,19 +170,20 @@ COMPONENTS = {
 
 
 
-<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L948" target="_blank">See source code</a>
+<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L988" target="_blank">See source code</a>
 
 
 
-Use this tag to insert content into component's slots.
+Use [`{% fill %}`](../template_tags#fill) tag to insert content into component's
+[slots](../../concepts/fundamentals/slots).
 
-`{% fill %}` tag may be used only within a `{% component %}..{% endcomponent %}` block,
+[`{% fill %}`](../template_tags#fill) tag may be used only within a `{% component %}..{% endcomponent %}` block,
 and raises a `TemplateSyntaxError` if used outside of a component.
 
 **Args:**
 
 - `name` (str, required): Name of the slot to insert this content into. Use `"default"` for
-    the default slot.
+    the [default slot](../../concepts/fundamentals/slots#default-slot).
 - `data` (str, optional): This argument allows you to access the data passed to the slot
     under the specified variable name. See [Slot data](../../concepts/fundamentals/slots#slot-data).
 - `fallback` (str, optional): This argument allows you to access the original content of the slot
@@ -266,7 +268,7 @@ Fill:
 ### Using default slot
 
 To access slot data and the fallback slot content on the default slot,
-use `{% fill %}` with `name` set to `"default"`:
+use [`{% fill %}`](../template_tags#fill) with `name` set to `"default"`:
 
 ```django
 {% component "button" %}
@@ -280,7 +282,7 @@ use `{% fill %}` with `name` set to `"default"`:
 ### Slot fills from Python
 
 You can pass a slot fill from Python to a component by setting the `body` kwarg
-on the `{% fill %}` tag.
+on the [`{% fill %}`](../template_tags#fill) tag.
 
 First pass a [`Slot`](../api#django_components.Slot) instance to the template
 with the [`get_template_data()`](../api#django_components.Component.get_template_data)
@@ -296,7 +298,7 @@ class Table(Component):
     }
 ```
 
-Then pass the slot to the `{% fill %}` tag:
+Then pass the slot to the [`{% fill %}`](../template_tags#fill) tag:
 
 ```django
 {% component "table" %}
@@ -306,7 +308,7 @@ Then pass the slot to the `{% fill %}` tag:
 
 !!! warning
 
-    If you define both the `body` kwarg and the `{% fill %}` tag's body,
+    If you define both the `body` kwarg and the [`{% fill %}`](../template_tags#fill) tag's body,
     an error will be raised.
 
     ```django
@@ -391,8 +393,11 @@ See more usage examples in
 
 
 
-The "provider" part of the [provide / inject feature](../../concepts/advanced/provide_inject).
+The [`{% provide %}`](../template_tags#provide) tag is part of the "provider" part of
+the [provide / inject feature](../../concepts/advanced/provide_inject).
+
 Pass kwargs to this tag to define the provider's data.
+
 Any components defined within the `{% provide %}..{% endprovide %}` tags will be able to access this data
 with [`Component.inject()`](../api#django_components.Component.inject).
 
@@ -445,7 +450,7 @@ class Child(Component):
         }
 ```
 
-Notice that the keys defined on the `{% provide %}` tag are then accessed as attributes
+Notice that the keys defined on the [`{% provide %}`](../template_tags#provide) tag are then accessed as attributes
 when accessing them with [`Component.inject()`](../api#django_components.Component.inject).
 
 ✅ Do this
@@ -467,11 +472,11 @@ user = self.inject("user_data")["user"]
 
 
 
-<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L474" target="_blank">See source code</a>
+<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L513" target="_blank">See source code</a>
 
 
 
-Slot tag marks a place inside a component where content can be inserted
+[`{% slot %}`](../template_tags#slot) tag marks a place inside a component where content can be inserted
 from outside.
 
 [Learn more](../../concepts/fundamentals/slots) about using slots.
@@ -485,7 +490,7 @@ or [React's `children`](https://react.dev/learn/passing-props-to-a-component#pas
 
 - `name` (str, required): Registered name of the component to render
 - `default`: Optional flag. If there is a default slot, you can pass the component slot content
-    without using the [`{% fill %}`](#fill) tag. See
+    without using the [`{% fill %}`](../template_tags#fill) tag. See
     [Default slot](../../concepts/fundamentals/slots#default-slot)
 - `required`: Optional flag. Will raise an error if a slot is required but not given.
 - `**kwargs`: Any extra kwargs will be passed as the slot data.
@@ -527,8 +532,8 @@ class Parent(Component):
 
 ### Slot data
 
-Any extra kwargs will be considered as slot data, and will be accessible in the [`{% fill %}`](#fill)
-tag via fill's `data` kwarg:
+Any extra kwargs will be considered as slot data, and will be accessible
+in the [`{% fill %}`](../template_tags#fill) tag via fill's `data` kwarg:
 
 Read more about [Slot data](../../concepts/fundamentals/slots#slot-data).
 
@@ -565,8 +570,8 @@ class Parent(Component):
 The content between the `{% slot %}..{% endslot %}` tags is the fallback content that
 will be rendered if no fill is given for the slot.
 
-This fallback content can then be accessed from within the [`{% fill %}`](#fill) tag using
-the fill's `fallback` kwarg.
+This fallback content can then be accessed from within the [`{% fill %}`](../template_tags#fill) tag
+using the fill's `fallback` kwarg.
 This is useful if you need to wrap / prepend / append the original slot's content.
 
 ```djc_py

--- a/src/django_components/__init__.py
+++ b/src/django_components/__init__.py
@@ -18,6 +18,7 @@ from django_components.util.command import (
 from django_components.component import (
     Component,
     ComponentInput,
+    ComponentNode,
     ComponentVars,
     all_components,
     get_component_by_class_id,
@@ -52,13 +53,16 @@ from django_components.extensions.debug_highlight import ComponentDebugHighlight
 from django_components.extensions.view import ComponentView, get_component_url
 from django_components.library import TagProtectedError
 from django_components.node import BaseNode, template_tag
+from django_components.provide import ProvideNode
 from django_components.slots import (
+    FillNode,
     Slot,
     SlotContent,
     SlotContext,
     SlotFallback,
     SlotFunc,
     SlotInput,
+    SlotNode,
     SlotRef,
     SlotResult,
 )
@@ -103,6 +107,7 @@ __all__ = [
     "ComponentInput",
     "ComponentMediaInput",
     "ComponentMediaInputPath",
+    "ComponentNode",
     "ComponentRegistry",
     "ComponentVars",
     "ComponentView",
@@ -115,6 +120,7 @@ __all__ = [
     "DynamicComponent",
     "Empty",
     "ExtensionComponentConfig",
+    "FillNode",
     "format_attributes",
     "get_component_by_class_id",
     "get_component_dirs",
@@ -131,6 +137,7 @@ __all__ = [
     "OnComponentUnregisteredContext",
     "OnRegistryCreatedContext",
     "OnRegistryDeletedContext",
+    "ProvideNode",
     "register",
     "registry",
     "RegistrySettings",
@@ -142,6 +149,7 @@ __all__ = [
     "SlotFallback",
     "SlotFunc",
     "SlotInput",
+    "SlotNode",
     "SlotRef",
     "SlotResult",
     "TagFormatterABC",

--- a/src/django_components/extension.py
+++ b/src/django_components/extension.py
@@ -28,7 +28,7 @@ from django_components.util.routing import URLRoute
 if TYPE_CHECKING:
     from django_components import Component
     from django_components.component_registry import ComponentRegistry
-    from django_components.slots import Slot, SlotResult
+    from django_components.slots import Slot, SlotNode, SlotResult
 
 
 TCallable = TypeVar("TCallable", bound=Callable)
@@ -155,6 +155,8 @@ class OnSlotRenderedContext(NamedTuple):
     """The Slot instance that was rendered"""
     slot_name: str
     """The name of the `{% slot %}` tag"""
+    slot_node: "SlotNode"
+    """The node instance of the `{% slot %}` tag"""
     slot_is_required: bool
     """Whether the slot is required"""
     slot_is_default: bool
@@ -743,6 +745,26 @@ class ComponentExtension(metaclass=ExtensionMeta):
             def on_slot_rendered(self, ctx: OnSlotRenderedContext) -> Optional[str]:
                 # Append a comment to the slot's rendered output
                 return ctx.result + "<!-- MyExtension comment -->"
+        ```
+
+        **Access slot metadata:**
+
+        You can access the [`{% slot %}` tag](../template_tags#slot)
+        node ([`SlotNode`](../api#django_components.SlotNode)) and its metadata using `ctx.slot_node`.
+
+        For example, to find the [`Component`](../api#django_components.Component) class to which
+        belongs the template where the [`{% slot %}`](../template_tags#slot) tag is defined, you can use
+        [`ctx.slot_node.template_component`](../api#django_components.SlotNode.template_component):
+
+        ```python
+        from django_components import ComponentExtension, OnSlotRenderedContext
+
+        class MyExtension(ComponentExtension):
+            def on_slot_rendered(self, ctx: OnSlotRenderedContext) -> Optional[str]:
+                # Access slot metadata
+                slot_node = ctx.slot_node
+                slot_owner = slot_node.template_component
+                print(f"Slot owner: {slot_owner}")
         ```
         """
         pass

--- a/src/django_components/provide.py
+++ b/src/django_components/provide.py
@@ -12,8 +12,11 @@ from django_components.util.misc import gen_id
 
 class ProvideNode(BaseNode):
     """
-    The "provider" part of the [provide / inject feature](../../concepts/advanced/provide_inject).
+    The [`{% provide %}`](../template_tags#provide) tag is part of the "provider" part of
+    the [provide / inject feature](../../concepts/advanced/provide_inject).
+
     Pass kwargs to this tag to define the provider's data.
+
     Any components defined within the `{% provide %}..{% endprovide %}` tags will be able to access this data
     with [`Component.inject()`](../api#django_components.Component.inject).
 
@@ -66,7 +69,7 @@ class ProvideNode(BaseNode):
             }
     ```
 
-    Notice that the keys defined on the `{% provide %}` tag are then accessed as attributes
+    Notice that the keys defined on the [`{% provide %}`](../template_tags#provide) tag are then accessed as attributes
     when accessing them with [`Component.inject()`](../api#django_components.Component.inject).
 
     ✅ Do this

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -3,6 +3,7 @@ Tests focusing on the Component class.
 For tests focusing on the `component` tag, see `test_templatetags_component.py`
 """
 
+import os
 import re
 from typing import Any, NamedTuple
 
@@ -661,7 +662,11 @@ class TestComponentRenderAPI:
 
         assert comp.node is not None
         assert comp.node.template_component == Outer
-        assert comp.node.template_name.endswith("tests/test_component.py::Outer")  # type: ignore
+
+        if os.name == "nt":
+            assert comp.node.template_name.endswith("tests\\test_component.py::Outer")  # type: ignore
+        else:
+            assert comp.node.template_name.endswith("tests/test_component.py::Outer")  # type: ignore
 
     def test_metadata__python(self):
         comp: Any = None

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -17,6 +17,7 @@ from pytest_django.asserts import assertHTMLEqual, assertInHTML
 
 from django_components import (
     Component,
+    ComponentRegistry,
     ComponentView,
     Slot,
     SlotInput,
@@ -597,6 +598,106 @@ class TestComponentRenderAPI:
         assert comp.kwargs == {}  # type: ignore[attr-defined]
         assert comp.slots == {}  # type: ignore[attr-defined]
         assert comp.context == Context()  # type: ignore[attr-defined]
+
+    def test_metadata__template(self):
+        comp: Any = None
+
+        @register("test")
+        class TestComponent(Component):
+            template = "hello"
+
+            def get_template_data(self, args, kwargs, slots, context):
+                nonlocal comp
+                comp = self
+
+        template_str: types.django_html = """
+            {% load component_tags %}
+            <div class="test-component">
+                {% component "test" / %}
+            </div>
+        """
+        template = Template(template_str)
+        rendered = template.render(Context())
+
+        assertHTMLEqual(rendered, '<div class="test-component">hello</div>')
+
+        assert isinstance(comp, TestComponent)
+
+        assert isinstance(comp.outer_context, Context)
+        assert comp.outer_context == Context()
+
+        assert isinstance(comp.registry, ComponentRegistry)
+        assert comp.registered_name == "test"
+
+        assert comp.node is not None
+        assert comp.node.template_component is None
+        assert comp.node.template_name == "<unknown source>"
+
+    def test_metadata__component(self):
+        comp: Any = None
+
+        @register("test")
+        class TestComponent(Component):
+            template = "hello"
+
+            def get_template_data(self, args, kwargs, slots, context):
+                nonlocal comp
+                comp = self
+
+        class Outer(Component):
+            template = "{% component 'test' only / %}"
+
+        rendered = Outer.render()
+
+        assert rendered == 'hello'
+
+        assert isinstance(comp, TestComponent)
+
+        assert isinstance(comp.outer_context, Context)
+        assert comp.outer_context is not comp.context
+
+        assert isinstance(comp.registry, ComponentRegistry)
+        assert comp.registered_name == "test"
+
+        assert comp.node is not None
+        assert comp.node.template_component == Outer
+        assert comp.node.template_name.endswith("tests/test_component.py::Outer")  # type: ignore
+
+    def test_metadata__python(self):
+        comp: Any = None
+
+        @register("test")
+        class TestComponent(Component):
+            template = "hello"
+
+            def get_template_data(self, args, kwargs, slots, context):
+                nonlocal comp
+                comp = self
+
+        rendered = TestComponent.render(
+            context=Context(),
+            args=(),
+            kwargs={},
+            slots={},
+            deps_strategy="document",
+            render_dependencies=True,
+            request=None,
+            outer_context=Context(),
+            registry=ComponentRegistry(),
+            registered_name="test",
+        )
+
+        assert rendered == 'hello'
+
+        assert isinstance(comp, TestComponent)
+
+        assert isinstance(comp.outer_context, Context)
+        assert comp.outer_context == Context()
+
+        assert isinstance(comp.registry, ComponentRegistry)
+        assert comp.registered_name == "test"
+
+        assert comp.node is None
 
 
 @djc_test

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -6,7 +6,7 @@ from django.http import HttpRequest, HttpResponse
 from django.template import Context
 from django.test import Client
 
-from django_components import Component, Slot, register, registry
+from django_components import Component, Slot, SlotNode, register, registry
 from django_components.app_settings import app_settings
 from django_components.component_registry import ComponentRegistry
 from django_components.extension import (
@@ -138,6 +138,13 @@ class DummyNestedExtension(ComponentExtension):
 
 class RenderExtension(ComponentExtension):
     name = "render"
+
+
+class SlotOverrideExtension(ComponentExtension):
+    name = "slot_override"
+
+    def on_slot_rendered(self, ctx: OnSlotRenderedContext):
+        return "OVERRIDEN BY EXTENSION"
 
 
 def with_component_cls(on_created: Callable):
@@ -341,12 +348,14 @@ class TestExtensionHooks:
 
         # Render the component with some args and kwargs
         test_context = Context({"foo": "bar"})
-        TestComponent.render(
+        rendered = TestComponent.render(
             context=test_context,
             args=("arg1", "arg2"),
             kwargs={"name": "Test"},
             slots={"content": "Some content"},
         )
+
+        assert rendered == "Hello Some content!"
 
         extension = cast(DummyExtension, app_settings.EXTENSIONS[4])
 
@@ -359,9 +368,24 @@ class TestExtensionHooks:
         assert slot_call.component_id == "ca1bc3e"
         assert isinstance(slot_call.slot, Slot)
         assert slot_call.slot_name == "content"
+        assert isinstance(slot_call.slot_node, SlotNode)
+        assert slot_call.slot_node.template_name.endswith("tests/test_extension.py::TestComponent")  # type: ignore
+        assert slot_call.slot_node.template_component == TestComponent
         assert slot_call.slot_is_required is True
         assert slot_call.slot_is_default is True
         assert slot_call.result == "Some content"
+
+    @djc_test(components_settings={"extensions": [SlotOverrideExtension]})
+    def test_on_slot_rendered__override(self):
+        @register("test_comp")
+        class TestComponent(Component):
+            template = "Hello {% slot 'content' required default / %}!"
+
+        rendered = TestComponent.render(
+            slots={"content": "Some content"},
+        )
+
+        assert rendered == "Hello OVERRIDEN BY EXTENSION!"
 
 
 @djc_test

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -369,7 +369,7 @@ class TestExtensionHooks:
         assert isinstance(slot_call.slot, Slot)
         assert slot_call.slot_name == "content"
         assert isinstance(slot_call.slot_node, SlotNode)
-        assert slot_call.slot_node.template_name.endswith("tests/test_extension.py::TestComponent")  # type: ignore
+        assert slot_call.slot_node.template_name.endswith("test_extension.py::TestComponent")  # type: ignore
         assert slot_call.slot_node.template_component == TestComponent
         assert slot_call.slot_is_required is True
         assert slot_call.slot_is_default is True

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -957,7 +957,7 @@ class TestSignatureBasedValidation:
         assert contents4 is None  # type: ignore
         assert node_id4 == "a1bc42"  # type: ignore
 
-        if os.name == 'nt':
+        if os.name == "nt":
             assert cast(str, template_name4).endswith("\\tests\\test_node.py::TestComponent")  # type: ignore
         else:
             assert cast(str, template_name4).endswith("/tests/test_node.py::TestComponent")  # type: ignore

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,12 +1,15 @@
 import inspect
+import os
 import re
+from typing import cast
+
 import pytest
 from django.template import Context, Template
 from django.template.base import TextNode, VariableNode
 from django.template.defaulttags import IfNode, LoremNode
 from django.template.exceptions import TemplateSyntaxError
 
-from django_components import types
+from django_components import Component, types
 from django_components.node import BaseNode, template_tag
 from django_components.templatetags import component_tags
 from django_components.util.tag_parser import TagAttr
@@ -849,7 +852,14 @@ class TestSignatureBasedValidation:
             @force_signature_validation
             def render(self, context: Context, name: str, **kwargs) -> str:
                 nonlocal captured
-                captured = self.params, self.nodelist, self.node_id, self.contents
+                captured = (
+                    self.params,
+                    self.nodelist,
+                    self.node_id,
+                    self.contents,
+                    self.template_name,
+                    self.template_component,
+                )
                 return f"Hello, {name}!"
 
         # Case 1 - Node with end tag and NOT self-closing
@@ -864,7 +874,7 @@ class TestSignatureBasedValidation:
         template1 = Template(template_str1)
         template1.render(Context({}))
 
-        params1, nodelist1, node_id1, contents1 = captured  # type: ignore
+        params1, nodelist1, node_id1, contents1, template_name1, template_component1 = captured  # type: ignore
         assert len(params1) == 1
         assert isinstance(params1[0], TagAttr)
         # NOTE: The comment node is not included in the nodelist
@@ -879,6 +889,8 @@ class TestSignatureBasedValidation:
         assert isinstance(nodelist1[7], TextNode)
         assert contents1 == "\n              INSIDE TAG {{ my_var }} {# comment #} {% lorem 1 w %} {% if True %} henlo {% endif %}\n            "  # noqa: E501
         assert node_id1 == "a1bc3e"
+        assert template_name1 == '<unknown source>'
+        assert template_component1 is None
 
         captured = None  # Reset captured
 
@@ -890,12 +902,14 @@ class TestSignatureBasedValidation:
         template2 = Template(template_str2)
         template2.render(Context({}))
 
-        params2, nodelist2, node_id2, contents2 = captured  # type: ignore
+        params2, nodelist2, node_id2, contents2, template_name2, template_component2 = captured  # type: ignore
         assert len(params2) == 1  # type: ignore
         assert isinstance(params2[0], TagAttr)  # type: ignore
         assert len(nodelist2) == 0  # type: ignore
         assert contents2 is None  # type: ignore
         assert node_id2 == "a1bc3f"  # type: ignore
+        assert template_name2 == '<unknown source>'  # type: ignore
+        assert template_component2 is None  # type: ignore
 
         captured = None  # Reset captured
 
@@ -906,7 +920,7 @@ class TestSignatureBasedValidation:
             @force_signature_validation
             def render(self, context: Context, name: str, **kwargs) -> str:
                 nonlocal captured
-                captured = self.params, self.nodelist, self.node_id, self.contents
+                captured = self.params, self.nodelist, self.node_id, self.contents, self.template_name, self.template_component  # noqa: E501
                 return f"Hello, {name}!"
 
         TestNodeWithoutEndTag.register(component_tags.register)
@@ -918,12 +932,38 @@ class TestSignatureBasedValidation:
         template3 = Template(template_str3)
         template3.render(Context({}))
 
-        params3, nodelist3, node_id3, contents3 = captured  # type: ignore
+        params3, nodelist3, node_id3, contents3, template_name3, template_component3 = captured  # type: ignore
         assert len(params3) == 1  # type: ignore
         assert isinstance(params3[0], TagAttr)  # type: ignore
         assert len(nodelist3) == 0  # type: ignore
         assert contents3 is None  # type: ignore
         assert node_id3 == "a1bc40"  # type: ignore
+        assert template_name3 == '<unknown source>'  # type: ignore
+        assert template_component3 is None  # type: ignore
+
+        # Case 4 - Node nested in Component end tag
+        class TestComponent(Component):
+            template = """
+                {% load component_tags %}
+                {% mytag2 'John' %}
+            """
+
+        TestComponent.render(Context({}))
+
+        params4, nodelist4, node_id4, contents4, template_name4, template_component4 = captured  # type: ignore
+        assert len(params4) == 1  # type: ignore
+        assert isinstance(params4[0], TagAttr)  # type: ignore
+        assert len(nodelist4) == 0  # type: ignore
+        assert contents4 is None  # type: ignore
+        assert node_id4 == "a1bc42"  # type: ignore
+
+        if os.name == 'nt':
+            assert cast(str, template_name4).endswith("\\tests\\test_node.py::TestComponent")  # type: ignore
+        else:
+            assert cast(str, template_name4).endswith("/tests/test_node.py::TestComponent")  # type: ignore
+
+        assert template_name4 == f"{__file__}::TestComponent"  # type: ignore
+        assert template_component4 is TestComponent  # type: ignore
 
         # Cleanup
         TestNodeWithEndTag.unregister(component_tags.register)

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -12,7 +12,8 @@ from django.template.base import NodeList, TextNode
 from pytest_django.asserts import assertHTMLEqual
 
 from django_components import Component, register, types
-from django_components.slots import Slot, SlotContext, SlotFallback
+from django_components.component import ComponentNode
+from django_components.slots import FillNode, Slot, SlotContext, SlotFallback
 
 from django_components.testing import djc_test
 from .testutils import PARAMETRIZE_CONTEXT_BEHAVIOR, setup_test_config
@@ -431,7 +432,7 @@ class TestSlot:
         assert isinstance(first_slot_func, Slot)
         assert first_slot_func.component_name == "SimpleComponent"
         assert first_slot_func.slot_name == "first"
-        assert first_slot_func.source == "python"
+        assert first_slot_func.fill_node is None
         assert first_slot_func.extra == {}
 
         first_nodelist: NodeList = first_slot_func.nodelist
@@ -465,7 +466,7 @@ class TestSlot:
         assert isinstance(first_slot_func, Slot)
         assert first_slot_func.component_name == "SimpleComponent"
         assert first_slot_func.slot_name == "first"
-        assert first_slot_func.source == "python"
+        assert first_slot_func.fill_node is None
         assert first_slot_func.extra == {}
         assert first_slot_func.nodelist is None
 
@@ -495,7 +496,7 @@ class TestSlot:
         assert isinstance(first_slot_func, Slot)
         assert first_slot_func.component_name == "SimpleComponent"
         assert first_slot_func.slot_name == "whoop"
-        assert first_slot_func.source == "python"
+        assert first_slot_func.fill_node is None
         assert first_slot_func.extra == {"foo": "bar"}
         assert first_slot_func.nodelist is None
 
@@ -530,7 +531,7 @@ class TestSlot:
         assert isinstance(first_slot_func, Slot)
         assert first_slot_func.component_name == "test"
         assert first_slot_func.slot_name == "default"
-        assert first_slot_func.source == "template"
+        assert isinstance(first_slot_func.fill_node, ComponentNode)
         assert first_slot_func.extra == {}
 
         first_nodelist: NodeList = first_slot_func.nodelist
@@ -571,7 +572,7 @@ class TestSlot:
         assert isinstance(first_slot_func, Slot)
         assert first_slot_func.component_name == "test"
         assert first_slot_func.slot_name == "first"
-        assert first_slot_func.source == "template"
+        assert isinstance(first_slot_func.fill_node, FillNode)
         assert first_slot_func.extra == {}
 
         first_nodelist: NodeList = first_slot_func.nodelist
@@ -616,7 +617,7 @@ class TestSlot:
         assert isinstance(first_slot_func, Slot)
         assert first_slot_func.component_name == "test"
         assert first_slot_func.slot_name == "whoop"
-        assert first_slot_func.source == "template"
+        assert isinstance(first_slot_func.fill_node, FillNode)
         assert first_slot_func.extra == {"foo": "bar"}
         assert first_slot_func.nodelist is None
 


### PR DESCRIPTION
Ok, this is the last PR related to slots and after this I'm [done working on slots](https://github.com/django-components/django-components/issues/433#issuecomment-2826726311) until v1 🤞 

This PR wires up metadata, so we can trace back to their origin when we have a Component or a Slot instance:

- If component comes from `{% component %}` tag, then `Component.node` will point to the `ComponentNode`
- If a slot fill comes from `{% fill %}` tag, then `Slot.fill_node` points to `FillNode`
- If a slot fill comes from `{% component %}` tag (AKA default fill), then `Slot.fill_node` points to that `ComponentNode`.

In extensions:

- In `on_slot_rendered` hook, one can access the original `{% slot %}` tag (aka `SlotNode`) via `ctx.slot_node`.

Moreover each template tag node defined by us (with our `BaseNode`) has access to 2 new properties:
- `template_name` - The name of the `Template` instance inside which the node was defined
- `template_component` - The component class that the `Template` belongs to

In other words, if a Component was defined with a template file:

```py
class MyTable(Component):
    template_file = "path/to/template.html"
```

And the template looked like this:

```py
<div>
  {% slot "content" default / %}
</div>
```

Then `SlotNode` will have the knowledge that it was defined inside a template file named `"path/to/template.html"`
and inside a Component `MyTable`.

Overall, this is a more general approach to what I previously did with `Slot.source`, which distinguished between if the slot was defined in a template or in Python. So I removed the `Slot.source` attribute.