### PR TITLE
fix: add required dependency package django-components to requirements-doc.

### DIFF
--- a/requirements-docs.in
+++ b/requirements-docs.in
@@ -16,5 +16,6 @@ mkdocstrings-python
 pymdown-extensions
 pygments
 pygments-djc
+django-components
 django>=4.2
 djc-core-html-parser>=1.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -41,9 +41,15 @@ cssselect2==0.8.0
 defusedxml==0.7.1
     # via cairosvg
 django==5.2.5
+    # via
+    #   -r requirements-docs.in
+    #   django-components
+django-components==0.141.5
     # via -r requirements-docs.in
 djc-core-html-parser==1.0.2
-    # via -r requirements-docs.in
+    # via
+    #   -r requirements-docs.in
+    #   django-components
 ghp-import==2.1.0
     # via mkdocs
 gitdb==4.0.12
@@ -117,11 +123,11 @@ mkdocs-get-deps==0.2.0
 mkdocs-git-authors-plugin==0.10.0
     # via -r requirements-docs.in
 mkdocs-git-revision-date-localized-plugin==1.4.7
-    # via hatch.envs.docs
+    # via -r requirements-docs.in
 mkdocs-include-markdown-plugin==7.1.7
-    # via hatch.envs.docs
-mkdocs-material==9.6.19
-    # via hatch.envs.docs
+    # via -r requirements-docs.in
+mkdocs-material[imaging]==9.6.19
+    # via -r requirements-docs.in
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
 mkdocs-minify-plugin==0.8.0
@@ -198,6 +204,7 @@ tinycss2==1.4.0
     #   cssselect2
 typing-extensions==4.14.1
     # via
+    #   django-components
     #   pydantic
     #   pydantic-core
     #   typing-inspection


### PR DESCRIPTION
Since this file uses `django_components`, it seems necessary to add `django_components` to `requirements-docs`.

Currently, if you create a virtual environment and install the dependencies with 
```pip install -r requirements-docs``` and running ```mkdocs serve``` will fail.
(This can be resolved by installing `django_components`.)