### PR TITLE
[codex] Speed up test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        os: [ubuntu-latest, windows-latest]
+        include:
+          - python-version: "3.10"
+            os: ubuntu-latest
+          - python-version: "3.11"
+            os: ubuntu-latest
+          - python-version: "3.12"
+            os: ubuntu-latest
+          - python-version: "3.13"
+            os: ubuntu-latest
+          - python-version: "3.14"
+            os: ubuntu-latest
+          - python-version: "3.10"
+            os: windows-latest
+          - python-version: "3.14"
+            os: windows-latest
 
     steps:
       # Configure git to handle long paths
@@ -43,6 +56,32 @@ jobs:
         run: |
           uv sync --group ci
 
+      - name: Run tests
+        run: uv run tox
+
+  e2e:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.14"]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          uv sync --group ci
+
       # TODO: DELETEME
       # Workaround: Yarn Debian repo switched GPG key (Jan 2026); old key in images breaks apt-get update.
       # See https://github.com/yarnpkg/yarn/issues/9218
@@ -54,15 +93,38 @@ jobs:
           sudo rm -f /etc/apt/sources.list.d/yarn.list 2>/dev/null || true
       # DELETEME_END
 
-      # NOTE: WINDOWS ONLY - Installing system dependencies for Playwright browsers takes ~3-4 mins.
-      # See https://github.com/django-components/django-components/pull/1554
-      # See https://playwright.dev/docs/browsers#managing-browser-binaries
-      - name: Install Playwright browsers
+      - name: Install Playwright browser
         run: |
-          # See https://playwright.dev/python/docs/intro#installing-playwright-pytest
-          uv run playwright install chromium firefox webkit --with-deps
-      - name: Run tests
-        run: uv run tox
+          uv run playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: uv run tox -e e2e
+
+  benchmark_snapshots:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.14"]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          uv sync --group ci
+
+      - name: Run benchmark snapshot tests
+        run: uv run tox -e benchmark_snapshot
 
   # Coverage job - runs tests with coverage on a single Python version
   # NOTE: The steps are the same as the build job.
