### PR TITLE
chore: fix Discord-on-PR workflow + add dates to releases

### DIFF
--- a/.github/workflows/pr-discord.yml
+++ b/.github/workflows/pr-discord.yml
@@ -1,7 +1,10 @@
 name: Notify Discord on new PRs
 
 on:
-  pull_request:
+  # NOTE: Using `pull_request_target` instead of `pull_request`
+  # so we can access repository secrets.
+  # See https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target
+  pull_request_target:
     types: [opened]
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@
 
 ## v0.141.6
 
+_29 Sep 2025_
+
 #### Fix
 
 - Fix error that occured when calling `Component.inject()` inside loops:
@@ -160,6 +162,8 @@
 
 ## v0.141.5
 
+_10 Sep 2025_
+
 #### Fix
 
 - Tests - Fix bug when using `@djc_test` decorator and the `COMPONENTS`
@@ -168,12 +172,16 @@
 
 ## v0.141.4
 
+_15 Aug 2025_
+
 #### Fix
 
 - Fix compatibility with Django's `{% include %}` and `{% extends %}` tags.
   See [#1325](https://github.com/django-components/django-components/issues/1325)
 
 ## v0.141.3
+
+_14 Aug 2025_
 
 #### Feat
 
@@ -190,11 +198,15 @@
 
 ## v0.141.2
 
+_21 Jul 2025_
+
 #### Fix
 
 - Fix bug where JS and CSS were missing when `{% component %}` tag was inside `{% include %}` tag ([#1296](https://github.com/django-components/django-components/issues/1296))
 
 ## v0.141.1
+
+_03 Jul 2025_
 
 #### Fix
 
@@ -213,6 +225,8 @@
 - Do not send `template_rendered` signal when rendering a component with no template. ([#1277](https://github.com/django-components/django-components/issues/1277))
 
 ## v0.141.0
+
+_10 Jun 2025_
 
 #### Feat
 
@@ -256,11 +270,15 @@
 
 ## v0.140.1
 
+_05 Jun 2025_
+
 #### Fix
 
 - Fix typo preventing benchmarking ([#1235](https://github.com/django-components/django-components/pull/1235))
 
 ## v0.140.0 🚨📢
+
+_05 Jun 2025_
 
 ⚠️ Major release ⚠️ - Please test thoroughly before / after upgrading.
 
@@ -1608,6 +1626,8 @@ Summary:
 
 ## v0.139.1
 
+_20 Apr 2025_
+
 #### Fix
 
 - Fix compatibility of component caching with `{% extend %}` block ([#1135](https://github.com/django-components/django-components/issues/1135))
@@ -1640,17 +1660,23 @@ Summary:
 
 ## v0.139.0
 
+_12 Apr 2025_
+
 #### Fix
 
 - Fix bug: Fix compatibility with `Finder.find()` in Django 5.2 ([#1119](https://github.com/django-components/django-components/issues/1119))
 
 ## v0.138
 
+_09 Apr 2025_
+
 #### Fix
 
 - Fix bug: Allow components with `Url.public = True` to be defined before `django.setup()`
 
 ## v0.137
+
+_09 Apr 2025_
 
 #### Feat
 
@@ -1741,6 +1767,8 @@ Summary:
 
 ## v0.136 🚨📢
 
+_05 Apr 2025_
+
 #### BREAKING CHANGES 🚨📢
 
 - Component input validation was moved to a separate extension [`djc-ext-pydantic`](https://github.com/django-components/djc-ext-pydantic).
@@ -1761,6 +1789,8 @@ Summary:
 - Make it possible to resolve URLs added by extensions by their names
 
 ## v0.135
+
+_31 Mar 2025_
 
 #### Feat
 
@@ -1825,11 +1855,15 @@ where each class name or style property can be managed separately.
 
 ## v0.134
 
+_23 Mar 2025_
+
 #### Fix
 
 - HOTFIX: Fix the use of URLs in `Component.Media.js` and `Component.Media.css`
 
 ## v0.133
+
+_23 Mar 2025_
 
 ⚠️ Attention ⚠️ - Please update to v0.134 to fix bugs introduced in v0.132.
 
@@ -1838,6 +1872,8 @@ where each class name or style property can be managed separately.
 - HOTFIX: Fix the use of URLs in `Component.Media.js` and `Component.Media.css`
 
 ## v0.132
+
+_22 Mar 2025_
 
 ⚠️ Attention ⚠️ - Please update to v0.134 to fix bugs introduced in v0.132.
 
@@ -1858,6 +1894,8 @@ where each class name or style property can be managed separately.
 - Fix installation for Python 3.13 on Windows.
 
 ## v0.131
+
+_20 Mar 2025_
 
 #### Feat
 
@@ -1907,6 +1945,8 @@ where each class name or style property can be managed separately.
 
 ## v0.130
 
+_20 Feb 2025_
+
 #### Feat
 
 - Access the HttpRequest object under `Component.request`.
@@ -1931,6 +1971,8 @@ where each class name or style property can be managed separately.
 
 ## v0.129
 
+_16 Feb 2025_
+
 #### Fix
 
 - Fix thread unsafe media resolve validation by moving it to ComponentMedia `__post_init` ([#977](https://github.com/django-components/django-components/pull/977)
@@ -1938,6 +1980,8 @@ where each class name or style property can be managed separately.
 - Fix error when template cache setting (`template_cache_size`) is set to 0 ([#974](https://github.com/django-components/django-components/pull/974)
 
 ## v0.128
+
+_04 Feb 2025_
 
 #### Feat
 
@@ -1961,11 +2005,15 @@ where each class name or style property can be managed separately.
 
 ## v0.127
 
+_01 Feb 2025_
+
 #### Fix
 
 - Fix component rendering when using `{% cache %}` with remote cache and multiple web servers ([#930](https://github.com/django-components/django-components/issues/930))
 
 ## v0.126
+
+_29 Jan 2025_
 
 #### Refactor
 
@@ -1976,6 +2024,8 @@ where each class name or style property can be managed separately.
     - And for the end of `<head>` we search for the **first** occurrence of `</head>`
 
 ## v0.125
+
+_22 Jan 2025_
 
 ⚠️ Attention ⚠️ - We migrated from `EmilStenstrom/django-components` to `django-components/django-components`.
 
@@ -2044,6 +2094,8 @@ If you see any broken links or other issues, please report them in [#922](https:
 
 ## v0.124
 
+_07 Jan 2025_
+
 #### Feat
 
 - Instead of inlining the JS and CSS under `Component.js` and `Component.css`, you can move
@@ -2095,11 +2147,15 @@ If you see any broken links or other issues, please report them in [#922](https:
 
 ## v0.123
 
+_23 Dec 2024_
+
 #### Fix
 
 - Fix edge cases around rendering components whose templates used the `{% extends %}` template tag ([#859](https://github.com/django-components/django-components/pull/859))
 
 ## v0.122
+
+_19 Dec 2024_
 
 #### Feat
 
@@ -2107,11 +2163,15 @@ If you see any broken links or other issues, please report them in [#922](https:
 
 ## v0.121
 
+_17 Dec 2024_
+
 #### Fix
 
 - Fix the use of Django template filters (`|lower:"etc"`) with component inputs [#855](https://github.com/django-components/django-components/pull/855).
 
 ## v0.120
+
+_15 Dec 2024_
 
 ⚠️ Attention ⚠️ - Please update to v0.121 to fix bugs introduced in v0.119.
 
@@ -2120,6 +2180,8 @@ If you see any broken links or other issues, please report them in [#922](https:
 - Fix the use of translation strings `_("bla")` as inputs to components [#849](https://github.com/django-components/django-components/pull/849).
 
 ## v0.119
+
+_13 Dec 2024_
 
 ⚠️ Attention ⚠️ - This release introduced bugs [#849](https://github.com/django-components/django-components/pull/849), [#855](https://github.com/django-components/django-components/pull/855). Please update to v0.121.
 
@@ -2136,6 +2198,8 @@ If you see any broken links or other issues, please report them in [#922](https:
 - Internal parsing of template tags tag was updated. No API change. (https://github.com/django-components/django-components/pull/827)
 
 ## v0.118
+
+_10 Dec 2024_
 
 #### Feat
 
@@ -2157,6 +2221,8 @@ If you see any broken links or other issues, please report them in [#922](https:
 
 ## v0.117
 
+_08 Dec 2024_
+
 #### Fix
 
 - The HTML parser no longer erronously inserts `<html><head><body>` on some occasions, and
@@ -2167,6 +2233,8 @@ If you see any broken links or other issues, please report them in [#922](https:
 - Replaced [Selectolax](https://github.com/rushter/selectolax) with [BeautifulSoup4](https://www.crummy.com/software/BeautifulSoup/bs4/doc/) as project dependencies.
 
 ## v0.116
+
+_06 Dec 2024_
 
 ⚠️ Attention ⚠️ - Please update to v0.117 to fix known bugs. See [#791](https://github.com/django-components/django-components/issues/791) and [#789](https://github.com/django-components/django-components/issues/789) and [#818](https://github.com/django-components/django-components/issues/818).
 
@@ -2215,6 +2283,8 @@ If you see any broken links or other issues, please report them in [#922](https:
 
 ## v0.115
 
+_02 Dec 2024_
+
 ⚠️ Attention ⚠️ - Please update to v0.117 to fix known bugs. See [#791](https://github.com/django-components/django-components/issues/791) and [#789](https://github.com/django-components/django-components/issues/789) and [#818](https://github.com/django-components/django-components/issues/818).
 
 #### Fix
@@ -2223,6 +2293,8 @@ If you see any broken links or other issues, please report them in [#922](https:
  (like `Component.template_name`) to POSIX paths.
 
 ## v0.114
+
+_27 Nov 2024_
 
 ⚠️ Attention ⚠️ - Please update to v0.117 to fix known bugs. See [#791](https://github.com/django-components/django-components/issues/791) and [#789](https://github.com/django-components/django-components/issues/789) and [#818](https://github.com/django-components/django-components/issues/818).
 
@@ -2233,6 +2305,8 @@ If you see any broken links or other issues, please report them in [#922](https:
 
 ## v0.113
 
+_26 Nov 2024_
+
 ⚠️ Attention ⚠️ - Please update to v0.117 to fix known bugs. See [#791](https://github.com/django-components/django-components/issues/791) and [#789](https://github.com/django-components/django-components/issues/789) and [#818](https://github.com/django-components/django-components/issues/818).
 
 #### Fix
@@ -2240,6 +2314,8 @@ If you see any broken links or other issues, please report them in [#922](https:
 - Ensure consistent order of scripts in `Component.Media.js`
 
 ## v0.112
+
+_26 Nov 2024_
 
 ⚠️ Attention ⚠️ - Please update to v0.117 to fix known bugs. See [#791](https://github.com/django-components/django-components/issues/791) and [#789](https://github.com/django-components/django-components/issues/789) and [#818](https://github.com/django-components/django-components/issues/818).
 
@@ -2249,6 +2325,8 @@ If you see any broken links or other issues, please report them in [#922](https:
 
 ## v0.111
 
+_26 Nov 2024_
+
 ⚠️ Attention ⚠️ - Please update to v0.117 to fix known bugs. See [#791](https://github.com/django-components/django-components/issues/791) and [#789](https://github.com/django-components/django-components/issues/789) and [#818](https://github.com/django-components/django-components/issues/818).
 
 #### Fix
@@ -2257,6 +2335,8 @@ If you see any broken links or other issues, please report them in [#922](https:
   tried to access provided data too early.
 
 ## v0.110 🚨📢
+
+_25 Nov 2024_
 
 _25 Nov 2024_
 
@@ -2586,6 +2666,8 @@ importing them.
 
 _11 Sep 2024_
 
+_11 Sep 2024_
+
 #### BREAKING CHANGES
 
 - `django_components.safer_staticfiles` app was removed. It is no longer needed.
@@ -2639,6 +2721,8 @@ _4 Sep 2024_
 
 _29 Aug 2024_
 
+_29 Aug 2024_
+
 #### Feat
 
 - Added support for dynamic components, where the component name is passed as a variable. (See [Dynamic components](https://github.com/django-components/django-components#dynamic-components))
@@ -2672,6 +2756,8 @@ _27 Aug 2024_
 - Component library authors can now configure `CONTEXT_BEHAVIOR` and `TAG_FORMATTER` settings independently from user settings.
 
 ## v0.92 🚨📢
+
+_22 Aug 2024_
 
 _22 Aug 2024_
 
@@ -2728,6 +2814,8 @@ _18 Aug 2024_
 
 _29 Jul 2024_
 
+_29 Jul 2024_
+
 #### BREAKING CHANGES
 
 - Autodiscovery module resolution changed. Following undocumented behavior was removed:
@@ -2744,6 +2832,8 @@ _29 Jul 2024_
     - Previously, autodiscovery handled relative files in `STATICFILES_DIRS`. To align with Django, `STATICFILES_DIRS` now must be full paths ([Django docs](https://docs.djangoproject.com/en/5.2/ref/settings/#std-setting-STATICFILES_DIRS)).
 
 ## v0.81 🚨📢
+
+_12 Jun 2024_
 
 _12 Jun 2024_
 
@@ -2769,11 +2859,15 @@ _1 Jun 2024_
 
 _1 Jun 2024_
 
+_1 Jun 2024_
+
 #### BREAKING CHANGES
 
 - Default value for the `COMPONENTS.context_behavior` setting was changes from `"isolated"` to `"django"`. If you did not set this value explicitly before, this may be a breaking change. See the rationale for change [here](https://github.com/django-components/django-components/issues/498).
 
 ## v0.77 🚨📢
+
+_23 May 2024_
 
 _23 May 2024_
 
@@ -2810,6 +2904,8 @@ _12 May 2024_
 
 _1 May 2024_
 
+_1 May 2024_
+
 #### BREAKING CHANGES
 
 - `{% if_filled "my_slot" %}` tags were replaced with `{{ component_vars.is_filled.my_slot }}` variables.
@@ -2825,6 +2921,8 @@ _17 Apr 2024_
 - Changed the default way how context variables are resolved in slots. See the [documentation](https://github.com/django-components/django-components/tree/0.67#isolate-components-slots) for more details.
 
 ## v0.50 🚨📢
+
+_26 Feb 2024_
 
 _26 Feb 2024_
 
@@ -2861,6 +2959,8 @@ _11 Apr 2023_
 - A second installable app `django_components.safer_staticfiles`. It provides the same behavior as `django.contrib.staticfiles` but with extra security guarantees (more info below in [Security Notes](https://github.com/django-components/django-components#security-notes)).
 
 ## v0.26 🚨📢
+
+_14 Mar 2023_
 
 _14 Mar 2023_
 


### PR DESCRIPTION
Fixes https://github.com/django-components/django-components/pull/1433#issuecomment-3367978592

> Btw I noticed that this PR didn't trigger the Discord integration ([see pipeline](https://github.com/django-components/django-components/actions/runs/18228321993/job/51918810372?pr=1433)). My guess is it's because this PR was opened from a fork, so it didn't have access to repository secrets. the URL to post to Discord is stored as a secret.
> 
> I'll fix this in the next PR
> 
> <img alt="Screenshot 2025-10-04 at 09 01 45" width="776" height="109" src="https://private-user-images.githubusercontent.com/25986782/497413236-50375ab6-9bf7-466f-a17f-b916fb11447c.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTk1NjE3MjgsIm5iZiI6MTc1OTU2MTQyOCwicGF0aCI6Ii8yNTk4Njc4Mi80OTc0MTMyMzYtNTAzNzVhYjYtOWJmNy00NjZmLWExN2YtYjkxNmZiMTE0NDdjLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTEwMDQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUxMDA0VDA3MDM0OFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWMzYWYzODY3YjI1NDJmZWI3MzM5NGU2ODk0YWMyNjRkZjg4OTAzYzE2NGE3OWM2MzI3YjU4ZTg1M2UwYzY0ZWEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.9Y91UzeEmBc4YBGjXNYqAsHC_P301c2lgm-69pWyTug">

