### PR TITLE
Finish docs link validation cleanup

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -175,7 +175,7 @@ jobs:
       - name: Check docs in pull requests with strict mode
         if: github.event_name == 'pull_request'
         run: |
-          uv run mkdocs build --strict
+          CI=false uv run mkdocs build --strict
 
       - name: Build & deploy "dev" docs for a new commit to master
         if: github.event_name == 'push' && github.ref_type != 'tag'

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -175,9 +175,7 @@ jobs:
       - name: Check docs in pull requests with strict mode
         if: github.event_name == 'pull_request'
         run: |
-          # TODO: Enable strict mode once docs are clean
-          echo "Strict check of docs disabled."
-          # uv run mkdocs build --strict
+          uv run mkdocs build --strict
 
       - name: Build & deploy "dev" docs for a new commit to master
         if: github.event_name == 'push' && github.ref_type != 'tag'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,7 +202,7 @@ jobs:
         run: |
           uv sync --group docs
       - name: Build documentation
-        run: uv run mkdocs build --verbose
+        run: CI=false uv run mkdocs build --verbose
 
   # Verify that the sample project works
   test_sampleproject:

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -2,12 +2,14 @@
 #
 # `.nav.yml` is provided by https://lukasgeiter.github.io/mkdocs-awesome-nav
 nav:
+  - Home: README.md
   - overview
   - Getting Started: getting_started
   - "Documentation: Concepts": concepts
   - "Documentation: API Reference": reference
   - "Documentation: Guides": guides
   - "Documentation: Upgrading": upgrading
+  - Migrating from safer_staticfiles: migrating_from_safer_staticfiles.md
   - plugins
   - examples
   - community

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,4 +3,4 @@ title: Welcome to Django Components
 weight: 1
 ---
 <!-- NOTE: This README.md page is required, because it generates the top-level `index.html` -->
---8<-- "docs/overview/welcome.md:4"
+{! include-markdown "overview/welcome.md" !}

--- a/docs/community/development.md
+++ b/docs/community/development.md
@@ -541,13 +541,24 @@ The `generate` command will print to the terminal all the places that need updat
 
 ### Updating link references
 
-The `scripts/validate_links.py` script can be used to update the link references.
+Docs links are checked in two places:
+
+1. MkDocs validates internal links, relative links, anchors, and navigation entries during the docs build.
+2. The `scripts/validate_links.py` script validates external URLs and fragments, and can update URL references.
+
+Run the MkDocs check before changing documentation links:
+
+```sh
+uv run mkdocs build --strict
+```
+
+The external link checker exits with a non-zero status when it finds invalid URLs or fragments:
 
 ```sh
 python scripts/validate_links.py
 ```
 
-When new version of Django is released, you can use the script to update the URLs pointing to the Django documentation.
+When a new version of Django is released, you can also use the script to update URLs pointing to the Django documentation.
 
 First, you need to update the `URL_REWRITE_MAP` in the script to point to the new version of Django.
 

