### PR TITLE
feat: on_xx_loaded extension hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Release notes
 
+## v0.141.0
+
+#### Feat
+
+- New extension hooks `on_template_loaded`, `on_js_loaded`, `on_css_loaded`, and `on_template_compiled`
+
+    The first 3 hooks are called when Component's template / JS / CSS is loaded as a string.
+
+    The `on_template_compiled` hook is called when Component's template is compiled to a Template.
+
+    The `on_xx_loaded` hooks can modify the content by returning the new value.
+
+    ```py
+    class MyExtension(ComponentExtension):
+        def on_template_loaded(self, ctx: OnTemplateLoadedContext) -> Optional[str]:
+            return ctx.content + "<!-- Hello! -->"
+
+        def on_js_loaded(self, ctx: OnJsLoadedContext) -> Optional[str]:
+            return ctx.content + "// Hello!"
+
+        def on_css_loaded(self, ctx: OnCssLoadedContext) -> Optional[str]:
+            return ctx.content + "/* Hello! */"
+    ```
+
+    See all [Extension hooks](https://django-components.github.io/django-components/0.141.0/reference/extension_hooks/).
+
+#### Fix
+
+- Subclassing - Previously, if a parent component defined `Component.template` or `Component.template_file`, it's subclass would use the same `Template` instance.
+
+    This could lead to unexpected behavior, where a change to the template of the subclass would also change the template of the parent class.
+
+    Now, each subclass has it's own `Template` instance, and changes to the template of the subclass do not affect the template of the parent class.
+
 ## v0.140.1
 
 #### Fix

--- a/docs/reference/extension_hooks.md
+++ b/docs/reference/extension_hooks.md
@@ -148,6 +148,42 @@ name | type | description
 `name` | `str` | The name the component was registered under
 `registry` | [`ComponentRegistry`](../api#django_components.ComponentRegistry) | The registry the component was unregistered from
 
+::: django_components.extension.ComponentExtension.on_css_loaded
+    options:
+      heading_level: 3
+      show_root_heading: true
+      show_signature: true
+      separate_signature: true
+      show_symbol_type_heading: false
+      show_symbol_type_toc: false
+      show_if_no_docstring: true
+      show_labels: false
+
+**Available data:**
+
+name | type | description
+--|--|--
+`component_cls` | [`Type[Component]`](../api#django_components.Component) | The Component class whose CSS was loaded
+`content` | `str` | The CSS content (string)
+
+::: django_components.extension.ComponentExtension.on_js_loaded
+    options:
+      heading_level: 3
+      show_root_heading: true
+      show_signature: true
+      separate_signature: true
+      show_symbol_type_heading: false
+      show_symbol_type_toc: false
+      show_if_no_docstring: true
+      show_labels: false
+
+**Available data:**
+
+name | type | description
+--|--|--
+`component_cls` | [`Type[Component]`](../api#django_components.Component) | The Component class whose JS was loaded
+`content` | `str` | The JS content (string)
+
 ::: django_components.extension.ComponentExtension.on_registry_created
     options:
       heading_level: 3
@@ -206,6 +242,44 @@ name | type | description
 `slot_is_required` | `bool` | Whether the slot is required
 `slot_name` | `str` | The name of the `{% slot %}` tag
 `slot_node` | `SlotNode` | The node instance of the `{% slot %}` tag
+
+::: django_components.extension.ComponentExtension.on_template_compiled
+    options:
+      heading_level: 3
+      show_root_heading: true
+      show_signature: true
+      separate_signature: true
+      show_symbol_type_heading: false
+      show_symbol_type_toc: false
+      show_if_no_docstring: true
+      show_labels: false
+
+**Available data:**
+
+name | type | description
+--|--|--
+`component_cls` | [`Type[Component]`](../api#django_components.Component) | The Component class whose template was loaded
+`template` | `django.template.base.Template` | The compiled template object
+
+::: django_components.extension.ComponentExtension.on_template_loaded
+    options:
+      heading_level: 3
+      show_root_heading: true
+      show_signature: true
+      separate_signature: true
+      show_symbol_type_heading: false
+      show_symbol_type_toc: false
+      show_if_no_docstring: true
+      show_labels: false
+
+**Available data:**
+
+name | type | description
+--|--|--
+`component_cls` | [`Type[Component]`](../api#django_components.Component) | The Component class whose template was loaded
+`content` | `str` | The template string
+`name` | `Optional[str]` | The name of the template
+`origin` | `Optional[django.template.base.Origin]` | The origin of the template
 
 ## Objects
 

--- a/src/django_components/context.py
+++ b/src/django_components/context.py
@@ -11,6 +11,7 @@ from django.template import Context
 from django_components.util.misc import get_last_index
 
 _COMPONENT_CONTEXT_KEY = "_DJC_COMPONENT_CTX"
+COMPONENT_IS_NESTED_KEY = "_DJC_COMPONENT_IS_NESTED"
 _STRATEGY_CONTEXT_KEY = "DJC_DEPS_STRATEGY"
 _INJECT_CONTEXT_KEY_PREFIX = "_DJC_INJECT__"
 

--- a/src/django_components/util/django_monkeypatch.py
+++ b/src/django_components/util/django_monkeypatch.py
@@ -3,8 +3,9 @@ from typing import Any, Optional, Type
 from django.template import Context, NodeList, Template
 from django.template.base import Origin, Parser
 
-from django_components.context import _COMPONENT_CONTEXT_KEY, _STRATEGY_CONTEXT_KEY
+from django_components.context import _COMPONENT_CONTEXT_KEY, _STRATEGY_CONTEXT_KEY, COMPONENT_IS_NESTED_KEY
 from django_components.dependencies import COMPONENT_COMMENT_REGEX, render_dependencies
+from django_components.extension import OnTemplateCompiledContext, OnTemplateLoadedContext, extensions
 from django_components.util.template_parser import parse_template
 
 
@@ -16,8 +17,8 @@ def monkeypatch_template_cls(template_cls: Type[Template]) -> None:
     template_cls._djc_patched = True
 
 
-# Patch `Template.__init__` to apply `extensions.on_template_preprocess()` if the template
-# belongs to a Component.
+# Patch `Template.__init__` to apply `on_template_loaded()` and `on_template_compiled()`
+# extension hooks if the template belongs to a Component.
 def monkeypatch_template_init(template_cls: Type[Template]) -> None:
     original_init = template_cls.__init__
 
@@ -27,6 +28,7 @@ def monkeypatch_template_init(template_cls: Type[Template]) -> None:
         self: Template,
         template_string: Any,
         origin: Optional[Origin] = None,
+        name: Optional[str] = None,
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -56,11 +58,27 @@ def monkeypatch_template_init(template_cls: Type[Template]) -> None:
             component_cls = None
 
         if component_cls is not None:
-            # TODO - Apply extensions.on_template_preprocess() here.
-            #        Then also test both cases when template as `template` or `template_file`.
-            pass
+            template_string = str(template_string)
+            template_string = extensions.on_template_loaded(
+                OnTemplateLoadedContext(
+                    component_cls=component_cls,
+                    content=template_string,
+                    origin=origin,
+                    name=name,
+                )
+            )
 
-        original_init(self, template_string, origin, *args, **kwargs)  # type: ignore[misc]
+        # Calling original `Template.__init__` should also compile the template into a Nodelist
+        # via `Template.compile_nodelist()`.
+        original_init(self, template_string, origin, name, *args, **kwargs)  # type: ignore[misc]
+
+        if component_cls is not None:
+            extensions.on_template_compiled(
+                OnTemplateCompiledContext(
+                    component_cls=component_cls,
+                    template=self,
+                )
+            )
 
     template_cls.__init__ = __init__
 
@@ -110,7 +128,7 @@ def monkeypatch_template_compile_nodelist(template_cls: Type[Template]) -> None:
 
 def monkeypatch_template_render(template_cls: Type[Template]) -> None:
     # Modify `Template.render` to set `isolated_context` kwarg of `push_state`
-    # based on our custom `Template._djc_is_component_nested`.
+    # based on our custom `_DJC_COMPONENT_IS_NESTED`.
     #
     # Part of fix for https://github.com/django-components/django-components/issues/508
     #
@@ -125,7 +143,7 @@ def monkeypatch_template_render(template_cls: Type[Template]) -> None:
     # doesn't require the source to be parsed multiple times. User can pass extra args/kwargs,
     # and can modify the rendering behavior by overriding the `_render` method.
     #
-    # NOTE 2: Instead of setting `Template._djc_is_component_nested`, alternatively we could
+    # NOTE 2: Instead of setting `_DJC_COMPONENT_IS_NESTED` context key, alternatively we could
     # have passed the value to `monkeypatch_template_render` directly. However, we intentionally
     # did NOT do that, so the monkey-patched method is more robust, and can be e.g. copied
     # to other.
@@ -137,12 +155,12 @@ def monkeypatch_template_render(template_cls: Type[Template]) -> None:
     def _template_render(self: Template, context: Context, *args: Any, **kwargs: Any) -> str:
         "Display stage -- can be called many times"
         # We parametrized `isolated_context`, which was `True` in the original method.
-        if not hasattr(self, "_djc_is_component_nested"):
+        if COMPONENT_IS_NESTED_KEY not in context:
             isolated_context = True
         else:
             # MUST be `True` for templates that are NOT import with `{% extends %}` tag,
             # and `False` otherwise.
-            isolated_context = not self._djc_is_component_nested
+            isolated_context = not context[COMPONENT_IS_NESTED_KEY]
 
         # This is original implementation, except we override `isolated_context`,
         # and we post-process the result with `render_dependencies()`.


### PR DESCRIPTION
This adds 4 new extension hooks `on_template_loaded`, `on_js_loaded`, `on_css_loaded`, and `on_template_compiled`

The first 3 hooks are called when Component's template / JS / CSS is loaded as a string.

The `on_template_compiled` hook is called when Component's template is compiled to a Template.

```py
class MyExtension(ComponentExtension):
    def on_template_loaded(self, ctx: OnTemplateLoadedContext) -> Optional[str]:
        return ctx.content + "<!-- Hello! -->"

    def on_js_loaded(self, ctx: OnJsLoadedContext) -> Optional[str]:
        return ctx.content + "// Hello!"

    def on_css_loaded(self, ctx: OnCssLoadedContext) -> Optional[str]:
        return ctx.content + "/* Hello! */"
```

Secondly, to get this working correctly, I had to update the logic for how the `Template` instances are created from `template` / `template_file`. The issue was that when subclassing components where the parent defined `template` / `template_file`, and child didn't define anything, then the child was missing the Template. Instead, we want the child to have it's own instance of template, so as if `template` / `template_file` were defined directly on the child component.