### PR TITLE
Create devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.0/containers/python-3
+{
+	"name": "Python 3.13",
+	"image": "mcr.microsoft.com/devcontainers/python:3.13-bullseye",
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": { 
+				"python.defaultInterpreterPath": "/usr/local/bin/python",
+				"python.linting.enabled": true
+			},
+			
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"ms-python.vscode-python-envs"
+			]
+		}
+	}
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	//"postCreateCommand": ""
+}


### PR DESCRIPTION
Turns out that there's a way to configure what container should be created when one uses Github's codespace feature (AKA the IDE in browser).

I was looking into this because I wanted to run the codebase in the browser in Python 3.13. It seems that the behaviour of Mypy is a bit different than in previous versions of Python, which led to this error in this pipeline:

https://github.com/django-components/django-components/actions/runs/16400669363/job/46339620229?pr=1300

And on my laptop I currently have Python 3.11.

The container config looks like a good starting point. Down the line we can add some more extensions so it's easier to start for others who might want to submit a small PR or play around.