### PR TITLE
ci: add missing django-components during docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,6 +60,8 @@ jobs:
             # See https://github.com/airspeed-velocity/asv/issues/1484
             python -m pip install -q pre-commit asv virtualenv==20.30
             python -m pip install -r requirements-docs.txt
+            # Install django-components locally
+            python -m pip install -e .
 
       ###########################################
       # RECORD BENCHMARK - ONLY ON PUSH TO MASTER


### PR DESCRIPTION
Another follow up to https://github.com/django-components/django-components/pull/1347 and https://github.com/django-components/django-components/pull/1376