### PR TITLE
feat: allow to yield multiple times in Component.on_render()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Release notes
 
+## v0.142.0
+
+#### Feat
+
+- Multiple yields in `Component.on_render()` - You can now yield multiple times within the same `on_render` method for complex rendering scenarios.
+
+    ```py
+    class MyTable(Component):
+        def on_render(self, context, template):
+            # First yield - render with one context
+            with context.push({"mode": "header"}):
+                header_html, header_error = yield template.render(context)
+            
+            # Second yield - render with different context
+            with context.push({"mode": "body"}):
+                body_html, body_error = yield template.render(context)
+            
+            # Third yield - render a string directly
+            footer_html, footer_error = yield "Footer content"
+            
+            # Process all results and return final output
+            if header_error or body_error or footer_error:
+                return "Error occurred during rendering"
+            
+            return f"{header_html}\n{body_html}\n{footer_html}"
+    ```
+
+    Each yield operation is independent and returns its own `(html, error)` tuple, allowing you to handle each rendering result separately.
+
 ## v0.141.6
 
 #### Fix


### PR DESCRIPTION
Step towards the `ErrorFallback` component (see https://github.com/django-components/django-components/issues/1085).

This refactors the flow of how the components are being rendered, in order to allow `Component.on_render()` to yield multiple times.

As a refresher:
- People can override `Component.on_render()` to e.g. override what template gets rendered, or to insert custom rendering logic. 
- Inside `on_render()`, when one renders the component's template with `template.render()`, this does NOT give the final result. Because we still need to process that output in the background.

   So to work with that, people can yield the value instead. When they yield it, they get access to the full rendered HTML.

    ```py
    class MyTable(Component):
        def on_render(self, context, template):
            html, error = yield template.render(context)
    ```

- We use that to implement the ErrorFallback component, which works roughly like so:

    ```py
    class ErrorFallback(Component):
        def on_render(self, context, template):
            # Try to render the original content
            html, error = yield self.slots.default(context)
            # If it failed, render the fallback instead
            if error is not None:
                return self.slots.fallback(context)
    ```

Now, with this PR, this pattern will become even more powerful for powerusers / UI library authors like me, allowing to render multiple templates in a single `on_render` method by yielding multiple times:

```py
class MyTable(Component):
    def on_render(self, context, template):
        # First yield - render with one context
        with context.push({"mode": "header"}):
            header_html, header_error = yield template.render(context)

        # Second yield - render with different context
        with context.push({"mode": "body"}):
            body_html, body_error = yield template.render(context)

        # Third yield - render a string directly
        footer_html, footer_error = yield "Footer content"

        # Process all results and return final output
        if header_error or body_error or footer_error:
            return "Error occurred during rendering"

        return f"{header_html}\n{body_html}\n{footer_html}"
```


<img width="1302" height="808" alt="Screenshot 2025-09-30 at 18 17 47" src="https://github.com/user-attachments/assets/c84bf7eb-bab4-4278-b1f0-dc0f2d2bf7f2" />
