### PR TITLE
Handle inclusion tags returning None

### DIFF
--- a/src/django_components/util/django_monkeypatch.py
+++ b/src/django_components/util/django_monkeypatch.py
@@ -295,6 +295,8 @@ def monkeypatch_inclusion_init(inclusion_node_cls: type[Node]) -> None:
 
         def new_func(*args: Any, **kwargs: Any) -> Any:
             result = orig_func(*args, **kwargs)
+            if result is None:
+                result = {}
             result["_DJC_INSIDE_INCLUSION_TAG"] = True
             return result
 

--- a/tests/test_dependency_rendering.py
+++ b/tests/test_dependency_rendering.py
@@ -681,3 +681,22 @@ class TestDependencyRendering:
         assert rendered.count("<style") == 1  # 1 Style
 
         registry.library.tags.pop("inclusion_tag")
+
+    # See https://github.com/django-components/django-components/issues/1603
+    def test_dependencies_with_component_in_inclusion_tag_returning_none(self):
+        registry.register(name="test_component", component=OtherComponent)
+
+        @registry.library.inclusion_tag("component_inside_include_sub.html")
+        def inclusion_tag():
+            return None
+
+        template_str: types.django_html = """
+            {% load component_tags %}
+            {% inclusion_tag %}
+        """
+        template = Template(template_str)
+        rendered: str = template.render(Context({}))
+
+        assert "XYZ:" in rendered
+
+        registry.library.tags.pop("inclusion_tag")


### PR DESCRIPTION
## Summary

- Treat an `inclusion_tag` result of `None` as an empty context before adding the internal dependency-rendering marker.
- Add a regression test for rendering a component inside an inclusion tag that returns `None`.

## Why

Some third-party inclusion tags rely on Django accepting `None` as an empty context. The dependency-rendering monkeypatch added its marker directly to the returned value, which raised when that value was `None`.

Fixes #1603.

## Validation

- `uv run pytest tests/test_dependency_rendering.py -k inclusion_tag`
- `uv run pytest tests/test_dependency_rendering.py`
- `uv run ruff check src/django_components/util/django_monkeypatch.py tests/test_dependency_rendering.py`