### PR TITLE
[codex] Update supported Django versions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,7 +72,7 @@ The package provides custom Django management commands:
 
 ### CI/CD Information  
 - GitHub Actions workflow: `.github/workflows/tests.yml`
-- Tests run on Python 3.10-3.14 with Django 4.2-5.2
+- Tests run on Python 3.10-3.14 with Django 5.2-6.0
 - Includes Playwright browser testing (requires `playwright install chromium firefox webkit --with-deps`)
 - Documentation building uses mkdocs
 - Pre-commit hooks run ruff

--- a/docs/overview/compatibility.md
+++ b/docs/overview/compatibility.md
@@ -2,9 +2,9 @@ Django-components supports all supported combinations versions of [Django](https
 
 | Python version | Django version |
 | -------------- | -------------- |
-| 3.10           | 4.2, 5.2       |
-| 3.11           | 4.2, 5.2       |
-| 3.12           | 4.2, 5.2, 6.0  |
+| 3.10           | 5.2            |
+| 3.11           | 5.2            |
+| 3.12           | 5.2, 6.0       |
 | 3.13           | 5.2, 6.0       |
 | 3.14           | 5.2, 6.0       |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ authors = [
 ]
 classifiers = [
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
     "Operating System :: OS Independent",
@@ -28,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 # Package dependencies
-dependencies = ["Django>=4.2", "djc-core>=1.3.0", "typing-extensions>=4.12.2"]
+dependencies = ["Django>=5.2", "djc-core>=1.3.0", "typing-extensions>=4.12.2"]
 license = { text = "MIT" }
 
 # See https://docs.pypi.org/project_metadata/#icons
@@ -119,7 +118,7 @@ docs = [
     # None filename value passed through pymdownx.highlight.
     "pygments<2.21",
     "pygments-djc",
-    "django>=4.2",
+    "django>=5.2",
     "djc-core>=1.3.0",
 ]
 

--- a/src/django_components/finders.py
+++ b/src/django_components/finders.py
@@ -97,18 +97,16 @@ class ComponentsFileSystemFinder(BaseFinder):
         """Look for files in the extra locations as defined in COMPONENTS.dirs."""
         # Handle deprecated `all` parameter:
         # - In Django 5.2, the `all` parameter was deprecated in favour of `find_all`.
-        # - Between Django 5.2 (inclusive) and 6.1 (exclusive), the `all` parameter was still
-        #   supported, but an error was raised if both were provided.
+        # - Between Django 5.2 and 6.1, the `all` parameter was still supported, but
+        #   an error was raised if both were provided.
         # - In Django 6.1, the `all` parameter was removed.
         #
         # See https://github.com/django/django/blob/5.2/django/contrib/staticfiles/finders.py#L58C9-L58C37
         # And https://github.com/django-components/django-components/issues/1119
-        if DJANGO_VERSION >= (5, 2) and DJANGO_VERSION < (6, 1):
+        if DJANGO_VERSION < (6, 1):
             find_all = self._check_deprecated_find_param(**kwargs)
-        elif DJANGO_VERSION >= (6, 1):
-            find_all = kwargs.get("find_all", False)
         else:
-            find_all = kwargs.get("all", False)
+            find_all = kwargs.get("find_all", False)
 
         matches: list[str] = []
         for prefix, root in self.locations:

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,9 @@ requires =
   tox-gh-actions>=3  # Run only those envs as set in [gh-actions]
 
 envlist =
-  py{310,311}-django{42,52}
-  py{312}-django{42,52,60}
+  py310-django{52}
+  py311-django{52}
+  py312-django{52,60}
   py{313,314}-django{52,60}
   e2e
   benchmark_snapshot
@@ -20,9 +21,9 @@ envlist =
 
 [gh-actions]
 python =
-  3.10: py310-django{42,52}
-  3.11: py311-django{42,52}
-  3.12: py312-django{42,52,60}
+  3.10: py310-django{52}
+  3.11: py311-django{52}
+  3.12: py312-django{52,60}
   3.13: py313-django{52,60}
   3.14: py314-django{52,60}
 
@@ -32,7 +33,6 @@ isolated_build = true
 package = wheel
 wheel_build_env = .pkg
 deps =
-  django42: Django>=4.2,<4.3
   django52: Django>=5.2,<5.3
   django60: Django>=6.0,<6.1
   djc-core==1.3.0

--- a/uv.lock
+++ b/uv.lock
@@ -600,7 +600,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.2" },
+    { name = "django", specifier = ">=5.2" },
     { name = "djc-core", specifier = ">=1.3.0" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
 ]
@@ -618,7 +618,7 @@ ci = [
     { name = "tox-gh-actions" },
     { name = "types-requests" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
-    { name = "virtualenv", specifier = "==21.2.4" },
+    { name = "virtualenv", specifier = "==21.3.0" },
     { name = "whitenoise" },
 ]
 dev = [
@@ -646,11 +646,11 @@ dev = [
     { name = "tox" },
     { name = "types-requests" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
-    { name = "virtualenv", specifier = "==21.2.4" },
+    { name = "virtualenv", specifier = "==21.3.0" },
     { name = "whitenoise" },
 ]
 docs = [
-    { name = "django", specifier = ">=4.2" },
+    { name = "django", specifier = ">=5.2" },
     { name = "djc-core", specifier = ">=1.3.0" },
     { name = "markdown-exec" },
     { name = "mike" },
@@ -668,7 +668,7 @@ docs = [
     { name = "mkdocs-redirects" },
     { name = "mkdocstrings" },
     { name = "mkdocstrings-python" },
-    { name = "pygments", specifier = "<2.20" },
+    { name = "pygments", specifier = "<2.21" },
     { name = "pygments-djc" },
     { name = "pymdown-extensions" },
 ]
@@ -2483,7 +2483,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.2.4"
+version = "21.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -2492,9 +2492,9 @@ dependencies = [
     { name = "python-discovery" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/8b/6331f7a7fe70131c301106ec1e7cf23e2501bf7d4ca3636805801ca191bb/virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e", size = 7614069, upload-time = "2026-04-27T17:05:58.927Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/eb/03bfb1299d4c4510329e470f13f9a4ce793df7fcb5a2fd3510f911066f61/virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7", size = 7594690, upload-time = "2026-04-27T17:05:55.468Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Updates the supported Python/Django matrix after Django 4.2 dropped out of the generated support table.

Fixes #1620.

## Changes

- Remove Django 4.2 from the compatibility docs, package classifiers, dependency floors, tox envs, and lock metadata.
- Keep the CI/contributor guidance aligned with the new Django 5.2-6.0 matrix.
- Remove the now-dead pre-Django-5.2 staticfiles finder compatibility branch.

## Validation

- `uv run python scripts/supported_versions.py check`
- `uv run tox -l`
- `uv run tox`
