### PR TITLE
fix(ci): declare the github-pages environment on the docs deploy job

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -25,6 +25,12 @@ jobs:
       contents: write # to commit the built version snapshots back to master
       pages: write # to deploy to Pages
       id-token: write # to verify the deployment originates from an appropriate source
+    # `actions/deploy-pages` requires the deploying job to declare the `github-pages`
+    # environment - without it the Pages API rejects the deployment with a 400
+    # ("Missing environment. Ensure your workflow's deployment job has an environment").
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy-pages.outputs.page_url }}
     runs-on: ubuntu-latest
     # Only run in original repo (not in forks)
     if: github.repository == 'django-components/django-components'


### PR DESCRIPTION
The first docs deploy after the docs-site cutover ([#1664](https://github.com/django-components/django-components/pull/1664)) failed at the `Deploy to GitHub Pages` step ([run](https://github.com/django-components/django-components/actions/runs/30356016564/job/90264288727)):

```
HttpError: Missing environment. Ensure your workflow's deployment job has an environment. Example:
jobs:
  deploy:
    environment:
      name: github-pages
```

`actions/deploy-pages` requires the deploying job to declare the `github-pages` environment. The `docs` job granted the right permissions (`pages: write`, `id-token: write`) but never declared the environment, so the Pages API rejected the deployment with a 400.

Adds the environment, wiring `url` to the existing `deploy-pages` step id.

## Note: this was only half the problem

The repo's Pages source was also still set to **"Deploy from a branch"** (`build_type: legacy`, `gh-pages`) - the ⚠️ manual step called out in #1664's description. I've since flipped it to **GitHub Actions** (`build_type: workflow`) via the API, so that half is already done.

The two failures masked each other: fixing only one would have produced a fresh failure from the other. Both are now addressed, so the next deploy on master should be the first real one.

Nothing was down in the meantime - the site kept serving the old mkdocs build from the `gh-pages` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)