### PR TITLE
refactor: deprecate Component.input and add raw_args, raw_kwargs, raw_slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -609,9 +609,9 @@ Summary:
     ```py
     class MyComponent(Component):
         def on_render(self, context, template):
-            assert self.raw_args == [1, 2, 3]
-            assert self.raw_kwargs == {"a": 1, "b": 2}
-            assert self.raw_slots == {"my_slot": "CONTENT"}
+            assert self.args == [1, 2, 3]
+            assert self.kwargs == {"a": 1, "b": 2}
+            assert self.slots == {"my_slot": "CONTENT"}
             assert self.context == {"my_slot": "CONTENT"}
             assert self.deps_strategy == "document"
             assert (self.deps_strategy != "ignore") is True

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -586,6 +586,66 @@ Summary:
     )
     ```
 
+- `Component.input` (and its type `ComponentInput`) is now deprecated. The `input` property will be removed in v1.
+
+    Instead, use attributes directly on the Component instance.
+
+    Before:
+
+    ```py
+    class MyComponent(Component):
+        def on_render(self, context, template):
+            assert self.input.args == [1, 2, 3]
+            assert self.input.kwargs == {"a": 1, "b": 2}
+            assert self.input.slots == {"my_slot": "CONTENT"}
+            assert self.input.context == {"my_slot": "CONTENT"}
+            assert self.input.deps_strategy == "document"
+            assert self.input.type == "document"
+            assert self.input.render_dependencies == True
+    ```
+
+    After:
+
+    ```py
+    class MyComponent(Component):
+        def on_render(self, context, template):
+            assert self.raw_args == [1, 2, 3]
+            assert self.raw_kwargs == {"a": 1, "b": 2}
+            assert self.raw_slots == {"my_slot": "CONTENT"}
+            assert self.context == {"my_slot": "CONTENT"}
+            assert self.deps_strategy == "document"
+            assert (self.deps_strategy != "ignore") is True
+    ```
+
+- Component method `on_render_after` was updated to receive also `error` field.
+
+    For backwards compatibility, the `error` field can be omitted until v1.
+
+    Before:
+
+    ```py
+    def on_render_after(
+        self,
+        context: Context,
+        template: Template,
+        html: str,
+    ) -> None:
+        pass
+    ```
+    
+    After:
+
+    ```py
+    def on_render_after(
+        self,
+        context: Context,
+        template: Template,
+        html: Optional[str],
+        error: Optional[Exception],
+    ) -> None:
+        pass
+    ```
+
 - If you are using the Components as views, the way to access the component class is now different.
 
     Instead of `self.component`, use `self.component_cls`. `self.component` will be removed in v1.
@@ -946,6 +1006,22 @@ Summary:
 
     Same as with the parameters in `Component.get_template_data()`, they will be instances of the `Args`, `Kwargs`, `Slots` classes
     if defined, or plain lists / dictionaries otherwise.
+
+- 4 attributes that were previously available only under the `Component.input` attribute
+    are now available directly on the Component instance:
+
+    - `Component.raw_args`
+    - `Component.raw_kwargs`
+    - `Component.raw_slots`
+    - `Component.deps_strategy`
+
+    The first 3 attributes are the same as the deprecated `Component.input.args`, `Component.input.kwargs`, `Component.input.slots` properties.
+
+    Compared to the `Component.args` / `Component.kwargs` / `Component.slots` attributes,
+    these "raw" attributes are not typed and will remain as plain lists / dictionaries
+    even if you define the `Args`, `Kwargs`, `Slots` classes.
+
+    The `Component.deps_strategy` attribute is the same as the deprecated `Component.input.deps_strategy` property.
 
 - New template variables `{{ component_vars.args }}`, `{{ component_vars.kwargs }}`, `{{ component_vars.slots }}`
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ class Table(Component):
         assert self.args == [123, "str"]
         assert self.kwargs == {"variable": "test", "another": 1}
         footer_slot = self.slots["footer"]
-        some_var = self.input.context["some_var"]
+        some_var = self.context["some_var"]
 
         # Access the request object and Django's context processors, if available
         assert self.request.GET == {"query": "something"}

--- a/docs/concepts/fundamentals/component_defaults.md
+++ b/docs/concepts/fundamentals/component_defaults.md
@@ -80,7 +80,7 @@ and so `selected_items` will be set to `[1, 2, 3]`.
 
     This is **NOT recommended**, because:
 
