### PR TITLE
Fix stale registry finalizer

### DIFF
--- a/src/django_components/component_registry.py
+++ b/src/django_components/component_registry.py
@@ -357,7 +357,15 @@ class ComponentRegistry:
         self._registry[name] = entry
 
         # If the component class is deleted, unregister it from this registry.
-        finalize(entry.cls, lambda: self.unregister(name) if name in self._registry else None)
+        # Use the object ID so the finalizer does not keep the class alive.
+        registered_cls_object_id = id(entry.cls)
+
+        def unregister_component() -> None:
+            current_entry = self._registry.get(name)
+            if current_entry is not None and id(current_entry.cls) == registered_cls_object_id:
+                self.unregister(name)
+
+        finalize(entry.cls, unregister_component)
 
         extensions.on_component_registered(
             OnComponentRegisteredContext(

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,3 +1,5 @@
+import gc
+
 import pytest
 from django.template import Context, Engine, Library, Template
 from pytest_django.asserts import assertHTMLEqual
@@ -35,6 +37,16 @@ class MockComponent2(Component):
 class MockComponentView(Component):
     def get(self, request, *args, **kwargs):
         pass
+
+
+def gen_reimported_component():
+    return type(
+        "ReimportedComponent",
+        (Component,),
+        {
+            "__module__": "tests.components.reimported_component",
+        },
+    )
 
 
 @djc_test
@@ -131,6 +143,22 @@ class TestComponentRegistry:
             custom_registry.register(name="testcomponent", component=MockComponentView)
         except AlreadyRegistered:
             pytest.fail("Should not raise AlreadyRegistered")
+
+    def test_stale_component_finalizer_does_not_unregister_replacement(self):
+        custom_registry = ComponentRegistry()
+
+        component_v1 = gen_reimported_component()
+        custom_registry.register(name="testcomponent", component=component_v1)
+
+        component_v2 = gen_reimported_component()
+        assert component_v1 is not component_v2
+        assert component_v1.class_id == component_v2.class_id
+
+        custom_registry.register(name="testcomponent", component=component_v2)
+        del component_v1
+        gc.collect()
+
+        assert custom_registry.get("testcomponent") is component_v2
 
     def test_simple_unregister(self):
         custom_registry = ComponentRegistry()


### PR DESCRIPTION
## Summary
- Avoid keeping registered component classes alive through registry finalizer callbacks
- Prevent stale finalizers from unregistering newer replacement component classes
- Add a regression test for reimported component replacement

Fixes #1598

## Validation
- uv run pytest tests/test_registry.py