### PR TITLE
Preserve template expression traceback errors

### DIFF
--- a/src/django_components/expression.py
+++ b/src/django_components/expression.py
@@ -101,7 +101,13 @@ class StringifiedNode(Node):
     def __init__(self, wrapped_node: Node) -> None:
         super().__init__()
         self.wrapped_node = wrapped_node
+        if hasattr(wrapped_node, "token"):
+            self.token = wrapped_node.token
+        if hasattr(wrapped_node, "origin"):
+            self.origin = wrapped_node.origin
 
     def render(self, context: Context) -> str:
+        if not hasattr(self, "origin") and context.render_context.template is not None:
+            self.origin = context.render_context.template.origin
         result = self.wrapped_node.render(context)
         return str(result)

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -320,6 +320,35 @@ class TestTemplateExpression:
         # fmt: on
 
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
+    def test_multinode_expression_in_component_preserves_render_error_in_debug(self, components_settings):
+        def explode(value, _arg=None):
+            raise ValueError(f"boom: {value}")
+
+        registry.library.filter("explode_1597", explode)
+
+        @register("test")
+        class SimpleComponent(Component):
+            template: types.django_html = "{{ value }}"
+
+            def get_template_data(self, args, kwargs, slots, context):
+                return {"value": kwargs["value"]}
+
+        template = Template(
+            """
+            {% load component_tags %}
+            {% component 'test' value="prefix {{ value|explode_1597 }}" / %}
+            """
+        )
+
+        old_debug = template.engine.debug
+        template.engine.debug = True
+        try:
+            with pytest.raises(ValueError, match="boom: bad"):
+                template.render(Context({"value": "bad"}))
+        finally:
+            template.engine.debug = old_debug
+
+    @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_ignores_invalid_tag(self, components_settings):
         registry.library.tag(noop)
 


### PR DESCRIPTION
## Summary

Fixes #1597.

When a multi-node template expression raised while Django template debug mode was enabled, `StringifiedNode` could become Django's culprit node without carrying the metadata Django expects for traceback annotation. That replaced the original rendering error with an unrelated `AttributeError`.

This preserves the wrapped node's template metadata, and falls back to the active render context origin when needed, so the original exception is surfaced.

## Validation

- `uv run pytest tests/test_expression.py -q`
- `uv run tox -e ruff,mypy`
