### PR TITLE
{% cache %} compat follow-ups: docs, callback leak fix, regression tests

### DIFF
--- a/docs/concepts/advanced/component_caching.md
+++ b/docs/concepts/advanced/component_caching.md
@@ -179,3 +179,93 @@ class MyComponent(Component):
 ```
 
 In this example, the component's rendered output is cached for 5 minutes using the `my_cache` backend.
+
+## Using Django's `{% cache %}` tag with components
+
+You can wrap Django's
+[`{% cache %}` tag](https://docs.djangoproject.com/en/5.2/topics/cache/#template-fragment-caching)
+around `{% component %}` calls:
+
+```django
+{% load component_tags %}
+{% cache 500 "homepage_sidebar" %}
+    {% component "user_links" / %}
+    {% component "recent_posts" / %}
+{% endcache %}
+```
+
+It works out of the box; loading `component_tags` installs a component-aware
+version of `{% cache %}` automatically.
+
+Use `{% cache %}` to cache a *region* of a template (possibly with several
+components inside). Use `Component.Cache` (above) to cache a *single
+component* by its inputs.
+
+### Things to watch out for
+
+A cache entry is the **first render's** output, replayed verbatim on every
+subsequent hit. A few cases where that bites you:
+
+#### Clicking a button fires the handler more than once
+
+If you embed the same `{% cache %}` block in two places on one page (e.g. a
+sidebar in both the header and footer, both with the same cache key), the
+inner component's client-side wiring ends up duplicated. A `click` or
+`input` handler from `Component.js` will fire N times per event, where N is
+the number of embeddings.
+
+❌ Don't:
+
+```django
+{# Header and footer, both with the same key #}
+{% cache 500 "search_box" %}{% component "search_input" / %}{% endcache %}
+...
+{% cache 500 "search_box" %}{% component "search_input" / %}{% endcache %}
+```
+
+✅ Do: use a distinct cache key per position, or only cache fragments that
+appear once per page.
+
+#### After a deploy, components silently lose their JS/CSS variables
+
+If your fragment cache is a persistent backend (Redis, memcached) and your
+components define `get_js_data()` or `get_css_data()`, the data those
+methods produce can vanish from the page after a server restart. The HTML
+still renders normally and no errors are logged, but the per-instance JS
+or CSS variables are gone.
+
+This happens because djc stores the actual variable values in a separate
+cache that is **per-process and in-memory by default**. After a restart,
+the cached fragment refers to variable data the new process no longer has.
+
+✅ Do: set the
+[`cache` setting](../../reference/settings.md#django_components.app_settings.ComponentsSettings.cache)
+to the same persistent backend you use for the fragment cache, so the
+variables survive restarts.
+
+#### Every user sees the first user's data
+
+```django
+{# Cache key includes user.id but NOT user.locale #}
+{% cache 500 "user_panel" user.id %}
+    {% component "user_panel" user=user / %}
+{% endcache %}
+```
+
+If the component's output depends on `user.locale` (or any input not in
+`vary_on`), the first user's locale freezes into the cache. Every other
+user with the same `user.id` sees that locale until the entry expires.
+
+✅ Do: include every input that affects the rendered output in `vary_on`.
+This is true of any Django fragment cache, but with components it can also
+affect client-side behavior, not just visible markup.
+
+### Importing djc patches Django's `{% cache %}` globally
+
+Importing `django_components` replaces Django's built-in `{% cache %}` tag
+for the whole Python process, including in plain (non-component) templates.
+
+Behavior is unchanged outside a component render: the patched tag delegates
+to Django's original implementation. The only observable difference is for
+third-party code that checks `type(node) is CacheNode` — it will see djc's
+subclass instead.

--- a/src/django_components/cache_tag.py
+++ b/src/django_components/cache_tag.py
@@ -2,33 +2,64 @@
 Compatibility shim that makes Django's built-in {% cache %} tag work correctly
 inside component templates.
 
-When component_tags is loaded, this module re-registers the "cache" tag with a
-subclass of Django's CacheNode whose render() clears _COMPONENT_CONTEXT_KEY before
-rendering the nodelist on a cache miss.  The fix is transparent: templates continue
-to use {% cache %} exactly as before; no tag rename is required.
+Importing this module overwrites Django's "{% cache %}" tag with `DjcCacheNode`,
+a subclass of Django's `CacheNode`. Templates continue to use {% cache %} exactly
+as before; no tag rename is required.
 
 Background
 ----------
-django-components uses a two-pass render.  Pass 1 (bottom-up): each nested
+django-components uses a two-pass render. Pass 1 (bottom-up): each nested
 {% component %} tag detects _COMPONENT_CONTEXT_KEY in the Django Context, stores
-its renderer in a module-level dict keyed by a fresh render ID, and returns only a
-placeholder `<template djc-render-id="...">`.  Pass 2 (root assembly): the root
-component replaces each placeholder with the renderer's output.
+its renderer in a process-local dict keyed by a fresh render ID, and returns only
+a placeholder `<template djc-render-id="...">`. Pass 2 (root assembly):
+the root component walks the queue and replaces every placeholder with the
+renderer's output.
 
 When {% cache %} wraps a {% component %} inside a component template:
 
-  Cache miss: {% component %} sees _COMPONENT_CONTEXT_KEY, returns a placeholder,
-  {% cache %} stores the placeholder string.
+  Cache miss: {% component %} sees _COMPONENT_CONTEXT_KEY, returns a placeholder.
+  Django's {% cache %} stores the placeholder string.
 
-  Cache hit: {% cache %} returns the stored placeholder directly.  {% component %}
-  is never executed; no renderer is registered.  Pass 2 finds the placeholder,
+  Cache hit: {% cache %} returns the stored placeholder directly. {% component %}
+  is never executed; no renderer is registered. Pass 2 finds the placeholder,
   looks up the missing renderer, and raises a KeyError.
 
-The fix: on a cache miss, temporarily remove _COMPONENT_CONTEXT_KEY from the
-context before rendering the nodelist.  Each {% component %} inside then acts as a
-render root and performs full two-pass assembly inline, producing complete HTML
-(including <!-- _RENDERED ... --> dependency comments).  That complete HTML is what
-gets cached and returned on subsequent hits.
+The fix: on a cache miss inside a component render, do the Pass-2 assembly
+immediately (see `_assemble_cached_fragment`). The string that ends up in the
+cache is fully assembled HTML with no placeholders. On a hit, that string is
+returned verbatim and the outer template treats it as opaque text. The
+`<!-- _RENDERED ... -->` dependency comments inside it bubble up to the real
+root and get resolved by `_render_dependencies` there.
+
+Global side effect on import
+----------------------------
+The bottom of this module also patches `django.templatetags.cache.register` so
+the same `DjcCacheNode` is used even when a template explicitly loads Django's
+own `{% load cache %}` library. This is intentional, so that load order does
+not change which implementation a template picks up.
+
+The side effect is process-global: any third-party Django code in the same
+process that does `{% load cache %}{% cache %}` will get `DjcCacheNode`.
+Behavior is unchanged outside a component render (`DjcCacheNode.render` early-
+returns to `super().render(context)` when `_COMPONENT_CONTEXT_KEY` is unset),
+but code that does an exact-type check (`type(node) is CacheNode`) will see
+the subclass instead of the original.
+
+Known limitations of cached fragments
+-------------------------------------
+Storing a fully-assembled string means two pieces of per-render state get frozen
+into the cache:
+
+  1. Inner components' `data-djc-id-<render_id>` attributes (the first
+     render's render_ids persist on every hit).
+  2. The `js_hash` / `css_hash` keys in `<!-- _RENDERED ... -->` markers.
+     They look up entries in `component_media_cache`, which is `LocMemCache`
+     by default (per-process). If the fragment cache outlives the process
+     (Redis + a deploy), the markers reference JS/CSS variable data that no
+     longer exists, and the variables silently drop from the page.
+
+User-facing docs: `docs/concepts/advanced/component_caching.md`.
+v3 fix (cache `RenderObject` instead of string): #1650.
 """
 
 from django.template import Context
@@ -41,43 +72,76 @@ from django_components.context import _COMPONENT_CONTEXT_KEY
 from django_components.util.misc import gen_id
 
 
+# `value` contains Pass-1 placeholders (<template djc-render-id="...">) for
+# any nested {% component %}. Run Pass-2 now so we cache fully assembled
+# HTML, not placeholders that depend on per-render queue entries.
 def _assemble_cached_fragment(context: Context, value: str) -> str:
     component_id = context.get(_COMPONENT_CONTEXT_KEY)
     if component_id is None:
         return value
 
+    # Tree may have been GC'd between nodelist render and now.
     component_ctx = component_context_cache.get(component_id)
     if component_ctx is None:
         return value
 
+    # Synthetic "cache" pseudo-component to act as the local Pass-2 root.
+    # The yielded `value` is what component_post_render treats as the root's HTML.
     render_id = gen_id()
 
     def render_fragment() -> OnRenderGenerator:
         _ = yield value
         return None
 
+    # Identity callbacks: real components use these to add `data-djc-id-...`
+    # attrs and `<!-- _RENDERED ... -->` markers; the cache pseudo-component
+    # has no class identity, so both are no-ops.
     component_ctx.tree.on_component_intermediate_callbacks[render_id] = lambda html: html
     component_ctx.tree.on_component_rendered_callbacks[render_id] = lambda html, error: (html, error)
 
-    return component_post_render(
-        renderer=render_fragment(),
-        render_id=render_id,
-        component_name="cache",
-        parent_render_id=None,
-        component_tree_context=component_ctx.tree,
-        on_component_tree_rendered=lambda html: html,
-    )
+    # `parent_render_id=None` makes this act as a render root, processing
+    # placeholders inline. `on_component_tree_rendered` MUST stay a no-op:
+    # a normal root passes `_render_dependencies` here, which resolves
+    # `<!-- _RENDERED -->` into `<script>`/`<link>` tags. Doing that here
+    # would break dep aggregation at the outer real root.
+    #
+    # Pop the callbacks in `finally` so a template-level loop with many
+    # {% cache %} invocations doesn't leave one set of dead lambdas per
+    # iteration in the (still-live) tree's callback dicts.
+    try:
+        return component_post_render(
+            renderer=render_fragment(),
+            render_id=render_id,
+            component_name="cache",
+            parent_render_id=None,
+            component_tree_context=component_ctx.tree,
+            on_component_tree_rendered=lambda html: html,
+        )
+    finally:
+        component_ctx.tree.on_component_intermediate_callbacks.pop(render_id, None)
+        component_ctx.tree.on_component_rendered_callbacks.pop(render_id, None)
 
 
 class DjcCacheNode(CacheNode):
     def render(self, context: Context) -> str:
+        # ---- djc-specific ----
         # If we are not inside a component render, the two-pass system is not
-        # active; delegate to the original implementation unchanged.
+        # active; delegate to Django's original implementation unchanged. This
+        # keeps {% cache %} behaving identically for non-component templates.
         if not context.get(_COMPONENT_CONTEXT_KEY):
             return super().render(context)
 
-        # Inside a component render, check the cache first (avoid touching the
-        # nodelist at all on a hit — identical to the original logic).
+        # ---- Copied from django.templatetags.cache.CacheNode.render (Django 5.2)
+        # The block below (expire_time / cache_name / fragment_cache / cache_key
+        # / fragment_cache.get) is a verbatim port of Django's CacheNode.render,
+        # with only these mechanical changes:
+        #   1. Imports moved inline (PLC0415) so importing this module does not
+        #      pull in cache machinery for templates that never use {% cache %}.
+        #   2. `raise ... from err` instead of bare `raise` (B904).
+        #   3. f-strings instead of `%` formatting.
+        #   4. Hit check inverted to early-return (`if value is not None: return`)
+        #      so the djc-specific assembly below is unindented.
+        # Keep this block in sync with upstream when bumping Django.
         from django.core.cache import InvalidCacheBackendError, caches  # noqa: PLC0415
         from django.core.cache.utils import make_template_fragment_key  # noqa: PLC0415
         from django.template import TemplateSyntaxError, VariableDoesNotExist  # noqa: PLC0415
@@ -110,13 +174,30 @@ class DjcCacheNode(CacheNode):
         vary_on = [var.resolve(context) for var in self.vary_on]
         cache_key = make_template_fragment_key(self.fragment_name, vary_on)
 
+        # Cache hit: return the stored value directly. Django does the same.
+        # For djc, the stored value is fully assembled HTML (no Pass-1
+        # placeholders), so the outer component's Pass-2 walks past it as text.
         value = fragment_cache.get(cache_key)
         if value is not None:
             return value
+        # ---- end Django-copied block ----
 
+        # Cache miss: render the cache body the same way Django would.
+        # Inside a component render, nested {% component %} tags return Pass-1
+        # placeholders (<template djc-render-id="...">), so `value` here is
+        # NOT yet a complete HTML fragment.
         value = self.nodelist.render(context)
+
+        # ---- djc-specific ----
+        # Resolve those placeholders inline by running a one-shot Pass-2
+        # assembly rooted at a synthetic "cache" pseudo-component. Result is
+        # fully assembled HTML, with `data-djc-id-...` attributes and
+        # `<!-- _RENDERED ... -->` markers baked in so the outer root can still
+        # aggregate JS/CSS dependencies across the whole page.
+        # See `_assemble_cached_fragment` above.
         value = _assemble_cached_fragment(context, value)
 
+        # ---- Copied from Django: store the value and return it. ----
         fragment_cache.set(cache_key, value, expire_time)
         return value
 

--- a/tests/test_django_cache_tag.py
+++ b/tests/test_django_cache_tag.py
@@ -7,6 +7,9 @@ rather than Pass-1 placeholders.  See src/django_components/cache_tag.py for the
 full explanation of why this is necessary.
 """
 
+import re
+
+import pytest
 from django.template import Context, Template
 from pytest_django.asserts import assertHTMLEqual
 
@@ -405,3 +408,89 @@ class TestCacheTagCompatibility:
 
         tpl.render(Context({}))
         assert render_count == 1, "Component should not re-render on cache hit via named backend"
+
+    def test_cache_embedded_twice_on_same_page_freezes_inner_render_id(self):
+        """
+        When the same cached fragment is embedded multiple times on one page
+        (constant `vary_on`), the inner component's `data-djc-id-<render_id>`
+        is reused on every embedding because the render_id was frozen at first
+        render. See #1650.
+        """
+
+        class InnerComponent(Component):
+            template: types.django_html = "<span>inner</span>"
+
+        class OuterComponent(Component):
+            template: types.django_html = """
+                {% load component_tags %}
+                <div>
+                    {% cache 500 "duplicate_embed" %}
+                        {% component "inner_dup" / %}
+                    {% endcache %}
+                    {% cache 500 "duplicate_embed" %}
+                        {% component "inner_dup" / %}
+                    {% endcache %}
+                </div>
+            """
+
+        registry.register("inner_dup", InnerComponent)
+        registry.register("outer_dup", OuterComponent)
+
+        rendered = Template('{% load component_tags %}{% component "outer_dup" / %}').render(Context({}))
+
+        # Pull every data-djc-id-<X> that appears on a <span> tag. Both inner
+        # spans should share the same X because the second {% cache %} is a HIT
+        # that replays the frozen render_id from the first MISS. This pins the
+        # documented limitation so a future change is forced to discuss it.
+        span_ids = re.findall(r"<span\s+data-djc-id-(\w+)", rendered)
+        assert len(span_ids) == 2, f"Expected 2 inner spans, got {len(span_ids)}: {rendered}"
+        assert span_ids[0] == span_ids[1], (
+            f"Inner component's data-djc-id is expected to be reused on cache hit "
+            f"(documented limitation), got {span_ids[0]!r} and {span_ids[1]!r}"
+        )
+
+    def test_error_in_cache_body_does_not_poison_cache(self):
+        """
+        If rendering the cache body raises mid-render, the partially-rendered
+        string MUST NOT be stored in the cache. A subsequent successful render
+        should produce a fresh value, not return a poisoned hit.
+        """
+        # Counter lets us flip behavior between renders.
+        call_count = 0
+
+        class FlakyComponent(Component):
+            template: types.django_html = "<span>{{ value }}</span>"
+
+            def get_template_data(self, args, kwargs, slots, context):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    raise RuntimeError("boom")
+                return {"value": "ok"}
+
+        class OuterComponent(Component):
+            template: types.django_html = """
+                {% load component_tags %}
+                <div>
+                    {% cache 500 "error_in_body" %}
+                        {% component "flaky" / %}
+                    {% endcache %}
+                </div>
+            """
+
+        registry.register("flaky", FlakyComponent)
+        registry.register("outer_flaky", OuterComponent)
+
+        tpl = Template('{% load component_tags %}{% component "outer_flaky" / %}')
+
+        # First render raises (cache MISS, body errors).
+        with pytest.raises(RuntimeError, match="boom"):
+            tpl.render(Context({}))
+
+        # Second render succeeds. If the cache had been poisoned with the
+        # half-rendered string from the first attempt, this would either
+        # return the poisoned value or fail to call FlakyComponent again
+        # (cache hit, no execution).
+        rendered = tpl.render(Context({}))
+        assert "ok" in rendered
+        assert call_count == 2, "FlakyComponent should run again on the second render (cache was not poisoned)"


### PR DESCRIPTION
(Juro)

As I read through #1619, I explored and found:
- 1 bug
- few edge cases that are still problematic with the compatibility with Django's `{% cache %}` tag.

I captured the "proper" solution here https://github.com/django-components/django-components/issues/1650.

But since the proper design would be possibly only in v3, right now I only documented what to be aware of when using the `{% cache %}` tag with components.

---

(Opus 4.8)

## Summary

Follow-ups to #1619 (Django `{% cache %}` tag compatibility with components):

- **Docs.** New "Using Django's `{% cache %}` tag with components" section in [docs/concepts/advanced/component_caching.md](docs/concepts/advanced/component_caching.md). Covers the three real gotchas users can hit (same cached fragment embedded twice on a page → handlers attached more than once; JS/CSS variables silently lost after a deploy with a persistent fragment cache; `vary_on` hygiene), and documents the process-global patch of Django's built-in `{% cache %}` tag.

- **Fix.** Bounded callback-dict accumulation in `_assemble_cached_fragment`: the two synthetic callbacks added to `tree.on_component_intermediate_callbacks` / `tree.on_component_rendered_callbacks` per `{% cache %}` invocation are now popped via `try/finally`, so a template-level loop with many `{% cache %}` calls doesn't leave one dead-lambda pair per iteration in the (still-live) tree's callback dicts.

- **Tests.** Two regression tests:
  - `test_cache_embedded_twice_on_same_page_freezes_inner_render_id` — pins the documented "frozen `data-djc-id`" behavior so a future change is forced to discuss it.
  - `test_error_in_cache_body_does_not_poison_cache` — verifies that an error mid-cache-body doesn't write a partial value (the second render must run the component again, not return a poisoned hit).

- **Docs/comments.** Rewrote the [cache_tag.py](src/django_components/cache_tag.py) module docstring (the old text described an earlier, abandoned implementation approach), and annotated the `DjcCacheNode.render` body to mark which lines are copied verbatim from Django's `CacheNode.render` (Django 5.2) and which are djc-specific. Helps future maintainers re-diff against upstream when Django bumps.

The architectural fix that would dissolve both documented limitations entirely (cache `RenderObject` instead of the rendered string) is tracked in #1650 for v3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)