### PR TITLE
Fix docs deploy strict warnings

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -189,7 +189,7 @@ jobs:
           git checkout master
 
           export SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
-          uv run mike deploy --push --update-aliases --title "dev (${SHORT_SHA})" dev
+          CI=false uv run mike deploy --push --update-aliases --title "dev (${SHORT_SHA})" dev
 
       - name: Build & deploy docs for a new tag
         if: github.ref_type == 'tag' && github.event_name == 'push'
@@ -204,5 +204,5 @@ jobs:
           git pull origin gh-pages
           git checkout master
 
-          uv run mike deploy --push --update-aliases $REF_NAME latest
+          CI=false uv run mike deploy --push --update-aliases $REF_NAME latest
           uv run mike set-default latest --push


### PR DESCRIPTION
## Summary

Fixes the docs deploy failure from https://github.com/django-components/django-components/actions/runs/25236139480.

The deploy path uses `mike deploy`, which internally runs `mkdocs build`. After enabling strict docs builds, that internal build was still running with `CI=true`, enabling the git metadata plugins and turning generated release-note warnings into a failed deploy.

This makes both `mike deploy` calls run with `CI=false`, matching the explicit docs build checks and preventing git metadata warnings for generated pages from aborting strict mode.

## Validation

- `CI=false uv run mkdocs build --strict`
- parsed `.github/workflows/release-docs.yml` as YAML
