### PR TITLE
fix(docs): stop the base path leaking into documented example URLs

### DIFF
--- a/docs_site/apps/docs/build/base_path.py
+++ b/docs_site/apps/docs/build/base_path.py
@@ -51,6 +51,25 @@ def _compile(base: str) -> re.Pattern[str]:
     return re.compile(rf'(\b(?:{attrs})=)(["\']?)/(?!/)(?!{already}/)')
 
 
+# Regions that hold *content*, not markup. A docs page can show example HTML such
+# as `<script src="/static/path/to/script.js">` inside a code block; that URL
+# describes what the reader's own app serves, so prefixing it with our deploy's
+# base path would corrupt the example. Everything inside these tags is left alone.
+_CODE_BLOCK_RE = re.compile(r"<(pre|code)\b[^>]*>.*?</\1\s*>", re.DOTALL | re.IGNORECASE)
+
+
+def _sub_outside_code(pattern: re.Pattern[str], replacement: str, text: str) -> str:
+    """Apply ``pattern`` to ``text``, leaving ``<pre>`` / ``<code>`` regions untouched."""
+    out: list[str] = []
+    last = 0
+    for match in _CODE_BLOCK_RE.finditer(text):
+        out.append(pattern.sub(replacement, text[last : match.start()]))
+        out.append(match.group(0))
+        last = match.end()
+    out.append(pattern.sub(replacement, text[last:]))
+    return "".join(out)
+
+
 def apply_base_path(output_dir: Path, base: str) -> int:
     """
     Prefix root-absolute URL attributes in every ``*.html`` under ``output_dir``
@@ -66,7 +85,7 @@ def apply_base_path(output_dir: Path, base: str) -> int:
     changed = 0
     for html in output_dir.rglob("*.html"):
         text = html.read_text(encoding="utf-8")
-        new = pattern.sub(replacement, text)
+        new = _sub_outside_code(pattern, replacement, text)
         # So base-path-aware JS (e.g. pagefind result links) can read the prefix.
         if "djc-base-path" not in new:
             new = new.replace("<head>", meta, 1)

--- a/docs_site/tests/test_base_path.py
+++ b/docs_site/tests/test_base_path.py
@@ -77,3 +77,28 @@ def test_idempotent(tmp_path: Path) -> None:
     apply_base_path(tmp_path, "/django-components")  # second run must not double-prefix
     assert page.read_text(encoding="utf-8") == once
     assert "/django-components/django-components" not in once
+
+
+def test_leaves_code_blocks_alone(tmp_path: Path) -> None:
+    """
+    Docs pages show example markup like `<script src="/static/app.js">` inside code
+    blocks. That URL describes what the *reader's* app serves, so prefixing it with
+    our deploy's base path would hand them a path that only works on our docs site.
+    """
+    page = _write(
+        tmp_path,
+        "index.html",
+        "<head></head>"
+        '<link rel="stylesheet" href="/static/css/site.css">'
+        '<pre><code># &lt;script src="/static/path/to/script.js">&lt;/script></code></pre>'
+        '<p>Inline <code>&lt;img src="/static/logo.png"></code> too.</p>',
+    )
+    apply_base_path(tmp_path, "/django-components")
+    out = page.read_text(encoding="utf-8")
+    # The page's own asset still moves under the base path...
+    assert 'href="/django-components/static/css/site.css"' in out
+    # ...but the documented examples are left exactly as written.
+    assert 'src="/static/path/to/script.js"' in out
+    assert 'src="/static/logo.png"' in out
+    assert "/django-components/static/path/to/script.js" not in out
+    assert "/django-components/static/logo.png" not in out


### PR DESCRIPTION
Two published pages currently show example code carrying the docs site's own URL prefix. Live on [/docs/reference/api/](https://django-components.github.io/django-components/docs/reference/api/):

```python
# <script src="/django-components/static/path/to/script.js"></script>
```

The source docstring ([`component.py:1702`](https://github.com/django-components/django-components/blob/master/src/django_components/component.py#L1702)) reads `src="/static/path/to/script.js"`. That URL describes what the **reader's** app serves - it has nothing to do with where our docs are hosted - so anyone copying the snippet gets a path that only resolves on django-components.github.io.

## Cause

`apply_base_path` ran its substitution over the entire document, so a root-absolute URL written inside a code block looked exactly like a real markup attribute. The rewrite matches `src="/...`, and HTML-escaped example markup (`&lt;script src="/static/...">`) still contains a literal `src="/`.

This surfaced with the base-path fix (#1686); the rewrite pass itself predates it and was simply a no-op while the site was built for a domain root.

## Fix

Restrict the rewrite to markup outside `<pre>` / `<code>`.

## Scope

6 URLs across 2 pages:

| Page | URLs |
|---|---|
| `docs/reference/api/` | `/static/path/to/{script.js,style.css}` |
| `docs/concepts/fundamentals/secondary_js_css_files/` | `/static/calendar/{script1.js,style1.css}` |

## Verification

Built the full site with `DOCS_BASE_PATH=/django-components` both before and after the change and diffed every page. The **only** content difference is those 6 URLs reverting to what the docs actually say - no real asset URL stopped being rewritten. Explicitly confirmed the example-interactivity attributes still move under the base path, e.g. `hx-post=/django-components/components/ext/view/components/ContactFormComponent_63e081/` on the form-submission example.

(162 files differed overall, but 160 of those were just per-run `data-djc-id-*` render IDs.)

New test `test_leaves_code_blocks_alone` asserts a page's own `<link href="/static/...">` still moves while an example `src="/static/..."` inside `<pre><code>` and inline `<code>` is left untouched.

`docs_build_check` passes all guards (149 pages), full `pytest` 1267 passed / 6 skipped, ruff + mypy clean.

## Note

The guards didn't catch this because the corrupted URLs are *valid* - they resolve fine on the deployed site. They're just semantically wrong for the reader. A guard for "no base path inside code blocks" would close that gap, but it's narrow enough that the unit test may be sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)