### PR TITLE
ci: restore cross-browser E2E coverage via weekly workflow

### DIFF
--- a/.github/workflows/tests-cross-browser.yml
+++ b/.github/workflows/tests-cross-browser.yml
@@ -1,0 +1,117 @@
+name: Cross-browser E2E tests
+
+# Weekly run of the E2E suite against Chromium, Firefox, and WebKit.
+#
+# The PR-time `e2e` lane in tests.yml only runs Chromium for speed. This
+# workflow is the safety net that catches browser-specific regressions
+# (e.g. a Firefox-only quirk in how `window.Components` is populated).
+#
+# Chromium is included as a baseline cell so that, when a failure shows up,
+# you can tell whether the bug is browser-specific (chromium passes, the
+# other(s) fail) or a generic E2E regression (chromium also fails — likely
+# the same thing the PR-time lane would have caught).
+
+on:
+  schedule:
+    # Mondays at 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  e2e_cross_browser:
+    runs-on: ubuntu-latest
+    strategy:
+      # One browser failing should not cancel the others — we want
+      # independent red/green per browser to make triage easy.
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: |
+          uv sync --group ci
+
+      # TODO: DELETEME
+      # Workaround: Yarn Debian repo switched GPG key (Jan 2026); old key in images breaks apt-get update.
+      # See https://github.com/yarnpkg/yarn/issues/9218
+      # Remove this step once CI images ship with the updated Yarn APT key or Yarn repo is no longer enabled by default.
+      - name: Disable broken third-party apt repos (e.g. Yarn) before Playwright install
+        run: |
+          # Playwright's --with-deps runs apt-get update; a broken/unsigned Yarn repo breaks it.
+          sudo rm -f /etc/apt/sources.list.d/yarn.list 2>/dev/null || true
+      # DELETEME_END
+
+      - name: Install Playwright browser
+        run: |
+          uv run playwright install ${{ matrix.browser }} --with-deps
+
+      - name: Run E2E tests
+        env:
+          DJC_TEST_BROWSERS: ${{ matrix.browser }}
+        run: uv run tox -e e2e
+
+  # File or update a tracking issue when the scheduled run fails. Only runs
+  # on `schedule` events, so manually-dispatched test runs don't open noisy
+  # issues. One open issue per outage: if an issue with the tracking label
+  # already exists, this job adds a comment; otherwise it creates a new one.
+  notify_failure:
+    needs: e2e_cross_browser
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          LABEL: ci-cross-browser-failure
+        run: |
+          set -euo pipefail
+
+          TITLE="Weekly cross-browser E2E run failed"
+          BODY=$(cat <<'EOF'
+          The scheduled cross-browser E2E run failed.
+
+          Check the matrix cells (chromium / firefox / webkit) in the run
+          to see which browsers failed. If chromium passes and one of the
+          others fails, the bug is browser-specific. If chromium also
+          fails, the PR-time e2e lane would have caught it too, so
+          this is likely flakiness or an environmental regression.
+
+          This issue is reused for subsequent failures while open. Close
+          it once the cross-browser run is green again.
+          EOF
+          )
+          # Append the runtime-specific lines separately so $RUN_URL and date expand correctly.
+          BODY="$BODY
+
+          - Run: $RUN_URL
+          - Triggered: $(date -u +"%Y-%m-%d %H:%M UTC")
+          - Workflow: .github/workflows/tests-cross-browser.yml"
+
+          # Strip leading whitespace from the heredoc indentation, and trailing newline from jq output.
+          existing=$(gh issue list --state open --label "$LABEL" --json number --jq '.[0].number // empty' | xargs)
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Another scheduled run failed: $RUN_URL ($(date -u +%Y-%m-%d))"
+          else
+            gh label create "$LABEL" \
+              --description "Cross-browser E2E workflow failure tracking" \
+              --color B60205 \
+              --force >/dev/null
+            gh issue create --title "$TITLE" --body "$BODY" --label "$LABEL"
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,6 +98,10 @@ jobs:
           uv run playwright install chromium --with-deps
 
       - name: Run E2E tests
+        # Restrict to chromium on PR-time runs for speed. The weekly
+        # tests-cross-browser.yml workflow exercises firefox and webkit.
+        env:
+          DJC_TEST_BROWSERS: chromium
         run: uv run tox -e e2e
 
   benchmark_snapshots:

--- a/docs/community/development.md
+++ b/docs/community/development.md
@@ -120,6 +120,28 @@ tox -e py310
 
 NOTE: See the available environments in `tox.ini`.
 