-    - The defaults will NOT be applied to inputs when using [`self.input`](../../../reference/api/#django_components.Component.input) property.
+    - The defaults will NOT be applied to inputs when using [`self.raw_kwargs`](../../../reference/api/#django_components.Component.raw_kwargs) property.
     - The defaults will NOT be applied when a field is given but set to `None`.
 
     Instead, define the defaults in the [`Defaults`](../../../reference/api/#django_components.Component.Defaults) class.

--- a/docs/concepts/fundamentals/html_js_css_variables.md
+++ b/docs/concepts/fundamentals/html_js_css_variables.md
@@ -241,7 +241,23 @@ class ProfileCard(Component):
             }
     ```
 
+<!-- TODO_v1 - Remove -->
+
 ### `input` property (low-level)
+
+!!! warning
+
+    The `input` property is deprecated and will be removed in v1.
+
+    Instead, use properties defined on the
+    [`Component`](../../../reference/api/#django_components.Component) class
+    directly like
+    [`self.context`](../../../reference/api/#django_components.Component.context).
+
+    To access the unmodified inputs, use
+    [`self.raw_args`](../../../reference/api/#django_components.Component.raw_args),
+    [`self.raw_kwargs`](../../../reference/api/#django_components.Component.raw_kwargs),
+    and [`self.raw_slots`](../../../reference/api/#django_components.Component.raw_slots) properties.
 
 The previous two approaches allow you to access only the most important inputs.
 
@@ -259,8 +275,6 @@ This includes:
 - [`input.context`](../../../reference/api/#django_components.ComponentInput.context) - [`Context`](https://docs.djangoproject.com/en/5.2/ref/templates/api/#django.template.Context) object that should be used to render the component
 - [`input.type`](../../../reference/api/#django_components.ComponentInput.type) - The type of the component (document, fragment)
 - [`input.render_dependencies`](../../../reference/api/#django_components.ComponentInput.render_dependencies) - Whether to render dependencies (CSS, JS)
-
-For more details, see [Component inputs](../render_api/#other-inputs).
 
 ```python
 class ProfileCard(Component):
@@ -336,7 +350,7 @@ class ProfileCard(Component):
 
     This is **NOT recommended**, because:
 
-    - The defaults will NOT be applied to inputs when using [`self.input`](../../../reference/api/#django_components.Component.input) property.
+    - The defaults will NOT be applied to inputs when using [`self.raw_kwargs`](../../../reference/api/#django_components.Component.raw_kwargs) property.
     - The defaults will NOT be applied when a field is given but set to `None`.
 
     Instead, define the defaults in the [`Defaults`](../../../reference/api/#django_components.Component.Defaults) class.
@@ -348,8 +362,10 @@ All three data methods have access to the Component's [Render API](../render_api
 - [`self.args`](../render_api/#args) - The positional arguments for the current render call
 - [`self.kwargs`](../render_api/#kwargs) - The keyword arguments for the current render call
 - [`self.slots`](../render_api/#slots) - The slots for the current render call
+- [`self.raw_args`](../render_api/#args) - Unmodified positional arguments for the current render call
+- [`self.raw_kwargs`](../render_api/#kwargs) - Unmodified keyword arguments for the current render call
+- [`self.raw_slots`](../render_api/#slots) - Unmodified slots for the current render call
 - [`self.context`](../render_api/#context) - The context for the current render call
-- [`self.input`](../render_api/#other-inputs) - All the component inputs
 - [`self.id`](../render_api/#component-id) - The unique ID for the current render call
 - [`self.request`](../render_api/#request-and-context-processors) - The request object
 - [`self.context_processors_data`](../render_api/#request-and-context-processors) - Data from Django's context processors
@@ -357,6 +373,7 @@ All three data methods have access to the Component's [Render API](../render_api
 - [`self.registry`](../render_api/#template-tag-metadata) - The [`ComponentRegistry`](../../../reference/api/#django_components.ComponentRegistry) instance
 - [`self.registered_name`](../render_api/#template-tag-metadata) - The name under which the component was registered
 - [`self.outer_context`](../render_api/#template-tag-metadata) - The context outside of the [`{% component %}`](../../../reference/template_tags#component) tag
+- `self.deps_strategy` - The strategy for rendering dependencies
 
 ## Type hints
 
@@ -399,7 +416,11 @@ class Button(Component):
 
 !!! note
 
-    The data available via [`self.input`](../../../reference/api/#django_components.Component.input) property is NOT typed.
+    To access "untyped" inputs, use [`self.raw_args`](../../../reference/api/#django_components.Component.raw_args),
+    [`self.raw_kwargs`](../../../reference/api/#django_components.Component.raw_kwargs),
+    and [`self.raw_slots`](../../../reference/api/#django_components.Component.raw_slots) properties.
+
+    These are plain lists and dictionaries, even when you added typing to your component.
 
 ### Typing data
 

--- a/docs/concepts/fundamentals/render_api.md
+++ b/docs/concepts/fundamentals/render_api.md
@@ -24,7 +24,7 @@ class Table(Component):
         assert self.args == [123, "str"]
         assert self.kwargs == {"variable": "test", "another": 1}
         footer_slot = self.slots["footer"]
-        some_var = self.input.context["some_var"]
+        some_var = self.context["some_var"]
 
     def get_template_data(self, args, kwargs, slots, context):
         # Access the request object and Django's context processors, if available
@@ -46,8 +46,11 @@ The Render API includes:
     - [`self.args`](../render_api/#args) - The positional arguments for the current render call
     - [`self.kwargs`](../render_api/#kwargs) - The keyword arguments for the current render call
     - [`self.slots`](../render_api/#slots) - The slots for the current render call
+    - [`self.raw_args`](../render_api/#args) - Unmodified positional arguments for the current render call
+    - [`self.raw_kwargs`](../render_api/#kwargs) - Unmodified keyword arguments for the current render call
+    - [`self.raw_slots`](../render_api/#slots) - Unmodified slots for the current render call
     - [`self.context`](../render_api/#context) - The context for the current render call
-    - [`self.input`](../render_api/#other-inputs) - All the component inputs
+    - [`self.deps_strategy`](../../advanced/rendering_js_css#dependencies-strategies) - The strategy for rendering dependencies
 
 - Request-related:
     - [`self.request`](../render_api/#request-and-context-processors) - The request object (if available)
@@ -76,6 +79,9 @@ If you defined the [`Component.Args`](../../../reference/api/#django_components.
 then the [`Component.args`](../../../reference/api/#django_components.Component.args) property will return an instance of that class.
 
 Otherwise, `args` will be a plain list.
+
+Use [`self.raw_args`](../../../reference/api/#django_components.Component.raw_args)
+to access the positional arguments as a plain list irrespective of [`Component.Args`](../../../reference/api/#django_components.Component.Args).
 
 **Example:**
 
@@ -119,6 +125,9 @@ then the [`Component.kwargs`](../../../reference/api/#django_components.Componen
 
 Otherwise, `kwargs` will be a plain dictionary.
 
+Use [`self.raw_kwargs`](../../../reference/api/#django_components.Component.raw_kwargs)
+to access the keyword arguments as a plain dictionary irrespective of [`Component.Kwargs`](../../../reference/api/#django_components.Component.Kwargs).
+
 **Example:**
 
 With `Kwargs` class:
@@ -160,6 +169,9 @@ If you defined the [`Component.Slots`](../../../reference/api/#django_components
 then the [`Component.slots`](../../../reference/api/#django_components.Component.slots) property will return an instance of that class.
 
 Otherwise, `slots` will be a plain dictionary.
+
+Use [`self.raw_slots`](../../../reference/api/#django_components.Component.raw_slots)
+to access the slots as a plain dictionary irrespective of [`Component.Slots`](../../../reference/api/#django_components.Component.Slots).
 
 **Example:**
 
@@ -215,44 +227,6 @@ Whether the context variables defined in `context` are available to the template
 
 - In `"isolated"` context behavior mode, the template will NOT have access to this context,
     and data MUST be passed via component's args and kwargs.
-
-### Other inputs
-
-You can access the most important inputs via [`self.args`](../render_api/#args),
-[`self.kwargs`](../render_api/#kwargs),
-and [`self.slots`](../render_api/#slots) properties.
-
-There are additional settings that may be passed to components.
-If you need to access these, you can use [`self.input`](../../../reference/api/#django_components.Component.input) property
-for a low-level access to all the inputs passed to the component.
-
-[`self.input`](../../../reference/api/#django_components.Component.input) ([`ComponentInput`](../../../reference/api/#django_components.ComponentInput)) has the mostly the same fields as the input to [`Component.render()`](../../../reference/api/#django_components.Component.render). This includes:
-
-- `args` - List of positional arguments
-- `kwargs` - Dictionary of keyword arguments
-- `slots` - Dictionary of slots. Values are normalized to [`Slot`](../../../reference/api/#django_components.Slot) instances
-- `context` - [`Context`](https://docs.djangoproject.com/en/5.2/ref/templates/api/#django.template.Context) object that should be used to render the component
-- And other kwargs passed to [`Component.render()`](../../../reference/api/#django_components.Component.render) like `type` and `render_dependencies`
-
-For example, you can use [`self.input.args`](../../../reference/api/#django_components.ComponentInput.args)
-and [`self.input.kwargs`](../../../reference/api/#django_components.ComponentInput.kwargs)
-to access the positional and keyword arguments passed to [`Component.render()`](../../../reference/api/#django_components.Component.render).
-
-```python
-class Table(Component):
-    def get_template_data(self, args, kwargs, slots, context):
-        # Access component's inputs, slots and context
-        assert self.input.args == [123, "str"]
-        assert self.input.kwargs == {"variable": "test", "another": 1}
-        footer_slot = self.input.slots["footer"]
-        some_var = self.input.context["some_var"]
-
-rendered = TestComponent.render(
-    kwargs={"variable": "test", "another": 1},
-    args=(123, "str"),
-    slots={"footer": "MY_SLOT"},
-)
-```
 
 ## Component ID
 

--- a/docs/overview/welcome.md
+++ b/docs/overview/welcome.md
@@ -230,7 +230,7 @@ class Table(Component):
         assert self.args == [123, "str"]
         assert self.kwargs == {"variable": "test", "another": 1}
         footer_slot = self.slots["footer"]
-        some_var = self.input.context["some_var"]
+        some_var = self.context["some_var"]
 
         # Access the request object and Django's context processors, if available
         assert self.request.GET == {"query": "something"}

--- a/docs/reference/template_tags.md
+++ b/docs/reference/template_tags.md
@@ -67,7 +67,7 @@ If you insert this tag multiple times, ALL JS scripts will be duplicately insert
 
 
 
-<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L3350" target="_blank">See source code</a>
+<a href="https://github.com/django-components/django-components/tree/master/src/django_components/templatetags/component_tags.py#L3796" target="_blank">See source code</a>
 
 
 

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -153,9 +153,12 @@ def get_component_by_class_id(comp_cls_id: str) -> Type["Component"]:
     return comp_cls_id_mapping[comp_cls_id]
 
 
+# TODO_v1 - Remove with `Component.input`
 @dataclass(frozen=True)
 class ComponentInput:
     """
+    Deprecated. Will be removed in v1.
+
     Object holding the inputs that were passed to [`Component.render()`](../api#django_components.Component.render)
     or the [`{% component %}`](../template_tags#component) template tag.
 
@@ -1992,9 +1995,13 @@ class Component(metaclass=ComponentMeta):
         self.args = default(args, [])
         self.kwargs = default(kwargs, {})
         self.slots = default(slots, {})
+        self.raw_args: List[Any] = self.args if isinstance(self.args, list) else list(self.args)
+        self.raw_kwargs: Dict[str, Any] = self.kwargs if isinstance(self.kwargs, dict) else to_dict(self.kwargs)
+        self.raw_slots: Dict[str, Slot] = self.slots if isinstance(self.slots, dict) else to_dict(self.slots)
         self.context = default(context, Context())
         # TODO_v1 - Remove `is_filled`, superseded by `Component.slots`
         self.is_filled = SlotIsFilled(to_dict(self.slots))
+        # TODO_v1 - Remove `Component.input`
         self.input = ComponentInput(
             context=self.context,
             # NOTE: Convert args / kwargs / slots to plain lists / dicts
@@ -2007,6 +2014,7 @@ class Component(metaclass=ComponentMeta):
             # TODO_v1 - Remove, superseded by `deps_strategy`
             render_dependencies=deps_strategy != "ignore",
         )
+        self.deps_strategy = deps_strategy
         self.request = request
         self.outer_context: Optional[Context] = outer_context
         self.registry = default(registry, registry_)
@@ -2122,8 +2130,11 @@ class Component(metaclass=ComponentMeta):
     ```
     """
 
+    # TODO_v1 - Remove `Component.input`
     input: ComponentInput
     """
+    Deprecated. Will be removed in v1.
+
     Input holds the data that were passed to the current component at render time.
 
     This includes:
@@ -2137,8 +2148,6 @@ class Component(metaclass=ComponentMeta):
         object that should be used to render the component
     - And other kwargs passed to [`Component.render()`](../api/#django_components.Component.render)
         like `deps_strategy`
-
-    Read more on [Component inputs](../../concepts/fundamentals/render_api/#other-inputs).
 
     **Example:**
 
@@ -2161,15 +2170,16 @@ class Component(metaclass=ComponentMeta):
 
     args: Any
     """
-    The `args` argument as passed to
-    [`Component.get_template_data()`](../api/#django_components.Component.get_template_data).
+    Positional arguments passed to the component.
 
     This is part of the [Render API](../../concepts/fundamentals/render_api).
 
-    If you defined the [`Component.Args`](../api/#django_components.Component.Args) class,
-    then the `args` property will return an instance of that class.
+    `args` has the same behavior as the `args` argument of
+    [`Component.get_template_data()`](../api/#django_components.Component.get_template_data):
 
-    Otherwise, `args` will be a plain list.
+    - If you defined the [`Component.Args`](../api/#django_components.Component.Args) class,
+        then the `args` property will return an instance of that `Args` class.
+    - Otherwise, `args` will be a plain list.
 
     **Example:**
 
@@ -2204,17 +2214,40 @@ class Component(metaclass=ComponentMeta):
     ```
     """
 
-    kwargs: Any
+    raw_args: List[Any]
     """
-    The `kwargs` argument as passed to
-    [`Component.get_template_data()`](../api/#django_components.Component.get_template_data).
+    Positional arguments passed to the component.
 
     This is part of the [Render API](../../concepts/fundamentals/render_api).
 
-    If you defined the [`Component.Kwargs`](../api/#django_components.Component.Kwargs) class,
-    then the `kwargs` property will return an instance of that class.
+    Unlike [`Component.args`](../api/#django_components.Component.args), this attribute
+    is not typed and will remain as plain list even if you define the
+    [`Component.Args`](../api/#django_components.Component.Args) class.
 
-    Otherwise, `kwargs` will be a plain dict.
+    **Example:**
+
+    ```python
+    from django_components import Component
+
+    class Table(Component):
+        def on_render_before(self, context: Context, template: Optional[Template]) -> None:
+            assert self.raw_args[0] == 123
+            assert self.raw_args[1] == 10
+    ```
+    """
+
+    kwargs: Any
+    """
+    Keyword arguments passed to the component.
+
+    This is part of the [Render API](../../concepts/fundamentals/render_api).
+
+    `kwargs` has the same behavior as the `kwargs` argument of
+    [`Component.get_template_data()`](../api/#django_components.Component.get_template_data):
+
+    - If you defined the [`Component.Kwargs`](../api/#django_components.Component.Kwargs) class,
+        then the `kwargs` property will return an instance of that `Kwargs` class.
+    - Otherwise, `kwargs` will be a plain dict.
 
     **Example:**
 
@@ -2252,17 +2285,40 @@ class Component(metaclass=ComponentMeta):
     ```
     """
 
-    slots: Any
+    raw_kwargs: Dict[str, Any]
     """
-    The `slots` argument as passed to
-    [`Component.get_template_data()`](../api/#django_components.Component.get_template_data).
+    Keyword arguments passed to the component.
 
     This is part of the [Render API](../../concepts/fundamentals/render_api).
 
-    If you defined the [`Component.Slots`](../api/#django_components.Component.Slots) class,
-    then the `slots` property will return an instance of that class.
+    Unlike [`Component.kwargs`](../api/#django_components.Component.kwargs), this attribute
+    is not typed and will remain as plain dict even if you define the
+    [`Component.Kwargs`](../api/#django_components.Component.Kwargs) class.
 
-    Otherwise, `slots` will be a plain dict.
+    **Example:**
+
+    ```python
+    from django_components import Component
+
+    class Table(Component):
+        def on_render_before(self, context: Context, template: Optional[Template]) -> None:
+            assert self.raw_kwargs["page"] == 123
+            assert self.raw_kwargs["per_page"] == 10
+    ```
+    """
+
+    slots: Any
+    """
+    Slots passed to the component.
+
+    This is part of the [Render API](../../concepts/fundamentals/render_api).
+
+    `slots` has the same behavior as the `slots` argument of
+    [`Component.get_template_data()`](../api/#django_components.Component.get_template_data):
+
+    - If you defined the [`Component.Slots`](../api/#django_components.Component.Slots) class,
+        then the `slots` property will return an instance of that class.
+    - Otherwise, `slots` will be a plain dict.
 
     **Example:**
 
@@ -2300,6 +2356,28 @@ class Component(metaclass=ComponentMeta):
     ```
     """
 
+    raw_slots: Dict[str, Slot]
+    """
+    Slots passed to the component.
+
+    This is part of the [Render API](../../concepts/fundamentals/render_api).
+
+    Unlike [`Component.slots`](../api/#django_components.Component.slots), this attribute
+    is not typed and will remain as plain dict even if you define the
+    [`Component.Slots`](../api/#django_components.Component.Slots) class.
+
+    **Example:**
+
+    ```python
+    from django_components import Component
+
+    class Table(Component):
+        def on_render_before(self, context: Context, template: Optional[Template]) -> None:
+            assert self.raw_slots["header"] == "MY_HEADER"
+            assert self.raw_slots["footer"] == "FOOTER: " + ctx.data["user_id"]
+    ```
+    """
+
     context: Context
     """
     The `context` argument as passed to
@@ -2319,6 +2397,39 @@ class Component(metaclass=ComponentMeta):
 
     - In `"isolated"` context behavior mode, the template will NOT have access to this context,
         and data MUST be passed via component's args and kwargs.
+    """
+
+    deps_strategy: DependenciesStrategy
+    """
+    Dependencies strategy defines how to handle JS and CSS dependencies of this and child components.
+
+    Read more about
+    [Dependencies rendering](../../concepts/fundamentals/rendering_components#dependencies-rendering).
+
+    This is part of the [Render API](../../concepts/fundamentals/render_api).
+
+    There are six strategies:
+
+    - [`"document"`](../../concepts/advanced/rendering_js_css#document) (default)
+        - Smartly inserts JS / CSS into placeholders or into `<head>` and `<body>` tags.
+        - Inserts extra script to allow `fragment` types to work.
+        - Assumes the HTML will be rendered in a JS-enabled browser.
+    - [`"fragment"`](../../concepts/advanced/rendering_js_css#fragment)
+        - A lightweight HTML fragment to be inserted into a document with AJAX.
+        - No JS / CSS included.
+    - [`"simple"`](../../concepts/advanced/rendering_js_css#simple)
+        - Smartly insert JS / CSS into placeholders or into `<head>` and `<body>` tags.
+        - No extra script loaded.
+    - [`"prepend"`](../../concepts/advanced/rendering_js_css#prepend)
+        - Insert JS / CSS before the rendered HTML.
+        - No extra script loaded.
+    - [`"append"`](../../concepts/advanced/rendering_js_css#append)
+        - Insert JS / CSS after the rendered HTML.
+        - No extra script loaded.
+    - [`"ignore"`](../../concepts/advanced/rendering_js_css#ignore)
+        - HTML is left as-is. You can still process it with a different strategy later with
+            [`render_dependencies()`](../api/#django_components.render_dependencies).
+        - Used for inserting rendered HTML into other components.
     """
 
     outer_context: Optional[Context]
@@ -2538,7 +2649,7 @@ class Component(metaclass=ComponentMeta):
 
         As the `{{ message }}` is taken from the "my_provide" provider.
         """
-        return get_injected_context_var(self.name, self.input.context, key, default)
+        return get_injected_context_var(self.name, self.context, key, default)
 
     @classmethod
     def as_view(cls, **initkwargs: Any) -> ViewFn:

--- a/src/django_components/components/dynamic.py
+++ b/src/django_components/components/dynamic.py
@@ -108,7 +108,7 @@ class DynamicComponent(Component):
     def on_render_before(self, context: Context, template: Template) -> Context:
         # Make a copy of kwargs so we pass to the child only the kwargs that are
         # actually used by the child component.
-        cleared_kwargs = self.input.kwargs.copy()
+        cleared_kwargs = self.raw_kwargs.copy()
 
         # Resolve the component class
         registry: Optional[ComponentRegistry] = cleared_kwargs.pop("registry", None)
@@ -119,11 +119,11 @@ class DynamicComponent(Component):
         comp_class = self._resolve_component(comp_name_or_class, registry)
 
         output = comp_class.render(
-            context=self.input.context,
-            args=self.input.args,
+            context=self.context,
+            args=self.raw_args,
             kwargs=cleared_kwargs,
-            slots=self.input.slots,
-            deps_strategy=self.input.deps_strategy,
+            slots=self.raw_slots,
+            deps_strategy=self.deps_strategy,
             registered_name=self.registered_name,
             outer_context=self.outer_context,
             registry=self.registry,

--- a/src/django_components/slots.py
+++ b/src/django_components/slots.py
@@ -688,7 +688,7 @@ class SlotNode(BaseNode):
         outer_context = component_ctx.outer_context
 
         # Slot info
-        slot_fills = component.input.slots
+        slot_fills = component.raw_slots
         slot_name = name
         is_default = self.flags[SLOT_DEFAULT_FLAG]
         is_required = self.flags[SLOT_REQUIRED_FLAG]

--- a/tests/test_benchmark_djc.py
+++ b/tests/test_benchmark_djc.py
@@ -2115,7 +2115,7 @@ class HeroIcon(Component):
         viewbox: Optional[str] = None,
         attrs: Optional[Dict] = None,
     ) -> Dict:
-        kwargs = IconDefaults(**self.input.kwargs)
+        kwargs = IconDefaults(**self.kwargs)
 
         if kwargs.variant not in ["outline", "solid"]:
             raise ValueError(f"Invalid variant: {kwargs.variant}. Must be either 'outline' or 'solid'")

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -251,6 +251,47 @@ class TestComponentLegacyApi:
         template_2 = _get_component_template(comp)
         assert template_2._test_id == "123"  # type: ignore[union-attr]
 
+    # TODO_v1 - Remove
+    def test_input(self):
+        class TestComponent(Component):
+            template: types.django_html = """
+                {% load component_tags %}
+                Variable: <strong>{{ variable }}</strong>
+                {% slot 'my_slot' / %}
+            """
+
+            def get_template_data(self, args, kwargs, slots, context):
+                assert self.input.args == [123, "str"]
+                assert self.input.kwargs == {"variable": "test", "another": 1}
+                assert isinstance(self.input.context, Context)
+                assert list(self.input.slots.keys()) == ["my_slot"]
+                my_slot = self.input.slots["my_slot"]
+                assert my_slot() == "MY_SLOT"
+
+                return {
+                    "variable": kwargs["variable"],
+                }
+
+            def on_render_before(self, context, template):
+                assert self.input.args == [123, "str"]
+                assert self.input.kwargs == {"variable": "test", "another": 1}
+                assert isinstance(self.input.context, Context)
+                assert list(self.input.slots.keys()) == ["my_slot"]
+                my_slot = self.input.slots["my_slot"]
+                assert my_slot() == "MY_SLOT"
+
+        rendered = TestComponent.render(
+            kwargs={"variable": "test", "another": 1},
+            args=(123, "str"),
+            slots={"my_slot": "MY_SLOT"},
+        )
+
+        assertHTMLEqual(
+            rendered,
+            """
+            Variable: <strong data-djc-id-ca1bc3e>test</strong> MY_SLOT
+            """,
+        )
 
 @djc_test
 class TestComponent:
@@ -476,7 +517,7 @@ class TestComponentRenderAPI:
         rendered = SimpleComponent.render()
         assert rendered == "render_id: ca1bc3e"
 
-    def test_input(self):
+    def test_raw_input(self):
         class TestComponent(Component):
             template: types.django_html = """
                 {% load component_tags %}
@@ -485,11 +526,11 @@ class TestComponentRenderAPI:
             """
 
             def get_template_data(self, args, kwargs, slots, context):
-                assert self.input.args == [123, "str"]
-                assert self.input.kwargs == {"variable": "test", "another": 1}
-                assert isinstance(self.input.context, Context)
-                assert list(self.input.slots.keys()) == ["my_slot"]
-                my_slot = self.input.slots["my_slot"]
+                assert self.raw_args == [123, "str"]
+                assert self.raw_kwargs == {"variable": "test", "another": 1}
+                assert isinstance(self.context, Context)
+                assert list(self.raw_slots.keys()) == ["my_slot"]
+                my_slot = self.raw_slots["my_slot"]
                 assert my_slot() == "MY_SLOT"
 
                 return {
@@ -497,11 +538,11 @@ class TestComponentRenderAPI:
                 }
 
             def on_render_before(self, context, template):
-                assert self.input.args == [123, "str"]
-                assert self.input.kwargs == {"variable": "test", "another": 1}
-                assert isinstance(self.input.context, Context)
-                assert list(self.input.slots.keys()) == ["my_slot"]
-                my_slot = self.input.slots["my_slot"]
+                assert self.raw_args == [123, "str"]
+                assert self.raw_kwargs == {"variable": "test", "another": 1}
+                assert isinstance(self.context, Context)
+                assert list(self.raw_slots.keys()) == ["my_slot"]
+                my_slot = self.raw_slots["my_slot"]
                 assert my_slot() == "MY_SLOT"
 
         rendered = TestComponent.render(

--- a/tests/test_component_defaults.py
+++ b/tests/test_component_defaults.py
@@ -34,7 +34,7 @@ class TestComponentDefaults:
                     "extra": "extra",  # Default because `None` was given
                     "fn": self.Defaults.fn,  # Default because missing
                 }
-                assert self.input.kwargs == {
+                assert self.raw_kwargs == {
                     "variable": "test",  # User-given
                     "another": 1,  # Default because missing
                     "extra": "extra",  # Default because `None` was given
@@ -46,11 +46,11 @@ class TestComponentDefaults:
                 assert [*slots.keys()] == ["my_slot"]
                 assert slots["my_slot"](Context(), None, None) == "MY_SLOT"  # type: ignore[arg-type]
 
-                assert self.input.args == [123]
-                assert [*self.input.slots.keys()] == ["my_slot"]
-                assert self.input.slots["my_slot"](Context(), None, None) == "MY_SLOT"  # type: ignore[arg-type]
+                assert self.raw_args == [123]
+                assert [*self.raw_slots.keys()] == ["my_slot"]
+                assert self.raw_slots["my_slot"](Context(), None, None) == "MY_SLOT"  # type: ignore[arg-type]
 
-                assert isinstance(self.input.context, Context)
+                assert isinstance(self.context, Context)
 
                 return {
                     "variable": kwargs["variable"],
@@ -82,11 +82,11 @@ class TestComponentDefaults:
                     "variable": "test",  # User-given
                     "fn": "fn_as_factory",  # Default because missing
                 }
-                assert self.input.kwargs == {
+                assert self.raw_kwargs == {
                     "variable": "test",  # User-given
                     "fn": "fn_as_factory",  # Default because missing
                 }
-                assert isinstance(self.input.context, Context)
+                assert isinstance(self.context, Context)
 
                 return {
                     "variable": kwargs["variable"],
@@ -117,12 +117,12 @@ class TestComponentDefaults:
                     # NOTE: NOT a factory, because it was set as `field(default=...)`
                     "fn": self.Defaults.fn.default,  # type: ignore[attr-defined]
                 }
-                assert self.input.kwargs == {
+                assert self.raw_kwargs == {
                     "variable": "test",  # User-given
                     # NOTE: NOT a factory, because it was set as `field(default=...)`
                     "fn": self.Defaults.fn.default,  # type: ignore[attr-defined]
                 }
-                assert isinstance(self.input.context, Context)
+                assert isinstance(self.context, Context)
 
                 return {
                     "variable": kwargs["variable"],
@@ -153,12 +153,12 @@ class TestComponentDefaults:
                     # NOTE: IS a factory, because it was set as `field(default_factory=...)`
                     "fn": "fn_as_factory",  # Default because missing
                 }
-                assert self.input.kwargs == {
+                assert self.raw_kwargs == {
                     "variable": "test",  # User-given
                     # NOTE: IS a factory, because it was set as `field(default_factory=...)`
                     "fn": "fn_as_factory",  # Default because missing
                 }
-                assert isinstance(self.input.context, Context)
+                assert isinstance(self.context, Context)
 
                 return {
                     "variable": kwargs["variable"],

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -729,7 +729,7 @@ class TestSlot:
             template = "CAPTURER"
 
             def get_template_data(self, args, kwargs, slots, context):
-                seen_slots.append(self.input.slots["my_slot"])
+                seen_slots.append(self.slots["my_slot"])
 
         MyTopLevelComponent.render()
 

--- a/tests/test_templatetags_slot_fill.py
+++ b/tests/test_templatetags_slot_fill.py
@@ -1066,7 +1066,7 @@ class TestPassthroughSlots:
         class OuterComp(Component):
             def get_template_data(self, args, kwargs, slots, context):
                 return {
-                    "slots": self.input.slots,
+                    "slots": self.slots,
                 }
 
             template: types.django_html = """
@@ -1117,7 +1117,7 @@ class TestPassthroughSlots:
         class OuterComp(Component):
             def get_template_data(self, args, kwargs, slots, context):
                 return {
-                    "slots": self.input.slots,
+                    "slots": self.slots,
                 }
 
             template: types.django_html = """


### PR DESCRIPTION
Last one before v0.140 🎉 🎉 @EmilStenstrom thank you for your infinite patience! 😄 

As mentioned in #1206, this marks `Component.input` as deprecated.

In order to avoid using `Component.input`, following Component attributes were added:

- `Component.raw_args` - Same as `input.args` - Positional args. Unlike `Component.args` this stays as plain list even when `Component.Args` is given.
- `Component.raw_kwargs` - Same as above, but for `kwargs`
- `Component.raw_slots` - Same as above, but for `slots`
- `Component.deps_strategy` - Stores the value passed to `Component.render()`, because it was stored only on `input.deps_strategy`.

Closes #1206