### PR TITLE
fix: stop CacheExtension leaking a cache key when a later extension short-circuits the render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,7 @@
 
 - **Fixed a component cache memory leak**
 
-    The component cache could retain an internal entry per render when another extension short-circuited a cached component's render. Such entries are now released together with the component.
-
-    See [#1607](https://github.com/django-components/django-components/issues/1607).
+    See [#1648](https://github.com/django-components/django-components/issues/1648).
 
 #### Refactor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
 
     See [#1598](https://github.com/django-components/django-components/issues/1598) / [#1630](https://github.com/django-components/django-components/pull/1630).
 
+- **Fixed a component cache memory leak**
+
+    The component cache could retain an internal entry per render when another extension short-circuited a cached component's render. Such entries are now released together with the component.
+
+    See [#1607](https://github.com/django-components/django-components/issues/1607).
+
 #### Refactor
 
 - **`ComponentRegistry.register()` raises `AlreadyRegistered` on any replacement**

--- a/src/django_components/extensions/cache.py
+++ b/src/django_components/extensions/cache.py
@@ -100,6 +100,13 @@ class ComponentCache(ExtensionComponentConfig):
     The name of the cache to use. If `None`, the default cache will be used.
     """
 
+    # Cache key for the in-progress render. Set in `CacheExtension.on_component_input` on a
+    # cache miss, and read back in `CacheExtension.on_component_rendered`. Stored here (on the
+    # per-component-instance config) rather than in a dict on the extension, so that the entry
+    # is released together with the component instead of leaking when another extension
+    # short-circuits the render. See `CacheExtension.on_component_rendered`.
+    _render_cache_key: str | None = None
+
     def get_entry(self, cache_key: str) -> Any:
         cache = self.get_cache()
         return cache.get(cache_key)
@@ -175,9 +182,6 @@ class CacheExtension(ComponentExtension):
 
     ComponentConfig = ComponentCache
 
-    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
-        self.render_id_to_cache_key: dict[str, str] = {}
-
     def on_component_input(self, ctx: OnComponentInputContext) -> Any | None:
         cache_instance = ctx.component.cache
         if not cache_instance.enabled:
@@ -190,9 +194,13 @@ class CacheExtension(ComponentExtension):
         if cached_result is not None:
             return cached_result
 
-        # NOTE: Store the mapping only on cache miss, because on cache hit the rendering
-        # is short-circuited and on_component_rendered (which pops the entry) is never called.
-        self.render_id_to_cache_key[ctx.component_id] = cache_key
+        # Cache miss - remember the key so `on_component_rendered` can store the result under it.
+        #
+        # NOTE: We stash the key on the per-component-instance config rather than in a dict on the
+        # extension. This way the key is released together with the component, instead of leaking
+        # when another extension's `on_component_input` short-circuits the render after ours has
+        # run (in which case `on_component_rendered` never fires for this component).
+        cache_instance._render_cache_key = cache_key
         return None
 
     # Save the rendered component to cache
@@ -201,9 +209,14 @@ class CacheExtension(ComponentExtension):
         if not cache_instance.enabled:
             return
 
+        # Don't cache the result if rendering raised.
         if ctx.error is not None:
-            self.render_id_to_cache_key.pop(ctx.component_id, None)
             return
 
-        cache_key = self.render_id_to_cache_key.pop(ctx.component_id)
+        # The key is set in `on_component_input` only on a cache miss. A cache hit short-circuits
+        # the render before this hook runs, so reaching here with no key means there's nothing
+        # to store.
+        cache_key = cache_instance._render_cache_key
+        if cache_key is None:
+            return
         cache_instance.set_entry(cache_key, ctx.result)

--- a/tests/test_component_cache.py
+++ b/tests/test_component_cache.py
@@ -1,5 +1,7 @@
+import gc
 import re
 import time
+import weakref
 
 import pytest
 from django.core.cache import caches
@@ -7,8 +9,8 @@ from django.template import Template
 from django.template.context import Context
 
 from django_components import Component, register
+from django_components.extension import ComponentExtension, OnComponentInputContext
 from django_components.extension import extensions as extension_manager
-from django_components.extensions.cache import CacheExtension
 from django_components.testing import djc_test
 
 from .testutils import setup_test_config
@@ -351,6 +353,26 @@ class TestComponentCache:
             )
 
 
+class ShortCircuitExtension(ComponentExtension):
+    """
+    Test extension that short-circuits the render from `on_component_input`, and records
+    weakrefs to the components it sees so a test can assert they are garbage-collected.
+
+    Because user extensions are always ordered after the built-in `CacheExtension`, this
+    reproduces the scenario where `CacheExtension.on_component_input` has already run (and
+    stored its key) but `on_component_rendered` never fires for the component.
+    """
+
+    name = "short_circuit"
+
+    def __init__(self) -> None:
+        self.seen_component_refs: list[weakref.ReferenceType] = []
+
+    def on_component_input(self, ctx: OnComponentInputContext) -> str:
+        self.seen_component_refs.append(weakref.ref(ctx.component))
+        return "SHORT_CIRCUITED"
+
+
 @djc_test(
     django_settings={
         "CACHES": {
@@ -360,34 +382,8 @@ class TestComponentCache:
         },
     },
 )
-class TestCacheRenderIdCleanup:
-    def _get_cache_ext(self) -> CacheExtension:
-        for ext in extension_manager.extensions:
-            if isinstance(ext, CacheExtension):
-                return ext
-        raise RuntimeError("CacheExtension not found")
-
-    def test_render_id_cleaned_up(self):
-        class TestComponent(Component):
-            template = "Hello {{ name }}"
-
-            class Cache:
-                enabled = True
-
-            def get_template_data(self, args, kwargs, slots, context):
-                return {"name": kwargs.get("name", "world")}
-
-        cache_ext = self._get_cache_ext()
-
-        # Cache miss
-        TestComponent.render(kwargs={"name": "world"})
-        assert len(cache_ext.render_id_to_cache_key) == 0
-
-        # Cache hit
-        TestComponent.render(kwargs={"name": "world"})
-        assert len(cache_ext.render_id_to_cache_key) == 0
-
-    def test_render_id_cleaned_up_on_error(self):
+class TestCacheRenderKeyLifecycle:
+    def test_error_does_not_cache(self):
         class ErrorComponent(Component):
             template = "Hello"
 
@@ -397,9 +393,49 @@ class TestCacheRenderIdCleanup:
             def on_render(self, context, template):
                 raise ValueError("deliberate error")
 
-        cache_ext = self._get_cache_ext()
-
         with pytest.raises(ValueError, match="deliberate error"):
             ErrorComponent.render()
 
-        assert len(cache_ext.render_id_to_cache_key) == 0
+        # Nothing should have been written to the cache on the error path.
+        assert len(caches["default"]._cache) == 0  # type: ignore[attr-defined]
+
+    @djc_test(components_settings={"extensions": [ShortCircuitExtension]})
+    def test_no_leak_when_later_extension_short_circuits(self):
+        """
+        Regression test for the leak where `CacheExtension.on_component_input` stored a key
+        on a cache miss, but a later extension short-circuited the render so
+        `on_component_rendered` never ran to release it.
+
+        The key now lives on the per-component-instance config, so it must be released
+        together with the component. We assert that by checking the component instances are
+        garbage-collected.
+        """
+
+        class TestComponent(Component):
+            template = "Hello {{ name }}"
+
+            class Cache:
+                enabled = True
+
+            def get_template_data(self, args, kwargs, slots, context):
+                return {"name": kwargs.get("name", "world")}
+
+        short_circuit_ext = None
+        for ext in extension_manager.extensions:
+            if isinstance(ext, ShortCircuitExtension):
+                short_circuit_ext = ext
+                break
+        assert short_circuit_ext is not None
+
+        for i in range(5):
+            output = TestComponent.render(kwargs={"name": f"n{i}"})
+            assert output == "SHORT_CIRCUITED"
+
+        # The extension saw all 5 components on a cache miss (CacheExtension ran first and
+        # stashed a key on each component's config).
+        assert len(short_circuit_ext.seen_component_refs) == 5
+
+        gc.collect()
+
+        # None of the components (and thus none of the stashed cache keys) are retained.
+        assert all(ref() is None for ref in short_circuit_ext.seen_component_refs)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,4 +1,5 @@
 import gc
+import sys
 import tempfile
 import weakref
 from pathlib import Path
@@ -1117,6 +1118,10 @@ class TestContextProcessors:
         with pytest.raises(ValueError, match="Variable 'request' defined in component 'TestComponent' conflicts"):
             TestComponent.render(request=HttpRequest())
 
+    @pytest.mark.skipif(
+        sys.implementation.name != "cpython",
+        reason="Relies on CPython refcount + generational GC ordering across two collect passes.",
+    )
     def test_request_is_gc_after_render(self):
         class TestComponent(Component):
             template: types.django_html = """Hello"""


### PR DESCRIPTION
(Opus 4.8)

## Summary

Fixes a memory leak in `CacheExtension` that is the residual case left by #1613 / #1607.

`CacheExtension` tracked the in-progress cache key in `render_id_to_cache_key` — a dict on the singleton extension, keyed by render ID — and removed the entry in `on_component_rendered`. User extensions are always ordered **after** the built-in `CacheExtension` ([`app_settings.py`](https://github.com/django-components/django-components/blob/master/src/django_components/app_settings.py)). So if a later extension's `on_component_input` short-circuits the render (returns non-`None`) **after** `CacheExtension` has already stored its key on a cache miss, `on_component_rendered` never fires for that component and the entry is orphaned — growing unboundedly, one entry per render.

### The fix

Store the key on the **per-component-instance** `ComponentCache` config instead of a dict on the extension. A fresh component (and thus a fresh config) is built per render, so:

- The key is released together with the component — no dict to leak into.
- There is no longer any cross-render shared mutable state in the extension, so it is correct under concurrent rendering by construction (the old dict was safe only because it was keyed by render ID).

### Reproduction (before the fix)

An extension whose `on_component_input` returns non-`None`, registered after `CacheExtension`, rendering a cache-enabled component on cache miss 5×:

```
DICT SIZE AFTER 5 SHORT-CIRCUITED RENDERS: 5
AssertionError: LEAK: 5 orphaned entries
```

## Tests

- Replaced the dict-introspecting `TestCacheRenderIdCleanup` with `TestCacheRenderKeyLifecycle`:
  - `test_no_leak_when_later_extension_short_circuits` — reproduces the bug via a `ShortCircuitExtension` and asserts (by weakref) that the component instances are garbage-collected.
  - `test_error_does_not_cache` — error path doesn't write to the cache.
- Guarded the existing `test_request_is_gc_after_render` (added in #1613) with `skipif` for non-CPython, since its two-pass `gc.collect()` relies on CPython collection ordering.

> Per CLAUDE.md's contract-change rule: the removed `TestCacheRenderIdCleanup` asserted on the internal `render_id_to_cache_key` dict, which this PR deletes. The replacement asserts the same guarantee (no leak) against the new, observable mechanism (component GC) rather than the now-removed internal attribute.

## Checks

- `uv run ruff check .` — clean
- `uv run ruff format --check` (touched files) — clean
- `uv run mypy src/django_components/extensions/cache.py` — clean
- `uv run pytest tests/test_component_cache.py tests/test_context.py tests/test_extension.py` — 122 passed

Refs #1607, https://github.com/django-components/django-components/pull/1613

🤖 Generated with [Claude Code](https://claude.com/claude-code)