+### Selecting tests by marker
+
+The suite is split into three lanes via pytest markers. The default test run skips the two heavyweight lanes:
+
+- `@pytest.mark.e2e` — browser-based end-to-end tests. Applied automatically by the `@with_playwright` decorator, so you don't tag tests by hand.
+- `@pytest.mark.benchmark_snapshot` — heavy benchmark snapshot tests (the four `test_benchmark_*.py` files). Applied automatically by `pytest_collection_modifyitems` in [`tests/conftest.py`](https://github.com/django-components/django-components/blob/master/tests/conftest.py) based on filename, so new tests added to those files are picked up without further configuration.
+
+You can target a single lane:
+
+```sh
+# Just the fast unit tests (the default — skips E2E and benchmark)
+pytest -m "not e2e and not benchmark_snapshot"
+
+# Just the E2E tests
+tox -e e2e
+
+# Just the benchmark snapshot tests
+tox -e benchmark_snapshot
+```
+
+The default `tox` env (e.g. `tox -e py314-django52`) runs the unit-test lane in parallel with `pytest-xdist` (`-n auto`). One exception: `tests/test_templatetags_provide.py` is force-run serially because it asserts on shared template-cache state that the parallel workers would race on.
+
 ## Linting and formatting
 
 To check linting rules, run:
@@ -175,16 +197,34 @@ class MyTest:
 You will need to install Playwright to run these tests. If you've already run `uv sync --group dev`, Playwright should be installed. Then install the browsers:
 
 ```sh
+# All three browsers (matches the default local behavior)
 playwright install chromium firefox webkit --with-deps
+
+# Or, if you only want to run against one browser, install just that one
+playwright install chromium --with-deps
 ```
 
-After Playwright is ready, run the tests the same way as before:
+After Playwright is ready, run the E2E lane:
 
 ```sh
-pytest
-# Or for specific Python version
-tox -e py310
+tox -e e2e
+# Or, without tox:
+pytest -m e2e
 ```
+
+### Selecting which browsers E2E tests run against
+
+By default, `@with_playwright` parametrizes each test across Chromium, Firefox, and WebKit. To limit which browsers are used (e.g. when you've only installed one), set the `DJC_TEST_BROWSERS` environment variable:
+
+```sh
+# Only run against Chromium
+DJC_TEST_BROWSERS=chromium tox -e e2e
+
+# Run against Chromium and Firefox
+DJC_TEST_BROWSERS=chromium,firefox pytest -m e2e
+```
+
+The PR-time `e2e` lane sets `DJC_TEST_BROWSERS=chromium` for speed. A separate weekly workflow (`.github/workflows/tests-cross-browser.yml`) runs the suite against Chromium, Firefox, and WebKit in parallel and catches browser-specific regressions. Running locally without the variable uses all three browsers.
 
 ### E2E Test Server Configuration
 
@@ -272,6 +312,55 @@ Or with tox:
 ```sh
 tox -e py310 -- --snapshot-update
 ```
+
+## How CI runs your tests
+
+GitHub Actions splits the test suite across multiple jobs in [`.github/workflows/tests.yml`](https://github.com/django-components/django-components/blob/master/.github/workflows/tests.yml). The split exists so that expensive setup (Playwright browsers, heavy benchmark renders) happens once per CI run instead of once per Python/OS cell.
+
+### The job lanes
+
+| Job | Matrix | When | What it runs | Tox env |
+| --- | --- | --- | --- | --- |
+| `build` | Ubuntu × Python 3.10–3.14, plus Windows × Python 3.10 and 3.14 | Every push / PR | Unit tests in parallel with `pytest-xdist`. Skips E2E and benchmark markers. No Playwright install. | `tox` |
+| `e2e` | Ubuntu × Python 3.14 | Every push / PR | Only `@pytest.mark.e2e` tests. Installs Chromium only. Sets `DJC_TEST_BROWSERS=chromium`. | `tox -e e2e` |
+| `benchmark_snapshots` | Ubuntu × Python 3.14 | Every push / PR | Only `@pytest.mark.benchmark_snapshot` tests. | `tox -e benchmark_snapshot` |
+| `coverage` | Ubuntu × Python 3.14 | Every push / PR | Unit-test lane with coverage, fails under 75%. | `tox -e coverage` |
+| `ruff`, `mypy` | Ubuntu × Python 3.14 | Every push / PR | Lint and type-check. | `tox -e ruff`, `tox -e mypy` |
+| `e2e_cross_browser` | Ubuntu × Python 3.14 × `{chromium, firefox, webkit}` | Weekly cron (Mon 06:00 UTC) + manual dispatch | E2E suite against each browser, one cell per browser. Chromium is included as a baseline. On scheduled failures, files or comments on a tracking issue labeled `ci-cross-browser-failure`. See [`tests-cross-browser.yml`](https://github.com/django-components/django-components/blob/master/.github/workflows/tests-cross-browser.yml). | `tox -e e2e` (with `DJC_TEST_BROWSERS=<browser>`) |
+
+### When the weekly cross-browser run fails
+
+When the scheduled run (not a manual dispatch) fails, a notification job opens or updates a GitHub issue labeled `ci-cross-browser-failure`. The first failure creates the issue; subsequent failures add a comment to the same issue instead of opening a new one. Close the issue manually once the cross-browser run is green again — the next failure after the issue is closed will open a new one.
+
+Triage flow when you see one of these issues:
+
+1. Open the linked workflow run and check which matrix cells (chromium / firefox / webkit) failed.
+2. If **only firefox or webkit** failed, the bug is browser-specific. Reproduce locally with `DJC_TEST_BROWSERS=firefox tox -e e2e` (after installing that browser).
+3. If **chromium also failed**, the PR-time `e2e` lane would have caught the same thing on the next push, so the most likely cause is flakiness or an environmental regression (Playwright version, browser binary, runner image).
+
+### Windows coverage is smoke-only
+
+The Windows matrix runs Python 3.10 and 3.14 only, not the full Python range. The intent is to catch path-handling regressions on Windows without paying full matrix cost. A Windows-specific failure on Python 3.11/3.12/3.13 will not appear in CI.
+
+### How tests get sorted into lanes
+
+- E2E tests get the `e2e` marker from the `@with_playwright` decorator, which also pulls in the `django_dev_server` fixture. So writing `@with_playwright` is the only thing you need to do to route a test into the E2E lane.
+- Benchmark tests get the `benchmark_snapshot` marker automatically based on file name (the four `test_benchmark_*.py` files), via a `pytest_collection_modifyitems` hook in `tests/conftest.py`. Adding a new test inside one of those files is enough.
+- Everything else is a "unit test" and runs in the default lane.
+
+### Local equivalents
+
+The same `tox` envs CI uses are available locally:
+
+```sh
+tox -e py314-django52       # unit-test lane, single cell
+tox -e e2e                  # E2E lane (needs playwright install first)
+tox -e benchmark_snapshot   # benchmark snapshot lane
+tox -e coverage             # unit-test lane with coverage
+tox -e ruff,mypy            # lint and type-check
+```
+
+Running `pytest` directly (no `tox`) runs everything in your local venv, including E2E and benchmark tests, so plain `pytest` does *more* than the CI unit-test lane does. Use `pytest -m "not e2e and not benchmark_snapshot"` to match the CI unit lane.
 
 ## Dev server
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,12 @@ def django_dev_server():
     yield from run_django_dev_server()
 
 
+# Auto-tag every test in the four benchmark files with `@pytest.mark.benchmark_snapshot`.
+# The marker is what the CI lane split keys off: the default tox env runs with
+# `-m "not benchmark_snapshot"` and the dedicated `benchmark_snapshot` tox env runs
+# with `-m benchmark_snapshot`. Doing the tagging here (instead of decorating each
+# test) means new tests added to these files are picked up automatically and the
+# "what counts as a benchmark" rule lives in one place.
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     for item in items:
         path = item.path

--- a/tox.ini
+++ b/tox.ini
@@ -72,8 +72,11 @@ deps =
   requests
   types-requests
   whitenoise
-set_env =
-  DJC_TEST_BROWSERS = chromium
+# Let DJC_TEST_BROWSERS flow through from the caller so the same tox env can
+# run against one browser (CI on PRs, fast) or all three (the weekly
+# cross-browser workflow, and local default). If unset, BROWSER_NAMES in
+# tests/e2e/utils.py falls back to chromium,firefox,webkit.
+passenv = DJC_TEST_BROWSERS
 commands = pytest -m e2e {posargs}
 
 [testenv:ruff]


### PR DESCRIPTION
(Opus 4.8)

## Summary

[#1623](https://github.com/django-components/django-components/pull/1623) split the test matrix into lanes and limited the E2E lane to **Chromium only** on every PR for speed. That dropped Firefox and WebKit coverage entirely. Past browser-specific bugs (e.g. a Firefox-only quirk in how `window.Components` is populated) show this coverage has value, so this PR reintroduces it - but on a **weekly cadence** instead of paying for it on every PR.

## Changes

- **New workflow `.github/workflows/tests-cross-browser.yml`**
  - Runs `tox -e e2e` weekly (Mondays 06:00 UTC) and on manual `workflow_dispatch`.
  - Matrix over `chromium`, `firefox`, `webkit`. `fail-fast: false` keeps each browser's red/green independent for easy triage.
  - **Chromium is included as a baseline cell**: if chromium passes and firefox/webkit fail, the bug is browser-specific; if chromium also fails, it's a generic E2E regression the PR-time lane would have caught.
  - A `notify_failure` job files or updates a tracking issue (label `ci-cross-browser-failure`) **on scheduled failures only**, so manual dispatch runs don't open noisy issues. One open issue per outage: it comments on an existing open issue if present, otherwise creates one.

- **`tox.ini`** - `[testenv:e2e]` now reads `DJC_TEST_BROWSERS` via `passenv` instead of hardcoding chromium with `set_env`, so the caller controls which browsers run. (`set_env` would have overridden the caller and silently broken the cross-browser run.)

- **`.github/workflows/tests.yml`** - the PR-time `e2e` lane now sets `DJC_TEST_BROWSERS=chromium` explicitly at the step level, preserving its fast single-browser default.

- **Docs** - `docs/community/development.md` documents the test markers, the CI lanes, and how to select browsers locally with `DJC_TEST_BROWSERS`. Added an explanatory comment to the `pytest_collection_modifyitems` hook in `tests/conftest.py`.

## Notes

- No change to what runs on PRs - they stay Chromium-only and just as fast.
- Notification is intentionally scheduled-only; we can revisit alerting (Slack/Discord) separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)