### PR TITLE
Audit and fix latent finalizer / reimport bugs (follow-up to #1598/#1630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,19 @@
 
     Multi-node template expressions (e.g. `value="prefix {{ x }}"` passed to a component) are wrapped in an internal `StringifiedNode` node that previously carried no template origin. As a result, Django's debug-mode traceback annotator could not locate the failing source line. The host template's origin is now threaded through to these nodes, so errors raised inside such expressions are annotated against the correct template file.
 
-    This builds on [#1597](https://github.com/django-components/django-components/issues/1597) and [#1635](https://github.com/django-components/django-components/pull/1635).
+    See [#1597](https://github.com/django-components/django-components/issues/1597) and [#1635](https://github.com/django-components/django-components/pull/1635).
+
+- **`@djc_test` no longer re-executes already-imported component modules between tests**
+
+    The fixture used to pop every autodiscovered module from `sys.modules` at teardown. Now, the teardown snapshots `sys.modules` at setup and only clears modules the test brought in itself.
+
+    See [#1598](https://github.com/django-components/django-components/issues/1598) / [#1630](https://github.com/django-components/django-components/pull/1630).
+
+#### Refactor
+
+- **`ComponentRegistry.register()` raises `AlreadyRegistered` on any replacement**
+
+    Previously `register()` silently overwrote an existing entry whenever the old and new classes had the same `class_id`. Now, different classes under the same name now raise `AlreadyRegistered`, and must call `registry.unregister(name)` first. Re-registering the **exact same class object** is still a no-op.
 
 ## v0.150.0
 

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -3457,14 +3457,6 @@ class Component(metaclass=ComponentMeta):
         return template_data, js_data, css_data
 
 
-# Perf
-# Each component may use different start and end tags. We represent this
-# as individual subclasses of `ComponentNode`. However, multiple components
-# may use the same start & end tag combination, e.g. `{% component %}` and `{% endcomponent %}`.
-# So we cache the already-created subclasses to be reused.
-component_node_subclasses_by_name: dict[str, tuple[type["ComponentNode"], ComponentRegistry]] = {}
-
-
 class ComponentNode(BaseNode):
     """
     Renders one of the components that was previously registered with
@@ -3608,23 +3600,16 @@ class ComponentNode(BaseNode):
         # Set the component-specific start and end tags by subclassing the BaseNode
         subcls_name = cls.__name__ + "_" + name
 
-        # We try to reuse the same subclass for the same start tag, so we can
-        # avoid creating a new subclass for each time `{% component %}` is called.
-        if start_tag not in component_node_subclasses_by_name:
-            subcls: type[ComponentNode] = type(subcls_name, (cls,), {"tag": start_tag, "end_tag": end_tag})
-            component_node_subclasses_by_name[start_tag] = (subcls, registry)
-
-            # Remove the cache entry when either the registry or the component are deleted
-            finalize(subcls, lambda: component_node_subclasses_by_name.pop(start_tag, None))
-            finalize(registry, lambda: component_node_subclasses_by_name.pop(start_tag, None))
-
-        cached_subcls, cached_registry = component_node_subclasses_by_name[start_tag]
-
-        if cached_registry is not registry:
-            raise RuntimeError(
-                f"Detected two Components from different registries using the same start tag '{start_tag}'",
-            )
-        if cached_subcls.end_tag != end_tag:
+        # Reuse the same subclass for the same start tag inside this registry, so we
+        # don't create a fresh subclass per `{% component %}` token. Cached per-registry
+        # rather than module-globally: lifetime follows the registry's own, and two
+        # registries can reuse the same start_tag without colliding.
+        cache = registry._node_subcls_cache
+        cached_subcls: type[ComponentNode] | None = cache.get(start_tag)
+        if cached_subcls is None:
+            cached_subcls = type(subcls_name, (cls,), {"tag": start_tag, "end_tag": end_tag})
+            cache[start_tag] = cached_subcls
+        elif cached_subcls.end_tag != end_tag:
             raise RuntimeError(
                 f"Detected two Components using the same start tag '{start_tag}' but with different end tags",
             )
@@ -3633,7 +3618,7 @@ class ComponentNode(BaseNode):
         node: ComponentNode = super(cls, cached_subcls).parse(  # type: ignore[attr-defined]
             parser,
             token,
-            registry=cached_registry,
+            registry=registry,
             name=name,
         )
         return node

--- a/src/django_components/component_registry.py
+++ b/src/django_components/component_registry.py
@@ -240,6 +240,10 @@ class ComponentRegistry:
     ) -> None:
         self._registry: dict[str, ComponentRegistryEntry] = {}  # component name -> component_entry mapping
         self._tags: dict[str, set[str]] = {}  # tag -> list[component names]
+        # `finalize` handle per registered name, so we can `.detach()` the previous
+        # one when the entry is replaced or removed. Without this, stale finalizers
+        # would fire later and pop the wrong entry from `self._registry` (see #1598).
+        self._finalizers: dict[str, finalize] = {}
         self._library = library
         self._settings = settings
 
@@ -325,6 +329,14 @@ class ComponentRegistry:
         {% endcomponent %}
         ```
 
+        `register()` is additive. Calling it again with the exact same class object
+        is a no-op. Calling it with any other class - even one whose
+        [`class_id`](./api.md#django_components.Component.class_id) collides with the
+        existing one - raises
+        [`AlreadyRegistered`](./exceptions.md#django_components.AlreadyRegistered).
+        Call [`unregister()`](#django_components.ComponentRegistry.unregister) first
+        if you intend to replace the registered class.
+
         Args:
             name (str): The name under which the component will be registered. Required.
             component (type[Component]): The component class to register. Required.
@@ -332,7 +344,7 @@ class ComponentRegistry:
         **Raises:**
 
         - [`AlreadyRegistered`](./exceptions.md#django_components.AlreadyRegistered)
-        if a different component was already registered under the same name.
+        if `name` is already registered with any class other than `component` itself.
 
         **Example:**
 
@@ -341,9 +353,18 @@ class ComponentRegistry:
         ```
 
         """
-        existing_component = self._registry.get(name)
-        if existing_component and existing_component.cls.class_id != component.class_id:
-            raise AlreadyRegistered(f'The component "{name}" has already been registered')
+        existing_entry = self._registry.get(name)
+        if existing_entry is not None:
+            if existing_entry.cls is component:
+                # Same class object - re-registration is a no-op. Happens naturally
+                # when `autodiscover()` / `import_libraries()` run more than once and
+                # touch the same module (whose `@register` decorator was already
+                # evaluated on first import).
+                return
+            raise AlreadyRegistered(
+                f'The component "{name}" has already been registered. '
+                f'Call `registry.unregister("{name}")` before registering a different class.',
+            )
 
         entry = self._register_to_library(name, component)
 
@@ -357,7 +378,9 @@ class ComponentRegistry:
         self._registry[name] = entry
 
         # If the component class is deleted, unregister it from this registry.
-        # Use the object ID so the finalizer does not keep the class alive.
+        # The id-check inside the callback is defense-in-depth - the primary mechanism
+        # for avoiding stale finalizer fires is `.detach()` on entry removal, see
+        # `unregister()` below.
         registered_cls_object_id = id(entry.cls)
 
         def unregister_component() -> None:
@@ -365,7 +388,7 @@ class ComponentRegistry:
             if current_entry is not None and id(current_entry.cls) == registered_cls_object_id:
                 self.unregister(name)
 
-        finalize(entry.cls, unregister_component)
+        self._finalizers[name] = finalize(entry.cls, unregister_component)
 
         extensions.on_component_registered(
             OnComponentRegisteredContext(
@@ -427,6 +450,12 @@ class ComponentRegistry:
 
         entry = self._registry[name]
         del self._registry[name]
+
+        # Detach the finalizer so it cannot later fire and pop a replacement entry
+        # registered under the same name.
+        stale_finalizer = self._finalizers.pop(name, None)
+        if stale_finalizer is not None:
+            stale_finalizer.detach()
 
         extensions.on_component_unregistered(
             OnComponentUnregisteredContext(

--- a/src/django_components/component_registry.py
+++ b/src/django_components/component_registry.py
@@ -244,6 +244,11 @@ class ComponentRegistry:
         # one when the entry is replaced or removed. Without this, stale finalizers
         # would fire later and pop the wrong entry from `self._registry` (see #1598).
         self._finalizers: dict[str, finalize] = {}
+        # start_tag -> ComponentNode subclass. Cache reused on every template parse
+        # so we don't create a fresh subclass per `{% component %}` token. Per-registry,
+        # so the cache dies with the registry instead of pinning it forever via a
+        # module-global dict.
+        self._node_subcls_cache: dict[str, type] = {}
         self._library = library
         self._settings = settings
 

--- a/src/django_components/component_registry.py
+++ b/src/django_components/component_registry.py
@@ -31,9 +31,15 @@ TComponent = TypeVar("TComponent", bound="Component")
 
 class AlreadyRegistered(Exception):
     """
-    Raised when you try to register a [Component](./api.md#django_components.Component),
-    but it's already registered with given
+    Raised when you try to register a [Component](./api.md#django_components.Component)
+    under a name that is already registered with the given
     [ComponentRegistry](./api.md#django_components.ComponentRegistry).
+
+    Re-registering the exact same class object under the same name is a no-op
+    and does NOT raise - so calling `autodiscover()` or `import_libraries()`
+    more than once is safe. Any *other* class under that name raises and you
+    must call [`unregister()`](./api.md#django_components.ComponentRegistry.unregister)
+    first to replace the existing registration.
     """
 
 

--- a/src/django_components/util/testing.py
+++ b/src/django_components/util/testing.py
@@ -333,6 +333,10 @@ def djc_test(
                         continue
                     _all_registries_copies.append((reg_ref, list(reg._registry.keys())))
 
+                # Snapshot which modules were already imported before the test ran.
+                # See `_clear_djc_global_state` for why this matters.
+                _initial_sys_modules = frozenset(sys.modules)
+
                 # Prepare global state
                 _setup_djc_global_state(gen_id_patcher, csrf_token_patcher)
 
@@ -342,6 +346,7 @@ def djc_test(
                         csrf_token_patcher,
                         _all_components,  # type: ignore[arg-type]
                         _all_registries_copies,
+                        _initial_sys_modules,
                         gc_collect,
                     )
 
@@ -457,6 +462,7 @@ def _clear_djc_global_state(
     csrf_token_patcher: CsrfTokenPatcher,
     initial_components: InitialComponents,
     initial_registries_copies: RegistriesCopies,
+    initial_sys_modules: frozenset[str],
     gc_collect: bool = False,
 ) -> None:
     gen_id_patcher.stop()
@@ -540,12 +546,16 @@ def _clear_djc_global_state(
         for key in keys_registered_during_test:
             registry_original.unregister(key)
 
-    # Delete autoimported modules from memory, so the module
-    # is executed also the next time one of the tests calls `autodiscover`.
+    # Drop modules that the test brought in itself, so a later test sees a clean import.
+    # Modules that were already in `sys.modules` before the test ran are left alone -
+    # popping them would force `importlib.import_module()` to re-execute the file on
+    # the next test, creating a new class object with the same `class_id` as the old one
+    # (the precondition behind #1598).
     from django_components.autodiscovery import LOADED_MODULES  # noqa: PLC0415
 
     for mod in LOADED_MODULES:
-        sys.modules.pop(mod, None)
+        if mod not in initial_sys_modules:
+            sys.modules.pop(mod, None)
     LOADED_MODULES.clear()
 
     # Clear extensions caches

--- a/src/django_components/util/testing.py
+++ b/src/django_components/util/testing.py
@@ -20,7 +20,7 @@ from django.template.loaders.base import Loader
 from django.test import override_settings
 
 from django_components import ComponentsSettings
-from django_components.component import ALL_COMPONENTS, Component, component_node_subclasses_by_name
+from django_components.component import ALL_COMPONENTS, Component
 from django_components.component_registry import ALL_REGISTRIES, ComponentRegistry
 from django_components.extension import extensions
 from django_components.perfutil.provide import provide_cache
@@ -494,9 +494,6 @@ def _clear_djc_global_state(
     if provide_cache:
         provide_cache.clear()
 
-    # Remove cached Node subclasses
-    component_node_subclasses_by_name.clear()
-
     # Clean up any loaded media (HTML, JS, CSS)
     for comp_cls_ref in ALL_COMPONENTS:
         comp_cls = comp_cls_ref()
@@ -555,6 +552,12 @@ def _clear_djc_global_state(
             elif current_entry.cls is not original_cls:
                 registry_original.unregister(name)
                 registry_original.register(name, original_cls)
+
+        # Drop the parsed ComponentNode subclass cache. Otherwise a follow-up test
+        # that uses the same start_tag with a different end_tag (e.g. via a custom
+        # tag_formatter) would trip the "different end tags" RuntimeError in
+        # `ComponentNode.parse()`.
+        registry_original._node_subcls_cache.clear()
 
     # Drop modules that the test brought in itself, so a later test sees a clean import.
     # Modules that were already in `sys.modules` before the test ran are left alone -

--- a/src/django_components/util/testing.py
+++ b/src/django_components/util/testing.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from django_components.component_media import ComponentMedia
 
 RegistryRef: TypeAlias = ReferenceType[ComponentRegistry]
-RegistriesCopies: TypeAlias = list[tuple[ReferenceType[ComponentRegistry], list[str]]]
+RegistriesCopies: TypeAlias = list[tuple[ReferenceType[ComponentRegistry], dict[str, type[Component]]]]
 InitialComponents: TypeAlias = list[ReferenceType[type[Component]]]
 
 
@@ -331,7 +331,9 @@ def djc_test(
                     reg = reg_ref()
                     if not reg:
                         continue
-                    _all_registries_copies.append((reg_ref, list(reg._registry.keys())))
+                    _all_registries_copies.append(
+                        (reg_ref, {name: entry.cls for name, entry in reg._registry.items()}),
+                    )
 
                 # Snapshot which modules were already imported before the test ran.
                 # See `_clear_djc_global_state` for why this matters.
@@ -528,23 +530,31 @@ def _clear_djc_global_state(
         if is_ref_deleted or registry_ref not in initial_registries_set:
             del ALL_REGISTRIES[len(ALL_REGISTRIES) - index - 1]
 
-    # For the remaining registries, unregistr components that were registered
-    # during tests.
-    # NOTE: The approach below does NOT take into account:
-    # - If a component was UNregistered during the test
-    # - If a previously-registered component was overwritten with different registration.
-    for reg_ref, init_keys in initial_registries_copies:
+    # For the remaining registries, restore the registry contents to their pre-test state:
+    # - Unregister keys that were added during the test
+    # - Restore any initial entry that was removed or replaced during the test
+    #   (re-applying with the original class object so tests that swap out a registration
+    #   for new settings - e.g. re-running `ComponentsConfig.ready()` - don't leak the
+    #   substituted entry into the next test)
+    for reg_ref, init_entries in initial_registries_copies:
         registry_original = reg_ref()
         if not registry_original:
             continue
 
-        # Get the keys that were registered during the test
-        initial_registered_keys = set(init_keys)
+        # Remove keys that were added during the test.
         after_test_registered_keys = set(registry_original._registry.keys())
-        keys_registered_during_test = after_test_registered_keys - initial_registered_keys
-        # Remove them
+        keys_registered_during_test = after_test_registered_keys - init_entries.keys()
         for key in keys_registered_during_test:
             registry_original.unregister(key)
+
+        # Restore initial entries that were removed or replaced during the test.
+        for name, original_cls in init_entries.items():
+            current_entry = registry_original._registry.get(name)
+            if current_entry is None:
+                registry_original.register(name, original_cls)
+            elif current_entry.cls is not original_cls:
+                registry_original.unregister(name)
+                registry_original.register(name, original_cls)
 
     # Drop modules that the test brought in itself, so a later test sees a clean import.
     # Modules that were already in `sys.modules` before the test ran are left alone -

--- a/src/django_components/util/weakref.py
+++ b/src/django_components/util/weakref.py
@@ -16,8 +16,8 @@ def cached_ref(obj: T) -> ReferenceType[T]:
     obj_id = id(obj)
     if obj_id not in GLOBAL_REFS:
         GLOBAL_REFS[obj_id] = ref(obj)
-
-    # Remove this entry from GLOBAL_REFS when the object is deleted.
-    finalize(obj, lambda: GLOBAL_REFS.pop(obj_id, None))
+        # Remove this entry from GLOBAL_REFS when the object is deleted.
+        # Attached only on first insertion - repeated calls must not stack finalizers.
+        finalize(obj, lambda: GLOBAL_REFS.pop(obj_id, None))
 
     return GLOBAL_REFS[obj_id]

--- a/tests/test_autodiscover.py
+++ b/tests/test_autodiscover.py
@@ -107,12 +107,17 @@ class TestImportLibraries:
 
 @djc_test
 class TestSysModulesIsolation:
-    """Regression coverage for #1598: modules present before a @djc_test should not be
-    re-executed by the test teardown."""
+    """
+    Regression coverage for #1598: modules present before a @djc_test should not be
+    re-executed by the test teardown.
+    """
 
     def test_modules_present_before_test_are_not_reimported(self):
-        # The module must be imported before any @djc_test cycle touches it.
-        import tests.components.single_file  # noqa: PLC0415
+        # Ensure the target module is in `sys.modules` before any @djc_test cycle
+        # touches it. This is the precondition the fix must preserve.
+        import importlib
+
+        importlib.import_module("tests.components.single_file")
 
         module_before = sys.modules.get("tests.components.single_file")
         assert module_before is not None
@@ -120,14 +125,14 @@ class TestSysModulesIsolation:
 
         @djc_test
         def inner_test() -> None:
-            from django_components.autodiscovery import autodiscover  # noqa: PLC0415
+            from django_components.autodiscovery import autodiscover
 
             autodiscover(map_module=lambda p: "tests." + p if p.startswith("components") else p)
 
         # Run two cycles - prior to the fix, the first teardown would pop the module from
         # `sys.modules`, and the second setup's `autodiscover` would re-execute it.
-        inner_test()
-        inner_test()
+        inner_test()  # type: ignore[call-arg]
+        inner_test()  # type: ignore[call-arg]
 
         module_after = sys.modules.get("tests.components.single_file")
         assert module_after is not None

--- a/tests/test_autodiscover.py
+++ b/tests/test_autodiscover.py
@@ -95,3 +95,35 @@ class TestImportLibraries:
             pytest.fail("Autodiscover should not raise AlreadyRegistered exception")
 
         assert seen == ["tests.components.single_file", "tests.components.multi_file.multi_file"]
+
+
+@djc_test
+class TestSysModulesIsolation:
+    """Regression coverage for #1598: modules present before a @djc_test should not be
+    re-executed by the test teardown."""
+
+    def test_modules_present_before_test_are_not_reimported(self):
+        # The module must be imported before any @djc_test cycle touches it.
+        import tests.components.single_file  # noqa: PLC0415
+
+        module_before = sys.modules.get("tests.components.single_file")
+        assert module_before is not None
+        module_id_before = id(module_before)
+
+        @djc_test
+        def inner_test() -> None:
+            from django_components.autodiscovery import autodiscover  # noqa: PLC0415
+
+            autodiscover(map_module=lambda p: "tests." + p if p.startswith("components") else p)
+
+        # Run two cycles - prior to the fix, the first teardown would pop the module from
+        # `sys.modules`, and the second setup's `autodiscover` would re-execute it.
+        inner_test()
+        inner_test()
+
+        module_after = sys.modules.get("tests.components.single_file")
+        assert module_after is not None
+        assert id(module_after) == module_id_before, (
+            "tests.components.single_file was re-executed across @djc_test cycles; "
+            "the sys.modules snapshot in _clear_djc_global_state should have prevented this."
+        )

--- a/tests/test_autodiscover.py
+++ b/tests/test_autodiscover.py
@@ -82,6 +82,14 @@ class TestImportLibraries:
         },
     )
     def test_import_libraries_map_modules(self):
+        # Strict `register()` requires explicit unregister before a reimport produces
+        # a fresh class object under the same name.
+        all_components = registry.all().copy()
+        if "single_file_component" in all_components:
+            registry.unregister("single_file_component")
+        if "multi_file_component" in all_components:
+            registry.unregister("multi_file_component")
+
         # Ensure that the modules are executed again after import
         if "tests.components.single_file" in sys.modules:
             del sys.modules["tests.components.single_file"]

--- a/tests/test_component_dynamic.py
+++ b/tests/test_component_dynamic.py
@@ -156,6 +156,11 @@ class TestDynamicComponent:
     def test_shorthand_formatter(self, components_settings):
         from django_components.apps import ComponentsConfig
 
+        # `ComponentsConfig.ready()` re-registers "dynamic" so it picks up the new
+        # tag_formatter. Strict `register()` requires an explicit unregister first.
+        if registry.has("dynamic"):
+            registry.unregister("dynamic")
+
         ComponentsConfig.ready(None)  # type: ignore[arg-type]
 
         registry.register(name="test", component=self._gen_simple_component())
@@ -179,6 +184,11 @@ class TestDynamicComponent:
     )
     def test_component_name_is_configurable(self, components_settings):
         from django_components.apps import ComponentsConfig
+
+        # See `test_shorthand_formatter` for why `ComponentsConfig.ready()` needs an
+        # explicit unregister under the strict `register()` contract.
+        if registry.has("dynamic"):
+            registry.unregister("dynamic")
 
         ComponentsConfig.ready(None)  # type: ignore[arg-type]
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -190,6 +190,44 @@ class TestComponentRegistry:
         custom_registry.unregister(name="testcomponent")
         assert "testcomponent" not in custom_registry._finalizers
 
+    def test_node_subcls_cache_is_per_registry(self):
+        # Each registry owns its own `_node_subcls_cache`. Replaces the previous
+        # module-global `component_node_subclasses_by_name` that pinned both the
+        # subclass and the registry forever.
+        library_a = Library()
+        library_b = Library()
+        registry_a = ComponentRegistry(library=library_a)
+        registry_b = ComponentRegistry(library=library_b)
+
+        assert registry_a._node_subcls_cache == {}
+        assert registry_b._node_subcls_cache == {}
+        assert registry_a._node_subcls_cache is not registry_b._node_subcls_cache
+
+    def test_module_global_node_subcls_cache_no_longer_exists(self):
+        # Pre-fix, `django_components.component` exposed a module-global
+        # `component_node_subclasses_by_name` that pinned subclasses + registries
+        # forever. The cache now lives per-registry. Catch any accidental
+        # reintroduction of the global.
+        import django_components.component as component_module  # noqa: PLC0415
+
+        assert not hasattr(component_module, "component_node_subclasses_by_name")
+
+    def test_node_subcls_cache_populated_on_parse(self):
+        library = Library()
+        registry_local = ComponentRegistry(library=library)
+        registry_local.register("simple", MockComponent)
+
+        engine = Engine.get_default()
+        engine.template_builtins.append(library)
+        try:
+            assert registry_local._node_subcls_cache == {}
+            Template("{% component 'simple' / %}")
+            # `_register_to_library` uses `formatter.start_tag(comp_name)`, which
+            # for the default formatter returns "component" regardless of comp_name.
+            assert list(registry_local._node_subcls_cache.keys()) == ["component"]
+        finally:
+            engine.template_builtins.remove(library)
+
     def test_simple_unregister(self):
         custom_registry = ComponentRegistry()
         custom_registry.register(name="testcomponent", component=MockComponent)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -144,21 +144,51 @@ class TestComponentRegistry:
         except AlreadyRegistered:
             pytest.fail("Should not raise AlreadyRegistered")
 
-    def test_stale_component_finalizer_does_not_unregister_replacement(self):
+    def test_register_different_class_with_same_class_id_raises(self):
+        # Two distinct class objects with identical `class_id` is the exact #1598
+        # scenario. Replacement must require an explicit unregister.
+        custom_registry = ComponentRegistry()
+
+        component_v1 = gen_reimported_component()
+        component_v2 = gen_reimported_component()
+        assert component_v1 is not component_v2
+        assert component_v1.class_id == component_v2.class_id
+
+        custom_registry.register(name="testcomponent", component=component_v1)
+        with pytest.raises(AlreadyRegistered):
+            custom_registry.register(name="testcomponent", component=component_v2)
+
+        # Original entry is untouched.
+        assert custom_registry.get("testcomponent") is component_v1
+
+    def test_unregister_then_reregister_with_replacement_class_succeeds(self):
         custom_registry = ComponentRegistry()
 
         component_v1 = gen_reimported_component()
         custom_registry.register(name="testcomponent", component=component_v1)
 
-        component_v2 = gen_reimported_component()
-        assert component_v1 is not component_v2
-        assert component_v1.class_id == component_v2.class_id
+        custom_registry.unregister(name="testcomponent")
 
+        component_v2 = gen_reimported_component()
         custom_registry.register(name="testcomponent", component=component_v2)
+        assert custom_registry.get("testcomponent") is component_v2
+
+        # Exactly one finalizer is tracked for the live entry.
+        assert len(custom_registry._finalizers) == 1
+
+        # Garbage-collecting the prior class object must NOT touch the live entry,
+        # since `unregister()` detached its finalizer.
         del component_v1
         gc.collect()
-
         assert custom_registry.get("testcomponent") is component_v2
+
+    def test_unregister_detaches_finalizer(self):
+        custom_registry = ComponentRegistry()
+        custom_registry.register(name="testcomponent", component=MockComponent)
+        assert "testcomponent" in custom_registry._finalizers
+
+        custom_registry.unregister(name="testcomponent")
+        assert "testcomponent" not in custom_registry._finalizers
 
     def test_simple_unregister(self):
         custom_registry = ComponentRegistry()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -208,7 +208,7 @@ class TestComponentRegistry:
         # `component_node_subclasses_by_name` that pinned subclasses + registries
         # forever. The cache now lives per-registry. Catch any accidental
         # reintroduction of the global.
-        import django_components.component as component_module  # noqa: PLC0415
+        import django_components.component as component_module
 
         assert not hasattr(component_module, "component_node_subclasses_by_name")
 

--- a/tests/test_util_weakref.py
+++ b/tests/test_util_weakref.py
@@ -1,0 +1,38 @@
+import gc
+import weakref
+
+from django_components.util.weakref import GLOBAL_REFS, cached_ref
+
+
+class _Dummy:
+    pass
+
+
+class TestCachedRef:
+    def test_returns_same_reference_on_repeated_calls(self):
+        obj = _Dummy()
+        r1 = cached_ref(obj)
+        r2 = cached_ref(obj)
+        assert r1 is r2
+        assert r1() is obj
+
+    def test_does_not_stack_finalizers_on_repeated_calls(self):
+        # `cached_ref` previously attached a new `weakref.finalize` on every
+        # call, even on cache hit. Each `finalize` registers a weak reference
+        # to the target, so the leak shows up as a growing
+        # `weakref.getweakrefcount(obj)`.
+        obj = _Dummy()
+        cached_ref(obj)
+        baseline = weakref.getweakrefcount(obj)
+        for _ in range(20):
+            cached_ref(obj)
+        assert weakref.getweakrefcount(obj) == baseline
+
+    def test_global_refs_entry_removed_on_collection(self):
+        obj = _Dummy()
+        cached_ref(obj)
+        obj_id = id(obj)
+        assert obj_id in GLOBAL_REFS
+        del obj
+        gc.collect()
+        assert obj_id not in GLOBAL_REFS


### PR DESCRIPTION
(Juro)

After reading through https://github.com/django-components/django-components/issues/1598 and https://github.com/django-components/django-components/pull/1630, I explored whether there are more bugs of the same class (where we set up ref finalizers to act on to act on some registered name instead of on the object identity itself).

Also decided to implement option B from https://github.com/django-components/django-components/issues/1598 - ie the `@djc_test` decorator should clean up / reset only those imports that were actually done DURING the test function, and leave alone those imports that have already ran before `@djc_test`.

---

(Opus 4.8)

## Summary

Audit of weak-reference and `finalize`-callback patterns adjacent to the registry, prompted by PR #1630 (which patched the symptom of #1598). The audit surfaced three more latent issues and one tightening opportunity. All four are fixed here as separate reviewable commits on one branch.

| # | Concern | Commit |
|---|---|---|
| 2 | `util.weakref.cached_ref` attached a fresh `weakref.finalize` to its target on every call (leak per call) | [`1c972de`](https://github.com/django-components/django-components/commit/1c972de) |
| 3 | `@djc_test` teardown popped *every* `LOADED_MODULES` entry from `sys.modules`, including modules that were already imported before the test - causing the next test's `autodiscover()` to re-execute them and produce class objects with colliding `class_id`s (the precondition behind #1598) | [`20b7e8f`](https://github.com/django-components/django-components/commit/20b7e8f) |
| 4 | `ComponentRegistry.register()` silently overwrote entries whenever the new class shared a `class_id` with the old one (the trapdoor #1598 went through). Per-name finalizer tracking now eagerly `.detach()`es on `unregister()` and the contract is strict. | [`df1c7c1`](https://github.com/django-components/django-components/commit/df1c7c1) |
| 1 | `component_node_subclasses_by_name` was a module-global dict whose tuple values held strong references to both the subclass and the registry, forming a self-pinning cycle that the cleanup `finalize` callbacks could never break. Cache moved per-registry. | [`1d933cb`](https://github.com/django-components/django-components/commit/1d933cb) |

A fifth commit ([`c94d4d5`](https://github.com/django-components/django-components/commit/c94d4d5)) carries the changelog, the updated `AlreadyRegistered` docstring, and ruff cleanup.

## Behaviour changes worth highlighting

- **`register()` is now strict.** Re-registering the *exact same class object* under the same name is a no-op (so calling `autodiscover()` / `import_libraries()` repeatedly is safe). Any *other* class under an existing name raises `AlreadyRegistered`. The new message tells the caller to `unregister()` first. Three existing tests that relied on the silent-overwrite path were updated to call `unregister()` explicitly.
- **`@djc_test` teardown is stronger.** It snapshots `sys.modules` at setup (Fix #3), restores initial registry entries that tests removed/replaced (needed for the strict register contract), and clears each registry's `_node_subcls_cache` (so a follow-up test using a different `tag_formatter` for the same start_tag isn't tripped).
- **Module-global `component_node_subclasses_by_name` is gone.** A new regression test catches accidental reintroduction.

## Test plan

- [x] `uv run ruff check .` - clean
- [x] `uv run ruff format --check .` - clean
- [x] `uv run mypy .` - clean (4 pre-existing errors in `docs/scripts/people.py` / `site/scripts/people.py` confirmed unrelated by running mypy on master)
- [x] `uv run pytest` (excluding benchmarks and e2e) - **1240 passed, 6 skipped, 0 failures**. The 111 e2e errors are pre-existing Playwright-not-installed.
- [x] `uv run mkdocs build --strict` - built successfully
- [x] Each fix has a regression test added alongside it. New tests:
  - `tests/test_util_weakref.py` (new file) - `cached_ref` does not stack finalizers, returns same ref, cleans up on GC
  - `tests/test_autodiscover.py::TestSysModulesIsolation` - module identity preserved across `@djc_test` cycles
  - `tests/test_registry.py` - strict register contract, finalizer detach on unregister, per-registry node cache
- [x] All five commits land their changes with the related test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)