### PR TITLE
fix(ci): build the docs site for its project-Pages subpath

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -34,6 +34,12 @@ jobs:
     runs-on: ubuntu-latest
     # Only run in original repo (not in forks)
     if: github.repository == 'django-components/django-components'
+    env:
+      # The site is published at https://django-components.github.io/django-components/,
+      # i.e. under a GitHub *project* Pages subpath, not at the domain root. The build
+      # emits root-absolute URLs (/static, /docs, /v) unless told otherwise, so without
+      # this every stylesheet, script and image 404s on the deployed site.
+      DOCS_BASE_PATH: /django-components
     steps:
       ##############################
       # SETUP


### PR DESCRIPTION
The first successful deploy after the cutover published a site that 404s on every asset:

```
GET https://django-components.github.io/static/css/site.css  net::ERR_ABORTED 404
```

Note the URL: `/static/...`, not `/django-components/static/...`.

## Cause

The site is published at `https://django-components.github.io/django-components/` - a GitHub **project** Pages subpath. The build defaults to a domain root and emits root-absolute URLs (`/static`, `/docs`, `/v`), so every stylesheet, script and image resolves one level too high.

The machinery to handle this already exists and is documented in `docs_site/README.md` under "Serving under a subpath": `settings.SITE_BASE_PATH` (env `DOCS_BASE_PATH`) drives `build/base_path.py::apply_base_path`, which prefixes the root-absolute URLs and emits `<meta name="djc-base-path">` for `search.js` and the version picker to read at runtime.

The deploy workflow simply never set it.

## Fix

Set `DOCS_BASE_PATH: /django-components` at the job level, so both `build_docs` (the tag snapshot path) and `docs_assemble` (the deploy artifact) pick it up.

`DOCS_SITE_URL` needs no change - its default already includes the subpath.

## Verification

Ran a real `docs_assemble` with the env var set:

```
Applied base path '/django-components' to 165 HTML files
Enabled the root version picker on 151 page(s)
```

- `site/index.html` has no unprefixed root-absolute `href`/`src` left
- `<meta name="djc-base-path" content="/django-components">` is emitted
- the previously-404ing `site/static/css/site.css` is present in the artifact

The only remaining `"/static/` matches anywhere in the output are inside syntax-highlighted code samples (`<span class=s2>"/static/analytics.js"</span>`) in the docs prose, which are correct as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)