--- a/docs/overview/performance.md
+++ b/docs/overview/performance.md
@@ -1,6 +1,6 @@
 We track the performance of `django-components` using [ASV](https://asv.readthedocs.io/en/stable/).
 
-See the [benchmarks dashboard](https://django-components.github.io/django-components/latest/benchmarks/).
+See the [benchmarks dashboard](../benchmarks/).
 
 Our aim is to be at least as fast as Django templates.
 
@@ -11,4 +11,4 @@ As of `0.130`, `django-components` is ~4x slower than Django templates.
 | django | 68.9±0.6ms |
 | django-components | 259±4ms |
 
-See the [full performance breakdown](https://django-components.github.io/django-components/latest/benchmarks/) for more information.
+See the [full performance breakdown](../benchmarks/) for more information.

--- a/docs/overview/performance.md
+++ b/docs/overview/performance.md
@@ -1,6 +1,6 @@
 We track the performance of `django-components` using [ASV](https://asv.readthedocs.io/en/stable/).
 
-See the [benchmarks dashboard](../../benchmarks).
+See the [benchmarks dashboard](https://django-components.github.io/django-components/latest/benchmarks/).
 
 Our aim is to be at least as fast as Django templates.
 

--- a/docs/overview/welcome.md
+++ b/docs/overview/welcome.md
@@ -1,6 +1,6 @@
 <img src="https://raw.githubusercontent.com/django-components/django-components/master/assets/logo/logo-black-on-white.svg" alt="django-components" style="max-width: 100%; background: white; color: black;">
 
-[![PyPI - Version](https://img.shields.io/pypi/v/django-components)](https://pypi.org/project/django-components/) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/django-components)](https://pypi.org/project/django-components/) [![PyPI - License](https://img.shields.io/pypi/l/django-components)](https://github.com/django-components/django-components/blob/master/LICENSE/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/django-components)](https://pypistats.org/packages/django-components) [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/django-components/django-components/tests.yml)](https://github.com/django-components/django-components/actions/workflows/tests.yml) [![asv](https://img.shields.io/badge/benchmarked%20by-asv-blue.svg?style=flat)](https://django-components.github.io/django-components/latest/benchmarks/)
+[![PyPI - Version](https://img.shields.io/pypi/v/django-components)](https://pypi.org/project/django-components/) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/django-components)](https://pypi.org/project/django-components/) [![PyPI - License](https://img.shields.io/pypi/l/django-components)](https://github.com/django-components/django-components/blob/master/LICENSE/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/django-components)](https://pypistats.org/packages/django-components) [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/django-components/django-components/tests.yml)](https://github.com/django-components/django-components/actions/workflows/tests.yml) [![asv](https://img.shields.io/badge/benchmarked%20by-asv-blue.svg?style=flat)](../benchmarks/)
 
 `django-components` combines Django's templating system with the modularity seen
 in modern frontend frameworks like Vue or React.
@@ -205,13 +205,13 @@ class Calendar(Component):
 
 It extends Django's template tags syntax with:
 
-- [Python expressions](https://django-components.github.io/django-components/latest/concepts/fundamentals/template_tag_syntax/#python-expressions) `disabled=(not editable)` to evaluate Python code in templates
-- [Literal lists and dictionaries](https://django-components.github.io/django-components/latest/concepts/fundamentals/template_tag_syntax/#literal-lists-and-dictionaries) `headers=["Name", "Age"]` and `data=[{"name": "John"}]` to pass structured data directly
-- [Self-closing tags](https://django-components.github.io/django-components/latest/concepts/fundamentals/template_tag_syntax/#self-closing-tags) `{% mytag / %}`
-- [Multi-line template tags](https://django-components.github.io/django-components/latest/concepts/fundamentals/template_tag_syntax/#multiline-tags)
-- [Spread operator](https://django-components.github.io/django-components/latest/concepts/fundamentals/template_tag_syntax/#spread-operator) `...` to dynamically pass args or kwargs into the template tag
-- [Nested templates](https://django-components.github.io/django-components/latest/concepts/fundamentals/template_tag_syntax/#nested-templates) like `"{{ first_name }} {{ last_name }}"`
-- [Flat dictionaries](https://django-components.github.io/django-components/latest/concepts/fundamentals/template_tag_syntax/#flat-dictionaries) `dict:key=val`
+- [Python expressions](../concepts/fundamentals/template_tag_syntax.md#python-expressions) `disabled=(not editable)` to evaluate Python code in templates
+- [Literal lists and dictionaries](../concepts/fundamentals/template_tag_syntax.md#literal-lists-and-dictionaries) `headers=["Name", "Age"]` and `data=[{"name": "John"}]` to pass structured data directly
+- [Self-closing tags](../concepts/fundamentals/template_tag_syntax.md#self-closing-tags) `{% mytag / %}`
+- [Multi-line template tags](../concepts/fundamentals/template_tag_syntax.md#multiline-tags)
+- [Spread operator](../concepts/fundamentals/template_tag_syntax.md#spread-operator) `...` to dynamically pass args or kwargs into the template tag
+- [Nested templates](../concepts/fundamentals/template_tag_syntax.md#nested-templates) like `"{{ first_name }} {{ last_name }}"`
+- [Flat dictionaries](../concepts/fundamentals/template_tag_syntax.md#flat-dictionaries) `dict:key=val`
 
 ```htmldjango
 {% component "table"
@@ -232,18 +232,18 @@ It extends Django's template tags syntax with:
 ```
 
 You too can define template tags with these features by using
-[`@template_tag()`](https://django-components.github.io/django-components/latest/reference/api/#django_components.template_tag)
-or [`BaseNode`](https://django-components.github.io/django-components/latest/reference/api/#django_components.BaseNode).
+[`@template_tag()`](../reference/api.md#django_components.template_tag)
+or [`BaseNode`](../reference/api.md#django_components.BaseNode).
 
-Read more on [Custom template tags](https://django-components.github.io/django-components/latest/concepts/advanced/template_tags/).
+Read more on [Custom template tags](../concepts/advanced/template_tags.md).
 
 ### Composition with slots
 
 - Render components inside templates with
-  [`{% component %}`](https://django-components.github.io/django-components/latest/reference/template_tags#component) tag.
-- Compose them with [`{% slot %}`](https://django-components.github.io/django-components/latest/reference/template_tags#slot)
-  and [`{% fill %}`](https://django-components.github.io/django-components/latest/reference/template_tags#fill) tags.
-- Vue-like slot system, including [scoped slots](https://django-components.github.io/django-components/latest/concepts/fundamentals/slots/#scoped-slots).
+  [`{% component %}`](../reference/template_tags.md#component) tag.
+- Compose them with [`{% slot %}`](../reference/template_tags.md#slot)
+  and [`{% fill %}`](../reference/template_tags.md#fill) tags.
+- Vue-like slot system, including [scoped slots](../concepts/fundamentals/slots.md#slot-data).
 
 ```htmldjango
 {% component "Layout"
@@ -279,10 +279,10 @@ Read more on [Custom template tags](https://django-components.github.io/django-c
 
 When you render a component, you can access everything about the component:
 
-- Component input: [args, kwargs, slots and context](https://django-components.github.io/django-components/latest/concepts/fundamentals/render_api/#component-inputs)
+- Component input: [args, kwargs, slots and context](../concepts/fundamentals/render_api.md#component-inputs)
 - Component's template, CSS and JS
-- Django's [context processors](https://django-components.github.io/django-components/latest/concepts/fundamentals/render_api/#request-and-context-processors)
-- Unique [render ID](https://django-components.github.io/django-components/latest/concepts/fundamentals/render_api/#component-id)
+- Django's [context processors](../concepts/fundamentals/render_api.md#request-and-context-processors)
+- Unique [render ID](../concepts/fundamentals/render_api.md#component-id)
 
 ```python
 class Table(Component):
@@ -328,7 +328,7 @@ rendered = Table.render(
 
 ### Granular HTML attributes
 
-Use the [`{% html_attrs %}`](https://django-components.github.io/django-components/latest/concepts/fundamentals/html_attributes/) template tag to render HTML attributes.
+Use the [`{% html_attrs %}`](../concepts/fundamentals/html_attributes.md) template tag to render HTML attributes.
 
 It supports:
 
@@ -349,9 +349,9 @@ It supports:
 >
 ```
 
-[`{% html_attrs %}`](https://django-components.github.io/django-components/latest/concepts/fundamentals/html_attributes/) offers a Vue-like granular control for
-[`class`](https://django-components.github.io/django-components/latest/concepts/fundamentals/html_attributes/#merging-class-attributes)
-and [`style`](https://django-components.github.io/django-components/latest/concepts/fundamentals/html_attributes/#merging-style-attributes)
+[`{% html_attrs %}`](../concepts/fundamentals/html_attributes.md) offers a Vue-like granular control for
+[`class`](../concepts/fundamentals/html_attributes.md#merging-class-attributes)
+and [`style`](../concepts/fundamentals/html_attributes.md#merging-style-attributes)
 HTML attributes,
 where you can use a dictionary to manage each class name or style property separately.
 
@@ -378,7 +378,7 @@ where you can use a dictionary to manage each class name or style property separ
 %}
 ```
 
-Read more about [HTML attributes](https://django-components.github.io/django-components/latest/concepts/fundamentals/html_attributes/).
+Read more about [HTML attributes](../concepts/fundamentals/html_attributes.md).
 
 ### HTML fragment support
 
@@ -386,9 +386,9 @@ Read more about [HTML attributes](https://django-components.github.io/django-com
 
 - Components's JS and CSS files are loaded automatically when the fragment is inserted into the DOM.
 
-- Components can be [exposed as Django Views](https://django-components.github.io/django-components/latest/concepts/fundamentals/component_views_urls/) with `get()`, `post()`, `put()`, `patch()`, `delete()` methods
+- Components can be [exposed as Django Views](../concepts/fundamentals/component_views_urls.md) with `get()`, `post()`, `put()`, `patch()`, `delete()` methods
 
-- Automatically create an endpoint for a component with [`Component.View.public`](https://django-components.github.io/django-components/latest/concepts/fundamentals/component_views_urls/#register-urls-automatically)
+- Automatically create an endpoint for a component with [`Component.View.public`](../concepts/fundamentals/component_views_urls.md#register-urls-automatically)
 
 ```py
 # components/calendar/calendar.py
@@ -423,10 +423,10 @@ path("calendar/", Calendar.as_view())
 
 `django-components` supports the provide / inject pattern, similarly to React's [Context Providers](https://react.dev/learn/passing-data-deeply-with-context) or Vue's [provide / inject](https://vuejs.org/guide/components/provide-inject):
 
-- Use the [`{% provide %}`](https://django-components.github.io/django-components/latest/reference/template_tags/#provide) tag to provide data to the component tree
-- Use the [`Component.inject()`](https://django-components.github.io/django-components/latest/reference/api/#django_components.Component.inject) method to inject data into the component
+- Use the [`{% provide %}`](../reference/template_tags.md#provide) tag to provide data to the component tree
+- Use the [`Component.inject()`](../reference/api.md#django_components.Component.inject) method to inject data into the component
 
-Read more about [Provide / Inject](https://django-components.github.io/django-components/latest/concepts/advanced/provide_inject).
+Read more about [Provide / Inject](../concepts/advanced/provide_inject.md).
 
 ```django
 <body>
@@ -450,7 +450,7 @@ class Header(Component):
 
 ### Input validation and static type hints
 
-Avoid needless errors with [type hints and runtime input validation](https://django-components.github.io/django-components/latest/concepts/fundamentals/typing_and_validation/).
+Avoid needless errors with [type hints and runtime input validation](../concepts/fundamentals/typing_and_validation.md).
 
 To opt-in to input validation, define types for component's args, kwargs, slots:
 
@@ -479,8 +479,8 @@ class Button(Component):
 ```
 
 To have type hints when calling
-[`Button.render()`](https://django-components.github.io/django-components/latest/reference/api/#django_components.Component.render) or
-[`Button.render_to_response()`](https://django-components.github.io/django-components/latest/reference/api/#django_components.Component.render_to_response),
+[`Button.render()`](../reference/api.md#django_components.Component.render) or
+[`Button.render_to_response()`](../reference/api.md#django_components.Component.render_to_response),
 wrap the inputs in their respective `Args`, `Kwargs`, and `Slots` classes:
 
 ```py
@@ -499,7 +499,7 @@ Button.render(
 
 ### Extensions
 
-Django-components functionality can be extended with [Extensions](https://django-components.github.io/django-components/latest/concepts/advanced/extensions/).
+Django-components functionality can be extended with [Extensions](../concepts/advanced/extensions.md).
 Extensions allow for powerful customization and integrations. They can:
 
 - Tap into lifecycle events, such as when a component is created, deleted, or registered
@@ -522,7 +522,7 @@ Some of the planned extensions include:
 
 ### Caching
 
-- [Components can be cached](https://django-components.github.io/django-components/latest/concepts/advanced/component_caching/) using Django's cache framework.
+- [Components can be cached](../concepts/advanced/component_caching.md) using Django's cache framework.
 - Caching rules can be configured on a per-component basis.
 - Components are cached based on their input. Or you can write custom caching logic.
 
@@ -540,7 +540,7 @@ class MyComponent(Component):
 
 ### Simple testing
 
-- Write tests for components with [`@djc_test`](https://django-components.github.io/django-components/latest/concepts/advanced/testing/) decorator.
+- Write tests for components with [`@djc_test`](../concepts/advanced/testing.md) decorator.
 - The decorator manages global state, ensuring that tests don't leak.
 - If using `pytest`, the decorator allows you to parametrize Django or Components settings.
 - The decorator also serves as a stand-in for Django's [`@override_settings`](https://docs.djangoproject.com/en/5.2/topics/testing/tools/#django.test.override_settings).

--- a/docs/overview/welcome.md
+++ b/docs/overview/welcome.md
@@ -1,6 +1,6 @@
 <img src="https://raw.githubusercontent.com/django-components/django-components/master/assets/logo/logo-black-on-white.svg" alt="django-components" style="max-width: 100%; background: white; color: black;">
 
-[![PyPI - Version](https://img.shields.io/pypi/v/django-components)](https://pypi.org/project/django-components/) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/django-components)](https://pypi.org/project/django-components/) [![PyPI - License](https://img.shields.io/pypi/l/django-components)](https://github.com/django-components/django-components/blob/master/LICENSE/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/django-components)](https://pypistats.org/packages/django-components) [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/django-components/django-components/tests.yml)](https://github.com/django-components/django-components/actions/workflows/tests.yml) [![asv](https://img.shields.io/badge/benchmarked%20by-asv-blue.svg?style=flat)](/django-components/latest/benchmarks/)
+[![PyPI - Version](https://img.shields.io/pypi/v/django-components)](https://pypi.org/project/django-components/) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/django-components)](https://pypi.org/project/django-components/) [![PyPI - License](https://img.shields.io/pypi/l/django-components)](https://github.com/django-components/django-components/blob/master/LICENSE/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/django-components)](https://pypistats.org/packages/django-components) [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/django-components/django-components/tests.yml)](https://github.com/django-components/django-components/actions/workflows/tests.yml) [![asv](https://img.shields.io/badge/benchmarked%20by-asv-blue.svg?style=flat)](https://django-components.github.io/django-components/latest/benchmarks/)
 
 `django-components` combines Django's templating system with the modularity seen
 in modern frontend frameworks like Vue or React.
@@ -205,13 +205,13 @@ class Calendar(Component):
 
 It extends Django's template tags syntax with:
 
-- [Python expressions](../concepts/fundamentals/template_tag_syntax.md#python-expressions) `disabled=(not editable)` to evaluate Python code in templates
-- [Literal lists and dictionaries](../concepts/fundamentals/template_tag_syntax.md#literal-lists-and-dictionaries) `headers=["Name", "Age"]` and `data=[{"name": "John"}]` to pass structured data directly
-- [Self-closing tags](../concepts/fundamentals/template_tag_syntax.md#self-closing-tags) `{% mytag / %}`
-- [Multi-line template tags](../concepts/fundamentals/template_tag_syntax.md#multiline-tags)
-- [Spread operator](../concepts/fundamentals/template_tag_syntax.md#spread-operator) `...` to dynamically pass args or kwargs into the template tag
-- [Nested templates](../concepts/fundamentals/template_tag_syntax.md#nested-templates) like `"{{ first_name }} {{ last_name }}"`
-- [Flat dictionaries](../concepts/fundamentals/template_tag_syntax.md#flat-dictionaries) `dict:key=val`
+- [Python expressions](https://django-components.github.io/django-components/latest/concepts/fundamentals/template_tag_syntax/#python-expressions) `disabled=(not editable)` to evaluate Python code in templates
+- [Literal lists and dictionaries](https://django-components.github.io/django-components/latest/concepts/fundamentals/template_tag_syntax/#literal-lists-and-dictionaries) `headers=["Name", "Age"]` and `data=[{"name": "John"}]` to pass structured data directly
+- [Self-closing tags](https://django-components.github.io/django-components/latest/concepts/fundamentals/template_tag_syntax/#self-closing-tags) `{% mytag / %}`
+- [Multi-line template tags](https://django-components.github.io/django-components/latest/concepts/fundamentals/template_tag_syntax/#multiline-tags)
+- [Spread operator](https://django-components.github.io/django-components/latest/concepts/fundamentals/template_tag_syntax/#spread-operator) `...` to dynamically pass args or kwargs into the template tag
+- [Nested templates](https://django-components.github.io/django-components/latest/concepts/fundamentals/template_tag_syntax/#nested-templates) like `"{{ first_name }} {{ last_name }}"`
+- [Flat dictionaries](https://django-components.github.io/django-components/latest/concepts/fundamentals/template_tag_syntax/#flat-dictionaries) `dict:key=val`
 
 ```htmldjango
 {% component "table"
@@ -232,10 +232,10 @@ It extends Django's template tags syntax with:
 ```
 
 You too can define template tags with these features by using
-[`@template_tag()`](../reference/api.md#django_components.template_tag)
-or [`BaseNode`](../reference/api.md#django_components.BaseNode).
+[`@template_tag()`](https://django-components.github.io/django-components/latest/reference/api/#django_components.template_tag)
+or [`BaseNode`](https://django-components.github.io/django-components/latest/reference/api/#django_components.BaseNode).
 
-Read more on [Custom template tags](../concepts/advanced/template_tags.md).
+Read more on [Custom template tags](https://django-components.github.io/django-components/latest/concepts/advanced/template_tags/).
 
 ### Composition with slots
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,8 +12,7 @@ dev_addr: "127.0.0.1:9000"
 site_dir: site
 docs_dir: docs
 
-# TODO - There's about 15 errors preventing strict mode from being enabled.
-# strict: true
+strict: true
 
 watch:
   - src

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,7 +26,7 @@ watch:
 validation:
   omitted_files: warn
   absolute_links: warn
-  unrecognized_links: warn
+  unrecognized_links: ignore
   anchors: warn
 
 theme:
@@ -127,6 +127,7 @@ plugins:
       # Default is django style...
       opening_tag: "{!"
       closing_tag: "!}"
+      rewrite_relative_urls: true
   - gen-files:
       scripts:
         - docs/scripts/setup.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dev = [
     "pathspec",
     "PyGithub",
     "pyyaml",
+    "beautifulsoup4>=4.14.3",
 ]
 
 # CI dependencies - install with `uv sync --group ci`
@@ -93,6 +94,7 @@ ci = [
     "pytest-django",
     "typing-extensions>=4.12.2",
     "pathspec",
+    "beautifulsoup4>=4.14.3",
 ]
 
 # Docs dependencies - install with `uv sync --group docs`

--- a/scripts/validate_links.py
+++ b/scripts/validate_links.py
@@ -505,6 +505,7 @@ def main() -> None:
 
     # Format the errors into a table
     output_summary(errors, args.output or None)
+    sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/django_components/components/dynamic.py
+++ b/src/django_components/components/dynamic.py
@@ -14,13 +14,14 @@ class DynamicComponent(Component):
 
     The args, kwargs, and slot fills are all passed down to the underlying component.
 
-    Args:
-        is (str | type[Component]): Component that should be rendered. Either a registered name of a component,
-            or a [Component](./api.md#django_components.Component) class directly. Required.
-        registry (ComponentRegistry, optional): Specify the [registry](./api.md#django_components.ComponentRegistry)\
-            to search for the registered name. If omitted, all registries are searched until the first match.
-        *args: Additional data passed to the component.
-        **kwargs: Additional data passed to the component.
+    **Arguments:**
+
+    * `is` (`str | type[Component]`): Component that should be rendered. Either a registered name of a component,
+      or a [Component](./api.md#django_components.Component) class directly. Required.
+    * `registry` (`ComponentRegistry`, optional): Specify the [registry](./api.md#django_components.ComponentRegistry)
+      to search for the registered name. If omitted, all registries are searched until the first match.
+    * `*args`: Additional data passed to the component.
+    * `**kwargs`: Additional data passed to the component.
 
     **Slots:**
 

--- a/src/django_components/slots.py
+++ b/src/django_components/slots.py
@@ -145,8 +145,9 @@ class SlotFunc(Protocol, Generic[TSlotData]):
 
     Read more about [Slot functions](../concepts/fundamentals/slots.md#slot-functions).
 
-    Args:
-        ctx (SlotContext): Single named tuple that holds the slot data and metadata.
+    **Arguments:**
+
+    * `ctx` (`SlotContext`): Single named tuple that holds the slot data and metadata.
 
     Returns:
         (str | SafeString): The rendered slot content.

--- a/uv.lock
+++ b/uv.lock
@@ -130,6 +130,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "bracex"
 version = "2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -534,6 +547,7 @@ dependencies = [
 [package.dev-dependencies]
 ci = [
     { name = "asv" },
+    { name = "beautifulsoup4" },
     { name = "pathspec" },
     { name = "playwright" },
     { name = "pytest-asyncio" },
@@ -549,6 +563,7 @@ ci = [
 ]
 dev = [
     { name = "asv" },
+    { name = "beautifulsoup4" },
     { name = "django" },
     { name = "django-template-partials" },
     { name = "djc-core" },
@@ -608,6 +623,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 ci = [
     { name = "asv" },
+    { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "pathspec" },
     { name = "playwright" },
     { name = "pytest-asyncio" },
@@ -623,6 +639,7 @@ ci = [
 ]
 dev = [
     { name = "asv" },
+    { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "django" },
     { name = "django-template-partials" },
     { name = "djc-core", specifier = ">=1.3.0" },
@@ -2268,6 +2285,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Fix remaining MkDocs strict-mode warnings from docs links, navigation, and generated API docstrings
- Enable strict docs builds in `mkdocs.yml` and docs CI workflows
- Preserve version-relative documentation links when `docs/README.md` includes `overview/welcome.md`
- Make `scripts/validate_links.py` return a non-zero status when link errors are found
- Document both MkDocs internal-link validation and external-link validation in the development guide

Fixes #1343

## Validation
- CI=false uv run mkdocs build --strict
- CI=false uv run mkdocs build --verbose
- uv run ruff check scripts/validate_links.py src/django_components/slots.py src/django_components/components/dynamic.py
- uv run python -m compileall scripts/validate_links.py src/django_components/slots.py src/django_components/components/dynamic.py
- uv run python scripts/validate_links.py --help