### PR TITLE
docs: fix wrong link to template variable page in sidebar

### DIFF
--- a/docs/reference/.nav.yml
+++ b/docs/reference/.nav.yml
@@ -11,6 +11,6 @@ nav:
   - Signals: signals.md
   - Tag formatters: tag_formatters.md
   - Template tags: template_tags.md
-  - Template variables: template_vars.md
+  - Template variables: template_variables.md
   - URLs: urls.md
   - Testing API: testing_api.md


### PR DESCRIPTION
Issue - https://github.com/django-components/django-components/issues/1294

Reflected the filename change from commit 458e189 in the nav, which was previously not updated.