@@ -85,24 +147,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # TODO: DELETEME
-      # Workaround: Yarn Debian repo switched GPG key (Jan 2026); old key in images breaks apt-get update.
-      # See https://github.com/yarnpkg/yarn/issues/9218
-      # Remove this step once CI images ship with the updated Yarn APT key or Yarn repo is no longer enabled by default.
-      - name: Disable broken third-party apt repos (e.g. Yarn) before Playwright install
-        if: runner.os == 'Linux'
-        run: |
-          # Playwright's --with-deps runs apt-get update; a broken/unsigned Yarn repo breaks it.
-          sudo rm -f /etc/apt/sources.list.d/yarn.list 2>/dev/null || true
-      # DELETEME_END
-
-      # NOTE: WINDOWS ONLY - Installing system dependencies for Playwright browsers takes ~3-4 mins.
-      # See https://github.com/django-components/django-components/pull/1554
-      # See https://playwright.dev/docs/browsers#managing-browser-binaries
-      - name: Install Playwright browsers
-        run: |
-          # See https://playwright.dev/python/docs/intro#installing-playwright-pytest
-          uv run playwright install chromium firefox webkit --with-deps
       # Run the actual tests with coverage
       - name: Run coverage
         run: uv run tox -e coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,9 @@ docs = [
     "mkdocstrings",
     "mkdocstrings-python",
     "pymdown-extensions",
-    "pygments",
+    # Pygments 2.20 breaks mkdocstrings signature rendering by rejecting the
+    # None filename value passed through pymdownx.highlight.
+    "pygments<2.20",
     "pygments-djc",
     "django>=4.2",
     "djc-core>=1.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "django-template-partials",
     "tox",
     "pytest",
+    "pytest-xdist",
     "pytest-django",
     "pytest-asyncio==1.3.0",
     "syrupy",
@@ -80,6 +81,7 @@ dev = [
 ci = [
     "tox",
     "tox-gh-actions",
+    "pytest-xdist",
     "playwright",
     "requests",
     "types-requests",
@@ -136,6 +138,10 @@ namespaces = false
 [tool.pytest.ini_options]
 testpaths = ["tests", "docs/examples"]
 asyncio_mode = "auto"
+markers = [
+    "e2e: browser-based end-to-end tests that need the Django test server",
+    "benchmark_snapshot: large benchmark-render snapshot tests",
+]
 
 ###########################################
 # FORMATTING & TYPE-CHECKING TOOLS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,22 @@ if TYPE_CHECKING:
     from _pytest.fixtures import FixtureRequest
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def django_dev_server():
     """Fixture to run Django development server in the background."""
     yield from run_django_dev_server()
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        path = item.path
+        if path.name in {
+            "test_benchmark_django.py",
+            "test_benchmark_django_small.py",
+            "test_benchmark_djc.py",
+            "test_benchmark_djc_small.py",
+        }:
+            item.add_marker(pytest.mark.benchmark_snapshot)
 
 
 @pytest_asyncio.fixture(scope="session")

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -1,12 +1,13 @@
 # ruff: noqa: T201
 
 import functools
+import os
 import subprocess
 import sys
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Literal, TypeAlias
+from typing import Any, Literal, TypeAlias, cast
 
 import pytest
 import requests
@@ -16,8 +17,16 @@ TEST_SERVER_PORT = "8000"
 TEST_SERVER_URL = f"http://127.0.0.1:{TEST_SERVER_PORT}"
 
 
-BROWSER_NAMES = ["chromium", "firefox", "webkit"]
 BrowserType: TypeAlias = Literal["chromium", "firefox", "webkit"]
+_DEFAULT_BROWSER_NAMES: list[BrowserType] = ["chromium", "firefox", "webkit"]
+BROWSER_NAMES: list[BrowserType] = []
+for raw_browser_name in os.environ.get("DJC_TEST_BROWSERS", ",".join(_DEFAULT_BROWSER_NAMES)).split(","):
+    browser_name = raw_browser_name.strip()
+    if not browser_name:
+        continue
+    if browser_name not in _DEFAULT_BROWSER_NAMES:
+        raise ValueError(f"Unknown browser: {browser_name}")
+    BROWSER_NAMES.append(cast("BrowserType", browser_name))
 
 
 async def _launch_browser(playwright: Playwright, browser_name: BrowserType) -> Browser:
@@ -44,8 +53,10 @@ def with_playwright(test_func: Callable[..., Any]) -> Callable[..., Any]:
 
     # NOTE: Using `browser` and `browser_name` as fixtures means that the test will be run
     #       once per browser type (chromium, firefox, webkit).
-    @functools.wraps(test_func)
+    @pytest.mark.e2e
+    @pytest.mark.usefixtures("django_dev_server")
     @pytest.mark.asyncio(scope="session")  # Needed to run the test in async mode
+    @functools.wraps(test_func)
     async def wrapper(self: Any, browser: Browser, browser_name: BrowserType, *args: Any, **kwargs: Any) -> Any:
         # Test
         await test_func(self, *args, browser=browser, browser_name=browser_name, **kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,8 @@ envlist =
   py{310,311}-django{42,52}
   py{312}-django{42,52,60}
   py{313,314}-django{52,60}
+  e2e
+  benchmark_snapshot
   ruff
   coverage
   mypy
@@ -49,7 +51,30 @@ deps =
   whitenoise
   # NOTE: Delete when Django 5.2 reaches end of life
   django-template-partials
-commands = pytest {posargs}
+commands =
+  pytest -n auto -m "not e2e and not benchmark_snapshot" --ignore=tests/test_templatetags_provide.py {posargs}
+  pytest -m "not e2e and not benchmark_snapshot" tests/test_templatetags_provide.py {posargs}
+
+[testenv:benchmark_snapshot]
+commands = pytest -m benchmark_snapshot {posargs}
+
+[testenv:e2e]
+package = wheel
+wheel_build_env = .pkg
+deps =
+  Django>=5.2,<5.3
+  djc-core==1.3.0
+  pytest
+  pytest-django
+  pytest-asyncio
+  playwright==1.57.0
+  pydantic
+  requests
+  types-requests
+  whitenoise
+set_env =
+  DJC_TEST_BROWSERS = chromium
+commands = pytest -m e2e {posargs}
 
 [testenv:ruff]
 deps = ruff
@@ -70,7 +95,7 @@ deps =
   types-requests
   whitenoise
 commands =
-  pytest --cov=django_components --cov-fail-under=75 --cov-branch
+  pytest -m "not e2e and not benchmark_snapshot" --cov=django_components --cov-fail-under=75 --cov-branch
 
 [testenv:mypy]
 deps =

--- a/uv.lock
+++ b/uv.lock
@@ -668,7 +668,7 @@ docs = [
     { name = "mkdocs-redirects" },
     { name = "mkdocstrings" },
     { name = "mkdocstrings-python" },
-    { name = "pygments" },
+    { name = "pygments", specifier = "<2.20" },
     { name = "pygments-djc" },
     { name = "pymdown-extensions" },
 ]
@@ -1899,11 +1899,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.20.0"
+version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -187,6 +187,9 @@ dependencies = [
     { name = "tinycss2" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/07/e8412a13019b3f737972dea23a2c61ca42becafc16c9338f4ca7a0caa993/cairosvg-2.9.0.tar.gz", hash = "sha256:1debb00cd2da11350d8b6f5ceb739f1b539196d71d5cf5eb7363dbd1bfbc8dc5", size = 40877, upload-time = "2026-03-13T15:42:00.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5011747466414c12cac8a8df77aa235068669a6a5a5df301a96209db6054/cairosvg-2.9.0-py3-none-any.whl", hash = "sha256:4b82d07d145377dffdfc19d9791bd5fb65539bb4da0adecf0bdbd9cd4ffd7c68", size = 45962, upload-time = "2026-03-14T13:56:33.512Z" },
+]
 
 [[package]]
 name = "certifi"
@@ -535,6 +538,7 @@ ci = [
     { name = "playwright" },
     { name = "pytest-asyncio" },
     { name = "pytest-django" },
+    { name = "pytest-xdist" },
     { name = "requests" },
     { name = "tox" },
     { name = "tox-gh-actions" },
@@ -560,6 +564,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-django" },
+    { name = "pytest-xdist" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "ruff" },
@@ -607,12 +612,13 @@ ci = [
     { name = "playwright" },
     { name = "pytest-asyncio" },
     { name = "pytest-django" },
+    { name = "pytest-xdist" },
     { name = "requests" },
     { name = "tox" },
     { name = "tox-gh-actions" },
     { name = "types-requests" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
-    { name = "virtualenv", specifier = "==20.35.4" },
+    { name = "virtualenv", specifier = "==21.2.4" },
     { name = "whitenoise" },
 ]
 dev = [
@@ -632,6 +638,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = "==1.3.0" },
     { name = "pytest-django" },
+    { name = "pytest-xdist" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "ruff" },
@@ -639,7 +646,7 @@ dev = [
     { name = "tox" },
     { name = "types-requests" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
-    { name = "virtualenv", specifier = "==20.35.4" },
+    { name = "virtualenv", specifier = "==21.2.4" },
     { name = "whitenoise" },
 ]
 docs = [
@@ -795,12 +802,21 @@ wheels = [
 ]
 
 [[package]]
-name = "filelock"
-version = "3.20.3"
+name = "execnet"
+version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
@@ -2052,6 +2068,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2061,6 +2090,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
 ]
 
 [[package]]
@@ -2441,17 +2483,18 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.35.4"
+version = "21.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
+    { name = "python-discovery" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/28/e6f1a6f655d620846bd9df527390ecc26b3805a0c5989048c210e22c5ca9/virtualenv-20.35.4.tar.gz", hash = "sha256:643d3914d73d3eeb0c552cbb12d7e82adf0e504dbf86a3182f8771a153a1971c", size = 6028799, upload-time = "2025-10-29T06:57:40.511Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/0c/c05523fa3181fdf0c9c52a6ba91a23fbf3246cc095f26f6516f9c60e6771/virtualenv-20.35.4-py3-none-any.whl", hash = "sha256:c21c9cede36c9753eeade68ba7d523529f228a403463376cf821eaae2b650f1b", size = 6005095, upload-time = "2025-10-29T06:57:37.598Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This splits the slow full test run into focused CI lanes so the compatibility matrix stops paying for browser setup and heavyweight snapshot tests on every Python/Django/OS combination.

Changes include:

- Run the main tox test env with `pytest-xdist`, excluding browser E2E and benchmark snapshot tests.
- Keep `tests/test_templatetags_provide.py` serial because it has shared cache assertions that are not xdist-safe.
- Add dedicated `e2e` and `benchmark_snapshot` tox envs.
- Make the Django E2E test server opt-in instead of an autouse fixture.
- Add `DJC_TEST_BROWSERS`, defaulting to all browsers locally while CI runs Chromium in the E2E lane.
- Reduce Windows matrix coverage to smoke coverage while keeping full Linux Python/Django coverage.
- Stop installing Playwright browsers in non-E2E CI jobs.

## Timing

Measured locally before the change:

- `uv run pytest -q`: `1325 passed, 7 skipped`, `real 120.50s`

Measured locally after the split:

- main non-E2E/non-benchmark run: `1211 passed, 6 skipped`, `real 9.69s`
- Chromium E2E lane: `37 passed`, `real 11.55s`
- benchmark snapshot lane: `4 passed`, `real 1.20s`

The comparable local split is about `22.44s` total versus `120.50s` before. CI should see a larger practical win because Playwright browser installation now only happens in the E2E job.

## Validation

- `uv run tox -e py314-django52`
- `uv run tox -e e2e,benchmark_snapshot`
- `uv run ruff check tests/conftest.py tests/e2e/utils.py`
- `uv run ruff format --check tests/conftest.py tests/e2e/utils.py`
- `uv run mypy tests/conftest.py tests/e2e/utils.py`