### PR TITLE
Release v0.151.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.151.0
 
+_2026-06-03_
+
 #### Feature
 
 - **Hot reload - Component files (templates, JS, CSS) are now updated without a server restart**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django_components"
-version = "0.150.1"
+version = "0.151.0"
 requires-python = ">=3.10, <4.0"
 description = "A way to create simple reusable template components in Django."
 keywords = ["django", "components", "css", "js", "html"]

--- a/uv.lock
+++ b/uv.lock
@@ -536,7 +536,7 @@ wheels = [
 
 [[package]]
 name = "django-components"
-version = "0.150.1"
+version = "0.151.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
## Summary

- Bump version from `0.150.1` to `0.151.0`
- Set release date to 2026-06-03 in CHANGELOG.md
- Update uv.lock

### What's in this release

- **Hot-reload component files without server restart** (#1657)
  - `reload_on_file_change` setting now supports `"off"` | `"hot"` | `"restart"`
  - Default changed from `False` to `"hot"`
  - Closes #1324, #1461

🤖 Generated with [Claude Code](https://claude.com/claude-code)