### PR TITLE
docs: warn against per-render state keyed by component ID in extensions

### DIFF
--- a/docs/concepts/advanced/extensions.md
+++ b/docs/concepts/advanced/extensions.md
@@ -497,6 +497,61 @@ class LoggerExtension(ComponentExtension):
         logger.log(...)
 ```
 
+### Storing data for a single render
+
+Sometimes an extension needs to remember something at the start of a component's render and
+use it again at the end. For example, you might compute a value in `on_component_input` and
+read it back in `on_component_rendered`.
+
+A natural first attempt is to keep a dictionary on the extension, with one entry per component:
+
+```python
+# ❌ Don't do this:
+class CacheLikeExtension(ComponentExtension):
+    name = "cache_like"
+
+    def __init__(self):
+        self.keys_by_id = {}
+
+    def on_component_input(self, ctx: OnComponentInputContext):
+        # Remember a value for this component...
+        self.keys_by_id[ctx.component_id] = compute_key(ctx)
+
+    def on_component_rendered(self, ctx: OnComponentRenderedContext):
+        # ...and read (and remove) it once the component finishes rendering.
+        key = self.keys_by_id.pop(ctx.component_id)
+        ...
+```
+
+The problem is that `on_component_rendered` does not always run. A component's render can be
+skipped - for example when the [cache extension](./component_caching.md) returns an
+already-cached result, or when another extension chooses to skip rendering. When a render is
+skipped, `on_component_rendered` is not called, so the entry added in `on_component_input` is
+never removed. The dictionary then keeps growing, one leftover entry per skipped render. That
+is a memory leak.
+
+Instead, store the value somewhere that is thrown away once the component is done rendering.
+Every component gets its own config object for your extension, available as
+`component.<extension_name>`, which is a good place to keep it:
+
+```python
+# ✅ Do this:
+class CacheLikeExtension(ComponentExtension):
+    name = "cache_like"
+
+    def on_component_input(self, ctx: OnComponentInputContext):
+        # `ctx.component.cache_like` is this component's config object for the
+        # `cache_like` extension. Storing the value here ties it to the component.
+        ctx.component.cache_like.render_key = compute_key(ctx)
+
+    def on_component_rendered(self, ctx: OnComponentRenderedContext):
+        key = ctx.component.cache_like.render_key
+        ...
+```
+
+Because that config object is discarded together with the component, nothing is left behind to
+leak, even when `on_component_rendered` is skipped.
+
 ## Extension commands
 
 Extensions in django-components can define custom commands that can be executed via the Django management command interface. This allows for powerful automation and customization capabilities.

--- a/src/django_components/extension.py
+++ b/src/django_components/extension.py
@@ -737,6 +737,29 @@ class ComponentExtension(metaclass=ExtensionMeta):
         You can use this to implement a caching mechanism for components, or define components
         that will be rendered conditionally.
 
+        !!! warning
+
+            When any extension short-circuits a component (by returning a non-null value), the
+            rest of that component's render is skipped, including
+            [`on_component_data`](./extension_hooks.md#django_components.extension.ComponentExtension.on_component_data)
+            and
+            [`on_component_rendered`](./extension_hooks.md#django_components.extension.ComponentExtension.on_component_rendered).
+
+            Extensions run in order, and the built-in extensions (including the cache) run before
+            user extensions. So your `on_component_input` may run even when a later extension
+            short-circuits the same component.
+
+            In practice this means: if you save something at the start of a render (here, in
+            `on_component_input`) so you can use or remove it later in `on_component_rendered`,
+            that later hook might never run. And if you saved it in a dictionary that lives on
+            your extension, nothing ever removes that entry, so the dictionary grows by one with
+            every skipped render. That is a memory leak.
+
+            To avoid this, store anything you need for a single render on the component itself,
+            or on something that lives only as long as the component (such as its config object
+            for your extension, or `Slot.extra`). It is then discarded automatically once the
+            component is done, whether or not `on_component_rendered` runs.
+
         **Example:**
 
         ```python


### PR DESCRIPTION
(Opus 4.8)

## Summary

Documentation follow-up to #1648 (the `CacheExtension` short-circuit leak).

That leak was a specific instance of a general trap for **extension authors**: if an extension stores per-render state in `on_component_input` (in a dict on the extension, keyed by `component_id`) and removes it in `on_component_rendered`, it leaks whenever a *later* extension short-circuits the render — because `on_component_rendered` never fires for that component, so the entry is never removed. One orphaned entry accumulates per skipped render.

This PR documents the trap and the fix (bind per-render state to the component's lifetime, e.g. its per-component extension config), so users don't reintroduce the same bug in their own extensions.

## Changes

- **`on_component_input` docstring** ([`extension.py`](https://github.com/django-components/django-components/blob/master/src/django_components/extension.py)) — a `!!! warning` explaining that short-circuiting skips `on_component_data` / `on_component_rendered`, and that per-render state must be tied to the component lifetime.
- **Extensions guide** ([`docs/concepts/advanced/extensions.md`](https://github.com/django-components/django-components/blob/master/docs/concepts/advanced/extensions.md)) — a new "Storing data for a single render" section with ❌/✅ examples, written for readers new to extensions. It sits next to the existing "Pass slot metadata" anti-pattern, which is the same shape for slots.

No code behavior change.

## Checks

- `uv run ruff check .` / `ruff format --check` — clean
- `uv run mypy src/django_components/extension.py` — clean
- `uv run mkdocs build --strict` — clean (link anchors verified against `docs/reference/extension_hooks.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)