### PR TITLE
bug: TemplateDoesNotExist while using double include using same extends in same component

### DIFF
--- a/tests/test_templatetags_extends.py
+++ b/tests/test_templatetags_extends.py
@@ -1075,3 +1075,44 @@ class TestExtendsCompat:
             <p data-djc-id-ca1bc40 data-djc-id-ca1bc42>This template extends another template.</p>
         """,
         )
+
+    @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
+    def test_double_include_template_with_extend(
+        self,
+        components_settings,
+    ):
+
+        @register("simple_component")
+        class SimpleComponent(Component):
+            template: types.django_html = """
+                {% slot 'content' / %}
+            """
+
+        template: types.django_html = """
+            {% extends 'block.html' %}
+            {% load component_tags %}
+            {% block body %}
+                {% component "simple_component" %}
+                    {% fill "content" %}
+                        {% include 'included.html' with variable="INCLUDED 1" %}
+                        {% include 'included.html' with variable="INCLUDED 2" %}
+                    {% endfill %}
+                {% endcomponent %}
+            {% endblock %}
+        """
+        rendered = Template(template).render(Context({"DJC_DEPS_STRATEGY": "ignore"}))
+
+        expected = """
+            <!DOCTYPE html>
+            <html lang="en">
+              <body>
+                <main role="main">
+                  <div class='container main-container'>
+                    Variable: <strong data-djc-id-ca1bc40="">INCLUDED 1</strong>
+                    Variable: <strong data-djc-id-ca1bc40="">INCLUDED 2</strong>
+                  </div>
+                </main>
+              </body>
+            </html>
+        """
+        assertHTMLEqual(rendered, expected)


### PR DESCRIPTION
Hello,

I'm reporting a bug that i have seen. I have no clue of how to resolve it for now.
I've made a test showing the issue to help you understand the issue.

## description
If you use **multiple** `include tag` which are using the same `extended template` in a component,
there is a `TemplateDoesNotExist` raised while resolving the second `include tag`.
As the `extended template` as already been used, it's skipped while trying to find the template by the template finder.

This remember me a problem of `origin` for slots that has been fixed in this [commit](https://github.com/django-components/django-components/commit/58d4c78671fe5733754280d0b055ff1346208a03).

I hope this help somehow. I'll try to figure it out a bit. I'm here to help if i can.