### PR TITLE
feat: add attrs composition tag and helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,47 @@
 
 #### Feature
 
-- **Added `{% attrs %}` and `compose_attrs()` for composing reusable HTML attribute dictionaries**
+- **New tag `{% attrs %}`, more powerful alternative to `{% html_attrs %}`**
 
-    The new `{% attrs %}` tag accepts attribute mappings and arbitrarily nested lists or tuples of mappings.
-    Ordinary attributes use the rightmost value, while `class` and `style` contributions are combined and
-    normalized. Rendered directly, the result is an escaped, space-delimited HTML attribute string.
+    The new `{% attrs %}` tag accepts dicts, optionally lists or nested lists of dicts.
 
-    When `{% attrs %}` is the sole node in a quoted component input, the component receives an `AttrsDict`
-    without serialization. `AttrsDict` is a `dict` subclass whose `str()` representation is the rendered HTML
-    attributes. The Python `compose_attrs()` helper returns the same type and follows the same merge rules.
+    ```django
+    {% attrs some_dict {"data-extra": 123} %}
+    ```
 
-    The existing `{% html_attrs %}` tag and `merge_attributes()` helper retain their previous, separate merge
-    behavior. `format_attributes()` and the new composition paths now reject invalid runtime HTML attribute names.
+    Merging: Old `{% html_attrs %}` merged all attributes. `{% attrs %}` merges only
+    `class` and `style`. For other attributes, the last one wins. This is now aligned with [Vue's behavior](https://vuejs.org/guide/essentials/class-and-style.html).
+
+    `class` and `style` still accept strings, dicts, and lists:
+
+    ```django
+    {% attrs {
+        "class": ["rounded", {"shadow": True}],
+        "style": ["color: red;", {"color": "blue"}],
+    } %}
+    ```
+
+    Rendered directly, the result is an escaped, space-delimited HTML attribute string:
+
+    ```django
+    <div {% attrs {"id": "1"} {"data-extra": 123} %}></div>
+              ↓
+    <div id="1" data-extra="123"></div>
+    ```
+
+    When `{% attrs %}` is the only tag in component's input, the component receives the dictionary without serialization:
+    
+    ```django
+    {% component "table"
+        table_attrs="{% attrs [base_attrs, {'class': 'compact'}] %}"
+    / %}
+    ```
+
+    Use the `compose_attrs()` helper in Python.
+
+    The existing `{% html_attrs %}` tag and `merge_attributes()` helper keep their old behavior.
+    
+    `format_attributes()` and the new attrs tag now reject invalid runtime HTML attribute names.
 
     See [#1703](https://github.com/django-components/django-components/issues/1703).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Release notes
 
+## v0.152.0
+
+#### Feature
+
+- **Added `{% attrs %}` and `compose_attrs()` for composing reusable HTML attribute dictionaries**
+
+    The new `{% attrs %}` tag accepts attribute mappings and arbitrarily nested lists or tuples of mappings.
+    Ordinary attributes use the rightmost value, while `class` and `style` contributions are combined and
+    normalized. Rendered directly, the result is an escaped, space-delimited HTML attribute string.
+
+    When `{% attrs %}` is the sole node in a quoted component input, the component receives an `AttrsDict`
+    without serialization. `AttrsDict` is a `dict` subclass whose `str()` representation is the rendered HTML
+    attributes. The Python `compose_attrs()` helper returns the same type and follows the same merge rules.
+
+    The existing `{% html_attrs %}` tag and `merge_attributes()` helper retain their previous, separate merge
+    behavior. `format_attributes()` and the new composition paths now reject invalid runtime HTML attribute names.
+
+    See [#1703](https://github.com/django-components/django-components/issues/1703).
+
 ## v0.151.1
 
 _2026-06-25_

--- a/README.md
+++ b/README.md
@@ -389,7 +389,10 @@ to compose ordinary attributes with last-value-wins behavior while still combini
 Its inputs may include lists nested to any depth:
 
 ```django
-<div {% attrs [base_attrs, [theme_attrs, state_attrs]] {'class': 'local'} %}></div>
+<div {% attrs
+   [base_attrs, [theme_attrs, state_attrs]]
+   {'class': 'local'}
+%}></div>
 ```
 
 Used by itself inside a quoted component input, `{% attrs %}` passes the resulting dictionary without

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ Its inputs may include lists nested to any depth:
 ```
 
 Used by itself inside a quoted component input, `{% attrs %}` passes the resulting dictionary without
-serializing it.
+serializing it. It supersedes `{% html_attrs %}` for attribute composition and is preferred for new code.
 
 Read more about [HTML attributes](https://django-components.github.io/django-components/latest/concepts/fundamentals/html_attributes/).
 

--- a/README.md
+++ b/README.md
@@ -384,6 +384,17 @@ where you can use a dictionary to manage each class name or style property separ
 %}
 ```
 
+When attributes already live in dictionaries, use [`{% attrs %}`](https://django-components.github.io/django-components/latest/concepts/fundamentals/html_attributes/#composing-attribute-dictionaries-with-attrs)
+to compose ordinary attributes with last-value-wins behavior while still combining `class` and `style`.
+Its inputs may include lists nested to any depth:
+
+```django
+<div {% attrs [base_attrs, [theme_attrs, state_attrs]] {'class': 'local'} %}></div>
+```
+
+Used by itself inside a quoted component input, `{% attrs %}` passes the resulting dictionary without
+serializing it.
+
 Read more about [HTML attributes](https://django-components.github.io/django-components/latest/concepts/fundamentals/html_attributes/).
 
 ### HTML fragment support

--- a/docs_site/content/docs/concepts/fundamentals/html_attributes.md
+++ b/docs_site/content/docs/concepts/fundamentals/html_attributes.md
@@ -92,6 +92,62 @@ In both cases, the attributes will be merged and rendered as:
 <div id="example" class="text-red pa-4" style="color: red;" data-id="123"></div>
 ```
 
+## Composing attribute dictionaries with `{% attrs %}`
+
+_New in version 0.152.0_
+
+Use the [`{% attrs %}`](../../reference/template_tags.md#attrs) tag when your inputs are already attribute
+dictionaries and you want to compose them in a defined order:
+
+```django
+<div {% attrs [base_attrs, [theme_attrs, state_attrs]] {'class': 'local'} %}></div>
+```
+
+Each argument may be a mapping (such as a dictionary), or a list or tuple nested to any depth. Every terminal
+value must be a mapping. The mappings are applied from left to right:
+
+- Ordinary attributes use the last value.
+- All `class` values are combined and normalized.
+- All `style` values are combined by CSS property, with later properties taking precedence.
+- The first occurrence of a key determines its position in the result.
+
+For example, with these inputs:
+
+```py
+base_attrs = {"id": "first", "class": "button", "title": "Open"}
+theme_attrs = {"class": {"primary": True}}
+state_attrs = {"id": "last", "disabled": True}
+```
+
+the tag above renders:
+
+```html
+<div id="last" class="button primary local" title="Open" disabled></div>
+```
+
+Attribute values are escaped. `True` renders a bare boolean attribute, while `False` and `None` are omitted.
+Attribute names must be non-empty strings and cannot contain whitespace, `=`, `/`, `>`, `<`, or the
+template-comment opener (`{` followed by `#`).
+
+The tag can also produce a dictionary for a component input. Put it by itself in a quoted nested template,
+with no surrounding text or whitespace:
+
+```django
+{% component "table"
+    table_attrs="{% attrs [base_attrs, [theme_attrs]] {'class': 'compact'} %}"
+/ %}
+```
+
+Here, `table_attrs` is an [`AttrsDict`][AttrsDict], a `dict` subclass, rather than a string. It supports normal
+mapping operations. Calling `str(table_attrs)` produces the escaped, space-delimited HTML attributes. If the
+nested template has surrounding text, whitespace, or any other node, django-components passes the serialized
+string instead.
+
+The older [`{% html_attrs %}`](../../reference/template_tags.md#html_attrs) tag remains useful when attributes
+are supplied as its `attrs` / `defaults` arguments and keyword arguments. Likewise, the legacy
+[`merge_attributes()`][merge_attributes] helper retains its existing behavior of space-joining every duplicate
+ordinary attribute. Neither is an alias for `{% attrs %}`.
+
 ## Summary
 
 1. The two arguments, `attrs` and `defaults`, can be passed as positional args:
@@ -392,11 +448,30 @@ Renders:
 
 In some cases, you want to prepare HTML attributes outside of templates.
 
-To achieve the same behavior as [`{% html_attrs %}`](../../reference/template_tags.md#html_attrs) tag, you can use the [`merge_attributes()`][merge_attributes] and [`format_attributes()`][format_attributes] helper functions.
+### Composing attributes
 
-### Merging attributes
+[`compose_attrs()`][compose_attrs] is the Python counterpart to the [`{% attrs %}`](../../reference/template_tags.md#attrs)
+tag. It accepts mappings and arbitrarily nested lists or tuples of mappings, and returns an
+[`AttrsDict`][AttrsDict]:
 
-[`merge_attributes()`][merge_attributes] accepts any number of dictionaries and merges them together, using the same merge strategy as [`{% html_attrs %}`](../../reference/template_tags.md#html_attrs).
+```python
+from django_components import compose_attrs
+
+table_attrs = compose_attrs(
+    [base_attrs, [theme_attrs, state_attrs]],
+    {"class": "compact", "aria-label": "Results"},
+)
+```
+
+Ordinary keys use the last value, while `class` and `style` are composed. Use the result as a normal dictionary,
+or call `str(table_attrs)` to serialize it as escaped HTML attributes.
+
+### Legacy merging for `{% html_attrs %}`
+
+[`merge_attributes()`][merge_attributes] accepts any number of dictionaries and merges them together, using the
+same merge strategy as [`{% html_attrs %}`](../../reference/template_tags.md#html_attrs). Unlike
+[`compose_attrs()`][compose_attrs], duplicate ordinary attributes are joined with a space instead of using the
+last value.
 
 ```python
 from django_components import merge_attributes
@@ -424,6 +499,7 @@ Which will output:
 ### Formatting attributes
 
 [`format_attributes()`][format_attributes] serializes attributes the same way as [`{% html_attrs %}`](../../reference/template_tags.md#html_attrs) tag does.
+It also accepts structured `class` and `style` values and validates attribute names using the rules above.
 
 ```py
 from django_components import format_attributes

--- a/docs_site/content/docs/concepts/fundamentals/html_attributes.md
+++ b/docs_site/content/docs/concepts/fundamentals/html_attributes.md
@@ -143,10 +143,11 @@ mapping operations. Calling `str(table_attrs)` produces the escaped, space-delim
 nested template has surrounding text, whitespace, or any other node, django-components passes the serialized
 string instead.
 
-The older [`{% html_attrs %}`](../../reference/template_tags.md#html_attrs) tag remains useful when attributes
-are supplied as its `attrs` / `defaults` arguments and keyword arguments. Likewise, the legacy
+The new `{% attrs %}` tag supersedes [`{% html_attrs %}`](../../reference/template_tags.md#html_attrs) for
+attribute composition. Prefer `{% attrs %}` in new code. `{% html_attrs %}` remains supported for backward
+compatibility, retaining its `attrs` / `defaults` and keyword-argument interface. Likewise, the legacy
 [`merge_attributes()`][merge_attributes] helper retains its existing behavior of space-joining every duplicate
-ordinary attribute. Neither is an alias for `{% attrs %}`.
+ordinary attribute; it is not an alias for `{% attrs %}`.
 
 ## Summary
 

--- a/docs_site/content/docs/concepts/fundamentals/template_tag_syntax.md
+++ b/docs_site/content/docs/concepts/fundamentals/template_tag_syntax.md
@@ -298,6 +298,24 @@ Here, `page` is a string:
 {% component 'blog_post' page=" {% random_int 10 20 %} " / %}
 ```
 
+The same rule lets the [`{% attrs %}`](html_attributes.md#composing-attribute-dictionaries-with-attrs) tag pass
+an attribute dictionary directly to another component. Here, `table_attrs` is an `AttrsDict`, a `dict` subclass:
+
+```django
+{% component "table"
+    table_attrs="{% attrs [base_attrs, [theme_attrs]] {'class': 'compact'} %}"
+/ %}
+```
+
+Adding even one space inside the quoted value takes the string path instead, so `table_attrs` receives serialized
+HTML attributes:
+
+```django
+{% component "table"
+    table_attrs=" {% attrs [base_attrs, [theme_attrs]] {'class': 'compact'} %} "
+/ %}
+```
+
 And same applies to the `{{ }}` variable tags:
 
 Here, `items` is a list:

--- a/docs_site/content/docs/index.md
+++ b/docs_site/content/docs/index.md
@@ -391,7 +391,7 @@ Its inputs may include lists nested to any depth:
 ```
 
 Used by itself inside a quoted component input, `{% attrs %}` passes the resulting dictionary without
-serializing it.
+serializing it. It supersedes `{% html_attrs %}` for attribute composition and is preferred for new code.
 
 Read more about [HTML attributes](concepts/fundamentals/html_attributes.md).
 

--- a/docs_site/content/docs/index.md
+++ b/docs_site/content/docs/index.md
@@ -382,6 +382,17 @@ where you can use a dictionary to manage each class name or style property separ
 %}
 ```
 
+When attributes already live in dictionaries, use [`{% attrs %}`](concepts/fundamentals/html_attributes.md#composing-attribute-dictionaries-with-attrs)
+to compose ordinary attributes with last-value-wins behavior while still combining `class` and `style`.
+Its inputs may include lists nested to any depth:
+
+```django
+<div {% attrs [base_attrs, [theme_attrs, state_attrs]] {'class': 'local'} %}></div>
+```
+
+Used by itself inside a quoted component input, `{% attrs %}` passes the resulting dictionary without
+serializing it.
+
 Read more about [HTML attributes](concepts/fundamentals/html_attributes.md).
 
 ### HTML fragment support

--- a/docs_site/tests/__snapshots__/test_reference.ambr
+++ b/docs_site/tests/__snapshots__/test_reference.ambr
@@ -4,6 +4,13 @@
     'api': dict({
       'entries': list([
         dict({
+          'canonical_anchor': 'AttrsDict',
+          'display_name': 'AttrsDict',
+          'dotted_path': 'django_components.AttrsDict',
+          'kind': 'class',
+          'legacy_anchor': 'django_components.AttrsDict',
+        }),
+        dict({
           'canonical_anchor': 'BaseNode',
           'display_name': 'BaseNode',
           'dotted_path': 'django_components.BaseNode',
@@ -324,6 +331,13 @@
           'dotted_path': 'django_components.cached_template',
           'kind': 'class',
           'legacy_anchor': 'django_components.cached_template',
+        }),
+        dict({
+          'canonical_anchor': 'compose_attrs',
+          'display_name': 'compose_attrs',
+          'dotted_path': 'django_components.compose_attrs',
+          'kind': 'class',
+          'legacy_anchor': 'django_components.compose_attrs',
         }),
         dict({
           'canonical_anchor': 'format_attributes',
@@ -980,6 +994,13 @@
     }),
     'template_tags': dict({
       'entries': list([
+        dict({
+          'canonical_anchor': 'attrs',
+          'display_name': 'attrs',
+          'dotted_path': 'django_components.attributes.AttrsNode',
+          'kind': 'template_tag',
+          'legacy_anchor': 'attrs',
+        }),
         dict({
           'canonical_anchor': 'component',
           'display_name': 'component',

--- a/docs_site/tests/test_reference.py
+++ b/docs_site/tests/test_reference.py
@@ -291,7 +291,7 @@ def _member(class_path: str, member_name: str) -> Any:
 
 def test_api_discovery_includes_classes_excludes_categorized() -> None:
     names = {entry.display_name for entry in api_page.discover().entries}
-    assert {"Component", "ComponentRegistry"} <= names
+    assert {"AttrsDict", "Component", "ComponentRegistry", "compose_attrs"} <= names
     # These live on other reference pages, not the general API page.
     assert "AlreadyRegistered" not in names  # exception -> exceptions page
     assert "DynamicComponent" not in names  # predefined component -> components page
@@ -447,7 +447,7 @@ def test_hook_context_entry_renders_fields_table() -> None:
 
 def test_template_tag_discovery_finds_tags() -> None:
     entries = tags_page.discover().entries
-    assert {"component", "fill", "slot", "provide", "html_attrs"} <= {e.display_name for e in entries}
+    assert {"attrs", "component", "fill", "slot", "provide", "html_attrs"} <= {e.display_name for e in entries}
     assert {e.kind for e in entries} == {"template_tag"}
 
 

--- a/docs_site/tests/test_reference.py
+++ b/docs_site/tests/test_reference.py
@@ -291,7 +291,7 @@ def _member(class_path: str, member_name: str) -> Any:
 
 def test_api_discovery_includes_classes_excludes_categorized() -> None:
     names = {entry.display_name for entry in api_page.discover().entries}
-    assert {"AttrsDict", "Component", "ComponentRegistry", "compose_attrs"} <= names
+    assert {"Component", "ComponentRegistry"} <= names
     # These live on other reference pages, not the general API page.
     assert "AlreadyRegistered" not in names  # exception -> exceptions page
     assert "DynamicComponent" not in names  # predefined component -> components page

--- a/src/django_components/__init__.py
+++ b/src/django_components/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: Some of the documentation is generated based on these exports
 # isort: off
 from django_components.app_settings import ContextBehavior, ComponentsSettings, ReloadMode, ReloadModeType
-from django_components.attributes import format_attributes, merge_attributes
+from django_components.attributes import AttrsDict, compose_attrs, format_attributes, merge_attributes
 from django_components.autodiscovery import autodiscover, import_libraries
 from django_components.dependencies import Dependency, DependencyKind, Script, Style
 from django_components.util.command import (
@@ -97,6 +97,7 @@ from django_components.components import DynamicComponent, ErrorFallback
 
 __all__ = [
     "AlreadyRegistered",
+    "AttrsDict",
     "BaseNode",
     "CommandArg",
     "CommandArgGroup",
@@ -175,6 +176,7 @@ __all__ = [
     "cached_template",
     "component_formatter",
     "component_shorthand_formatter",
+    "compose_attrs",
     "format_attributes",
     "get_component_by_class_id",
     "get_component_defaults",

--- a/src/django_components/attributes.py
+++ b/src/django_components/attributes.py
@@ -3,7 +3,8 @@
 # And https://github.com/Xzya/django-web-components/blob/b43eb0c832837db939a6f8c1980334b0adfdd6e4/django_web_components/attributes.py  # noqa: E501
 
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
+from functools import lru_cache
 from typing import Any, Literal, TypeAlias
 
 from django.template import Context
@@ -15,6 +16,9 @@ from django_components.node import BaseNode
 ClassValue: TypeAlias = Sequence["ClassValue"] | str | dict[str, bool]
 StyleDict: TypeAlias = dict[str, str | int | Literal[False] | None]
 StyleValue: TypeAlias = Sequence["StyleValue"] | str | StyleDict
+AttrsSource: TypeAlias = Mapping[str, Any] | list["AttrsSource"] | tuple["AttrsSource", ...]
+
+_INVALID_HTML_ATTR_NAME_CHARS = frozenset(" \t\n\r=/><")
 
 
 class HtmlAttrsNode(BaseNode):
@@ -90,9 +94,190 @@ class HtmlAttrsNode(BaseNode):
         return format_attributes(final_attrs)
 
 
+class AttrsDict(dict[str, Any]):
+    """
+    A dictionary of HTML attributes that serializes to attribute markup.
+
+    `AttrsDict` has normal dictionary behavior for indexing, iteration, equality,
+    component inputs, and mapping unpacking. Calling `str()` on it formats and
+    escapes its items as HTML attributes, so the same value can also be rendered
+    directly in a template.
+
+    Create instances with [`compose_attrs()`][compose_attrs] or the
+    [`{% attrs %}`][attrs] template tag.
+
+    `AttrsDict` deliberately does not implement Django's trusted-markup protocol.
+    If it is used as an attribute value, its serialized form is escaped for that
+    surrounding context.
+    """
+
+    def __str__(self) -> str:
+        return str(format_attributes(self))
+
+
+class AttrsNode(BaseNode):
+    """
+    Compose mappings into an attribute dictionary and render it as HTML attributes.
+
+    Each argument may be a mapping or an arbitrarily nested list or tuple of
+    mappings. Sources are applied from left to right. Ordinary attributes use the
+    last value, while `class` and `style` contributions are combined using the same
+    structured values as [`normalize_class()`][normalize_class] and
+    [`normalize_style()`][normalize_style].
+
+    ```django
+    <div {% attrs [base_attrs, [state_attrs]] local_attrs %}></div>
+    ```
+
+    When the tag is the sole node in a nested template expression, it returns an
+    [`AttrsDict`][AttrsDict] without serializing it. This makes it possible to pass
+    the result directly to a component:
+
+    ```django
+    {% component "table"
+        table_attrs="{% attrs [base_attrs, {'class': 'compact'}] %}"
+    / %}
+    ```
+
+    Any surrounding text or template nodes cause the result to be serialized to
+    an escaped, space-delimited attribute string.
+
+    See [HTML attributes](../concepts/fundamentals/html_attributes.md) for details.
+    """
+
+    tag = "attrs"
+    end_tag = None
+    allowed_flags = ()
+
+    # BaseNode declares Django's string-only render contract. This tag intentionally
+    # returns a native value when called directly by TemplateExpression.
+    def render(self, context: Context, *attrs: AttrsSource) -> AttrsDict:  # type: ignore[override]  # noqa: ARG002
+        return compose_attrs(*attrs)
+
+    def render_annotated(self, context: Context) -> SafeString:
+        # Django's NodeList requires every node to render a string, while a direct
+        # render() call must retain AttrsDict for nested template expressions. Keep
+        # string conversion inside Django's exception annotation boundary so errors
+        # raised while formatting still point to this tag in debug mode.
+        try:
+            return mark_safe(str(self.render(context)))
+        except Exception as err:
+            if context.template.engine.debug:
+                culprit_node = getattr(err, "_culprit_node", None)
+                if culprit_node is None:
+                    culprit_node = self
+                    err._culprit_node = culprit_node  # type: ignore[attr-defined]
+                if (
+                    not hasattr(err, "template_debug")
+                    and context.render_context.template.origin == culprit_node.origin
+                ):
+                    template_debug = context.render_context.template.get_exception_info(err, culprit_node.token)
+                    err.template_debug = template_debug  # type: ignore[attr-defined]
+            raise
+
+
+def compose_attrs(*attrs: AttrsSource) -> AttrsDict:
+    """
+    Compose HTML attribute mappings from left to right.
+
+    Arguments may be mappings or arbitrarily nested lists or tuples whose terminal
+    values are mappings. Ordinary keys use the last value without changing their
+    first-seen order. All `class` and `style` values are collected and normalized,
+    so each source can contribute classes and style properties independently.
+
+    `None` contributes nothing to `class` and `style`. As with ordinary HTML
+    attributes, `None` and `False` values are omitted when the returned
+    [`AttrsDict`][AttrsDict] is rendered, while `True` renders a bare attribute.
+
+    Unlike the legacy [`merge_attributes()`][merge_attributes], this function does
+    not join collisions for ordinary attributes with spaces.
+
+    Examples:
+        ```python
+        compose_attrs(
+            [{"id": "first", "class": "button"}, [{"class": {"active": True}}]],
+            {"id": "last"},
+        )
+        # == {"id": "last", "class": "button active"}
+        ```
+
+    Raises:
+        TypeError: If a terminal value is not a mapping, or an attribute name is
+            not a string.
+        ValueError: If the source containers are cyclic, or an attribute name is
+            invalid.
+
+    """
+    result = AttrsDict()
+    classes: list[ClassValue] = []
+    styles: list[StyleValue] = []
+
+    for attrs_dict in _iter_attr_mappings(attrs):
+        for authored_key, value in attrs_dict.items():
+            key = _validate_html_attr_name(authored_key)
+
+            if key == "class":
+                # Reserve the key's first-seen position even when this source has
+                # no contribution. Empty normalized class values are retained in
+                # the mapping and omitted only while formatting.
+                result.setdefault(key, None)
+                if value is not None:
+                    classes.append(value)
+            elif key == "style":
+                result.setdefault(key, None)
+                if value is not None:
+                    styles.append(value)
+            else:
+                result[key] = value
+
+    if classes:
+        result["class"] = normalize_class(classes)
+    if styles:
+        result["style"] = normalize_style(styles)
+
+    return result
+
+
+def _iter_attr_mappings(sources: Sequence[AttrsSource]) -> Iterator[Mapping[str, Any]]:
+    # Use an explicit stack so supported nesting depth is not constrained by
+    # Python's recursion limit. Exit markers distinguish a real cycle from the
+    # same list or tuple being reused in separate branches.
+    stack: list[tuple[AttrsSource, bool]] = [(source, False) for source in reversed(sources)]
+    active_container_ids: set[int] = set()
+
+    while stack:
+        source, is_exit = stack.pop()
+        if is_exit:
+            active_container_ids.remove(id(source))
+            continue
+
+        if isinstance(source, Mapping):
+            yield source
+            continue
+
+        if not isinstance(source, (list, tuple)):
+            msg = (
+                "compose_attrs() arguments must be a mapping or a nested list or tuple of mappings; "
+                f"got {type(source).__name__}"
+            )
+            raise TypeError(msg)
+
+        source_id = id(source)
+        if source_id in active_container_ids:
+            raise ValueError("compose_attrs() source containers cannot contain a cycle")
+
+        active_container_ids.add(source_id)
+        stack.append((source, True))
+        stack.extend((item, False) for item in reversed(source))
+
+
 def format_attributes(attributes: Mapping[str, Any]) -> str:
     """
-    Format a dict of attributes into an HTML attributes string.
+    Format a mapping of attributes into an HTML attributes string.
+
+    Attribute names must be strings and valid HTML attribute names. `class`
+    and `style` accept structured values and are normalized before rendering.
+    Empty normalized `class` and `style` values are omitted.
 
     Read more about [HTML attributes](../concepts/fundamentals/html_attributes.md).
 
@@ -111,6 +296,19 @@ def format_attributes(attributes: Mapping[str, Any]) -> str:
     attr_list = []
 
     for key, value in attributes.items():
+        key = _validate_html_attr_name(key)  # noqa: PLW2901
+
+        if key == "class" and value is not None:
+            if not isinstance(value, str):
+                value = normalize_class(value)  # noqa: PLW2901
+            if not value:
+                continue
+        elif key == "style" and value is not None:
+            if not isinstance(value, str):
+                value = normalize_style(value)  # noqa: PLW2901
+            if not value:
+                continue
+
         if value is None or value is False:
             continue
         if value is True:
@@ -119,6 +317,34 @@ def format_attributes(attributes: Mapping[str, Any]) -> str:
             attr_list.append(format_html('{}="{}"', key, value))
 
     return mark_safe(SafeString(" ").join(attr_list))
+
+
+@lru_cache(maxsize=512)
+def _is_valid_exact_html_attr_name(name: str) -> bool:
+    return bool(name) and not any(char in _INVALID_HTML_ATTR_NAME_CHARS for char in name) and "{#" not in name
+
+
+def _validate_html_attr_name(name: Any) -> str:
+    if not isinstance(name, str):
+        msg = f"HTML attributes must use string attribute names, got {type(name).__name__} key {name!r}."
+        raise TypeError(msg)
+
+    # Avoid retaining arbitrary string subclasses or invoking their custom hash
+    # and equality implementations in the shared cache.
+    is_valid = (
+        _is_valid_exact_html_attr_name(name)
+        if type(name) is str
+        else bool(name) and not any(char in _INVALID_HTML_ATTR_NAME_CHARS for char in name) and "{#" not in name
+    )
+    if not is_valid:
+        msg = (
+            f"HTML attributes contain invalid HTML attribute name {name!r}. Attribute names must be non-empty and "
+            "cannot contain whitespace, '=', '/', '>', '<', or the template-comment opener '{#'."
+        )
+        raise ValueError(msg)
+    # Drop any custom behavior from a str subclass before using the name in
+    # escaping and formatting operations.
+    return name if type(name) is str else str.__str__(name)
 
 
 # TODO_V1 - Remove in v1, keep only `format_attributes` going forward

--- a/src/django_components/attributes.py
+++ b/src/django_components/attributes.py
@@ -96,21 +96,43 @@ class HtmlAttrsNode(BaseNode):
 
 class AttrsDict(dict[str, Any]):
     """
-    A dictionary of HTML attributes that serializes to attribute markup.
+    Reuse composed HTML attributes as both a dictionary and rendered markup.
 
-    `AttrsDict` has normal dictionary behavior for indexing, iteration, equality,
-    component inputs, and mapping unpacking. Calling `str()` on it formats and
-    escapes its items as HTML attributes, so the same value can also be rendered
-    directly in a template.
+    You will usually create an `AttrsDict` with [`compose_attrs()`][compose_attrs]
+    in Python or the [`{% attrs %}`][attrs] template tag. Use it like a regular
+    dictionary when passing attributes to a component, reading values, or unpacking
+    keyword arguments:
 
-    Create instances with [`compose_attrs()`][compose_attrs] or the
-    [`{% attrs %}`][attrs] template tag.
+    ```python
+    attrs = compose_attrs(
+        {"id": "save", "class": "button"},
+        {"class": {"active": True}},
+    )
 
-    `AttrsDict` deliberately does not implement Django's trusted-markup protocol.
-    If it is used as an attribute value, its serialized form is escaped for that
-    surrounding context.
+    attrs["id"]
+    # "save"
+
+    str(attrs)
+    # 'id="save" class="button active"'
+    ```
+
+    In a component template, pass the native dictionary by using `{% attrs %}` as
+    the only node in a quoted input:
+
+    ```django
+    {% component "table" table_attrs="{% attrs base_attrs local_attrs %}" / %}
+    ```
+
+    Unlike `{% html_attrs %}`, these APIs produce a reusable native dictionary in
+    addition to rendering attributes. `AttrsDict`,
+    [`compose_attrs()`][compose_attrs], and `{% attrs %}` supersede
+    `{% html_attrs %}` for attribute composition. Prefer the new APIs in new code;
+    `{% html_attrs %}` remains supported for backward compatibility.
     """
 
+    # Do not implement Django's __html__ trusted-markup protocol here. The
+    # standalone tag marks its already-escaped output safe, while an AttrsDict
+    # reused as an attribute value must still be escaped for that outer context.
     def __str__(self) -> str:
         return str(format_attributes(self))
 
@@ -141,6 +163,10 @@ class AttrsNode(BaseNode):
 
     Any surrounding text or template nodes cause the result to be serialized to
     an escaped, space-delimited attribute string.
+
+    This tag supersedes `{% html_attrs %}` for attribute composition. Prefer
+    `{% attrs %}` in new code; `{% html_attrs %}` remains supported for backward
+    compatibility.
 
     See [HTML attributes](../concepts/fundamentals/html_attributes.md) for details.
     """
@@ -329,22 +355,31 @@ def _validate_html_attr_name(name: Any) -> str:
         msg = f"HTML attributes must use string attribute names, got {type(name).__name__} key {name!r}."
         raise TypeError(msg)
 
-    # Avoid retaining arbitrary string subclasses or invoking their custom hash
-    # and equality implementations in the shared cache.
-    is_valid = (
-        _is_valid_exact_html_attr_name(name)
-        if type(name) is str
-        else bool(name) and not any(char in _INVALID_HTML_ATTR_NAME_CHARS for char in name) and "{#" not in name
-    )
-    if not is_valid:
+    # Convert subclasses to an exact string without invoking custom __str__
+    # behavior, and never retain arbitrary subclasses in the shared cache.
+    exact_name = name if type(name) is str else str.__str__(name)
+    if not _is_valid_exact_html_attr_name(exact_name):
         msg = (
-            f"HTML attributes contain invalid HTML attribute name {name!r}. Attribute names must be non-empty and "
-            "cannot contain whitespace, '=', '/', '>', '<', or the template-comment opener '{#'."
+            f"HTML attributes contain invalid HTML attribute name {exact_name!r}. Attribute names must be non-empty "
+            "and cannot contain whitespace, '=', '/', '>', '<', or the template-comment opener '{#'."
         )
         raise ValueError(msg)
-    # Drop any custom behavior from a str subclass before using the name in
-    # escaping and formatting operations.
-    return name if type(name) is str else str.__str__(name)
+
+    # A str subclass can customize __str__ or Django's __html__ trusted-markup
+    # protocol. Reject a name whose formatted representation differs from its
+    # actual string value instead of silently discarding or rendering that payload.
+    if type(name) is not str:
+        rendered_name = str(conditional_escape(name))
+        expected_name = str(conditional_escape(exact_name))
+        if rendered_name != expected_name:
+            msg = (
+                f"HTML attributes contain invalid HTML attribute name {rendered_name!r}. Attribute name objects must "
+                "render exactly as their string value and cannot contain whitespace, '=', '/', '>', '<', or the "
+                "template-comment opener '{#'."
+            )
+            raise ValueError(msg)
+
+    return exact_name
 
 
 # TODO_V1 - Remove in v1, keep only `format_attributes` going forward

--- a/src/django_components/library.py
+++ b/src/django_components/library.py
@@ -35,6 +35,7 @@ class TagProtectedError(Exception):
 
 
 PROTECTED_TAGS = [
+    "attrs",
     "component_css_dependencies",
     "component_js_dependencies",
     "fill",

--- a/src/django_components/templatetags/component_tags.py
+++ b/src/django_components/templatetags/component_tags.py
@@ -1,6 +1,6 @@
 import django.template
 
-from django_components.attributes import HtmlAttrsNode
+from django_components.attributes import AttrsNode, HtmlAttrsNode
 from django_components.cache_tag import do_djc_cache
 from django_components.component import ComponentNode
 from django_components.dependencies import ComponentCssDependenciesNode, ComponentJsDependenciesNode
@@ -20,6 +20,7 @@ register = django.template.Library()
 # NOTE: The docs-site reference generator (`docs_site/apps/docs/reference/`) actually
 #   searches this file for all `Node` classes and uses them to generate the documentation.
 #   The docstring on the Node classes is used as the tag's documentation.
+AttrsNode.register(register)
 ComponentNode.register(register)
 ComponentCssDependenciesNode.register(register)
 ComponentJsDependenciesNode.register(register)
@@ -36,6 +37,7 @@ register.tag("cache", do_djc_cache)
 # For an intuitive use via Python imports, the tags are aliased to the function name.
 # E.g. so if the tag name is `slot`, one can also do:
 # `from django_components.templatetags.component_tags import slot`
+attrs = AttrsNode.parse
 component = ComponentNode.parse
 component_css_dependencies = ComponentCssDependenciesNode.parse
 component_js_dependencies = ComponentJsDependenciesNode.parse
@@ -46,6 +48,7 @@ slot = SlotNode.parse
 
 
 __all__ = [
+    "attrs",
     "component",
     "component_css_dependencies",
     "component_js_dependencies",

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,11 +1,14 @@
+import json
 import re
+from types import MappingProxyType
+from typing import Any
 
 import pytest
 from django.template import Context, Template, TemplateSyntaxError
 from django.utils.safestring import SafeString, mark_safe
 from pytest_django.asserts import assertHTMLEqual
 
-from django_components import Component, register, types
+from django_components import AttrsDict, Component, compose_attrs, register, types
 from django_components.attributes import format_attributes, merge_attributes, parse_string_style
 from django_components.testing import djc_test
 
@@ -42,6 +45,278 @@ class TestFormatAttributes:
 
     def test_attribute_with_true_value(self):
         assert format_attributes({"required": True}) == "required"
+
+    def test_normalizes_structured_class_and_style(self):
+        assert (
+            format_attributes(
+                {
+                    "class": ["button", {"active": True}],
+                    "style": ["color: red;", {"color": "blue"}],
+                },
+            )
+            == 'class="button active" style="color: blue;"'
+        )
+
+    def test_omits_empty_structured_class_and_style(self):
+        assert format_attributes({"class": {"hidden": False}, "style": {"color": False}}) == ""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "",
+            "bad name",
+            "bad\tname",
+            "bad\nname",
+            "bad\rname",
+            "bad=name",
+            "bad/name",
+            "bad>name",
+            "bad<name",
+            "bad{#name",
+        ],
+    )
+    def test_rejects_invalid_attribute_name(self, name):
+        with pytest.raises(ValueError, match="invalid HTML attribute name"):
+            format_attributes({name: "value"})
+
+    def test_rejects_non_string_attribute_name(self):
+        with pytest.raises(TypeError, match="must use string attribute names"):
+            format_attributes({1: "value"})  # type: ignore[dict-item]
+
+    def test_strips_custom_markup_behavior_from_attribute_name(self):
+        class UnsafeName(str):
+            __slots__ = ()
+
+            def __html__(self):
+                return 'title onmouseover="unsafe"'
+
+        assert format_attributes({UnsafeName("title"): "safe"}) == 'title="safe"'
+
+
+@djc_test
+class TestComposeAttrs:
+    def test_returns_attrs_dict(self):
+        result = compose_attrs({"id": "one"})
+
+        assert isinstance(result, AttrsDict)
+        assert isinstance(result, dict)
+        assert result == {"id": "one"}
+
+    def test_flattens_nested_sources_at_any_depth(self):
+        source = {"id": "first", "class": "base"}
+        nested: Any = {"title": "deep"}
+        for _ in range(1_100):
+            nested = [nested]
+
+        result = compose_attrs([source, [[{"class": "active"}]], nested], {"id": "last"})
+
+        assert result == {
+            "id": "last",
+            "class": "base active",
+            "title": "deep",
+        }
+
+    def test_accepts_nested_tuples(self):
+        result = compose_attrs(({"id": "one"}, ({"title": "two"},)), {"role": "button"})
+
+        assert result == {"id": "one", "title": "two", "role": "button"}
+
+    def test_accepts_non_dict_mapping_leaves(self):
+        result = compose_attrs([MappingProxyType({"id": "one"})])
+
+        assert result == {"id": "one"}
+
+    def test_ordinary_keys_use_last_value(self):
+        result = compose_attrs(
+            {"id": "first", "disabled": True},
+            [{"id": "last", "disabled": False}],
+        )
+
+        assert result == {"id": "last", "disabled": False}
+
+    def test_merges_class_and_style(self):
+        result = compose_attrs(
+            {
+                "class": "base removable",
+                "style": "color: red; width: 10px;",
+            },
+            [
+                {
+                    "class": {"active": True, "removable": False},
+                    "style": {"color": "blue", "width": False},
+                },
+            ],
+        )
+
+        assert result == {
+            "class": "base active",
+            "style": "color: blue;",
+        }
+
+    def test_none_class_and_style_contributions_are_ignored(self):
+        result = compose_attrs(
+            {"class": "base", "style": "color: red;"},
+            {"class": None, "style": None},
+        )
+
+        assert result == {"class": "base", "style": "color: red;"}
+
+    def test_preserves_first_seen_key_order(self):
+        result = compose_attrs(
+            {"id": "first", "class": "base"},
+            {"title": "hello", "id": "last", "class": "active"},
+        )
+
+        assert list(result) == ["id", "class", "title"]
+
+    def test_does_not_mutate_sources(self):
+        first = {"class": ["base"], "id": "one"}
+        second = {"class": {"active": True}, "id": "two"}
+
+        compose_attrs(first, second)
+
+        assert first == {"class": ["base"], "id": "one"}
+        assert second == {"class": {"active": True}, "id": "two"}
+
+    def test_rejects_non_mapping_leaf(self):
+        with pytest.raises(TypeError, match="mapping or a nested list or tuple of mappings"):
+            compose_attrs([{"id": "one"}, ["not-a-mapping"]])  # type: ignore[list-item]
+
+    def test_rejects_cyclic_sources(self):
+        cyclic: list = []
+        cyclic.append(cyclic)
+
+        with pytest.raises(ValueError, match="cannot contain a cycle"):
+            compose_attrs(cyclic)
+
+    def test_allows_reusing_the_same_source_container(self):
+        shared: Any = [{"class": "shared"}]
+
+        result = compose_attrs([shared, shared])
+
+        assert result == {"class": "shared"}
+
+
+@djc_test
+class TestAttrsDict:
+    def test_stringifies_as_escaped_html_attributes(self):
+        attrs = compose_attrs({"title": "<unsafe>", "disabled": True, "hidden": False})
+
+        assert str(attrs) == 'title="&lt;unsafe&gt;" disabled'
+
+    def test_does_not_mark_itself_safe_in_an_attribute_value(self):
+        attrs = compose_attrs({"title": "hello"})
+
+        assert format_attributes({"data-attrs": attrs}) == 'data-attrs="title=&quot;hello&quot;"'
+
+    def test_retains_mapping_behavior(self):
+        attrs = compose_attrs({"id": "one", "class": "button"})
+
+        assert {**attrs} == {"id": "one", "class": "button"}
+        assert json.loads(json.dumps(attrs)) == {"id": "one", "class": "button"}
+
+
+@djc_test
+class TestAttrsTag:
+    def test_serializes_nested_sources(self):
+        template = Template(
+            """
+            {% load component_tags %}
+            <div {% attrs [first, [second]] third %}></div>
+            """,
+        )
+
+        rendered = template.render(
+            Context(
+                {
+                    "first": {"id": "first", "class": "base"},
+                    "second": {"class": "active", "title": "<unsafe>"},
+                    "third": {"id": "last", "disabled": True},
+                },
+            ),
+        )
+
+        assertHTMLEqual(
+            rendered,
+            '<div id="last" class="base active" title="&lt;unsafe&gt;" disabled></div>',
+        )
+
+    def test_passes_attrs_dict_from_exact_nested_template(self):
+        captured = {}
+
+        @register("attrs_receiver")
+        class AttrsReceiver(Component):
+            template: types.django_html = ""
+
+            def get_template_data(self, args, kwargs, slots, context):
+                captured["attrs"] = kwargs["attrs"]
+                return {}
+
+        template = Template(
+            """
+            {% load component_tags %}
+            {% component "attrs_receiver"
+                attrs="{% attrs [first, [second]] {'class': 'local'} %}"
+            / %}
+            """,
+        )
+
+        template.render(
+            Context(
+                {
+                    "first": {"id": "first", "class": "base"},
+                    "second": {"id": "last", "class": "active"},
+                },
+            ),
+        )
+
+        assert isinstance(captured["attrs"], AttrsDict)
+        assert captured["attrs"] == {"id": "last", "class": "base active local"}
+
+    def test_surrounding_text_stringifies_attrs(self):
+        captured = {}
+
+        @register("attrs_string_receiver")
+        class AttrsStringReceiver(Component):
+            template: types.django_html = ""
+
+            def get_template_data(self, args, kwargs, slots, context):
+                captured["attrs"] = kwargs["attrs"]
+                return {}
+
+        template = Template(
+            """
+            {% load component_tags %}
+            {% component "attrs_string_receiver"
+                attrs="prefix {% attrs {'title': '<unsafe>'} %}"
+            / %}
+            """,
+        )
+
+        template.render(Context({}))
+
+        assert captured["attrs"] == 'prefix title="&lt;unsafe&gt;"'
+
+    def test_serialization_error_is_annotated_in_debug_mode(self):
+        class ExplodingValue:
+            def __str__(self):
+                raise ValueError("cannot serialize")
+
+        template = Template(
+            """
+            {% load component_tags %}
+            <div {% attrs attrs %}></div>
+            """,
+        )
+        old_debug = template.engine.debug
+        template.engine.debug = True
+        try:
+            with pytest.raises(ValueError, match="cannot serialize") as exc_info:
+                template.render(Context({"attrs": {"title": ExplodingValue()}}))
+        finally:
+            template.engine.debug = old_debug
+
+        assert hasattr(exc_info.value, "template_debug")
 
 
 @djc_test

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -83,14 +83,20 @@ class TestFormatAttributes:
         with pytest.raises(TypeError, match="must use string attribute names"):
             format_attributes({1: "value"})  # type: ignore[dict-item]
 
-    def test_strips_custom_markup_behavior_from_attribute_name(self):
+    def test_rejects_custom_markup_behavior_in_attribute_name(self):
         class UnsafeName(str):
             __slots__ = ()
 
             def __html__(self):
                 return 'title onmouseover="unsafe"'
 
-        assert format_attributes({UnsafeName("title"): "safe"}) == 'title="safe"'
+        with pytest.raises(ValueError, match="invalid HTML attribute name") as exc_info:
+            format_attributes({UnsafeName("title"): "safe"})
+
+        assert 'title onmouseover="unsafe"' in str(exc_info.value)
+
+    def test_accepts_safe_string_attribute_name_with_unchanged_representation(self):
+        assert format_attributes({mark_safe("title"): "safe"}) == 'title="safe"'
 
 
 @djc_test

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -327,6 +327,7 @@ class TestProtectedTags:
     )
     def test_raises_on_overriding_our_tags(self):
         for tag in [
+            "attrs",
             "component_css_dependencies",
             "component_js_dependencies",
             "fill",

--- a/tox.ini
+++ b/tox.ini
@@ -87,6 +87,8 @@ commands =
 
 [testenv:coverage]
 deps =
+  Django>=5.2,<6.1
+  djc-core==1.3.1
   pytest-cov
   pytest-django
   pytest-asyncio


### PR DESCRIPTION
## Summary

- add `{% attrs %}`, `compose_attrs()`, and the dict-compatible `AttrsDict`
- accept mappings inside arbitrarily nested lists or tuples, with rightmost-wins ordinary attributes and composed `class` / `style` values
- preserve `AttrsDict` when `{% attrs %}` is the sole node in a nested component input, while safely serializing it in normal template output
- validate runtime HTML attribute names and reject string subclasses whose rendered representation changes the name
- supersede `{% html_attrs %}` for new attribute-composition code while retaining its existing behavior for backward compatibility
- document the template and Python APIs and update generated API/tag reference snapshots

Closes #1703

## Verification

- `uv run pytest tests/test_attributes.py tests/test_expression.py tests/test_registry.py -q` (150 passed)
- `uv run pytest --ignore=tests/test_component_css_e2e.py --ignore=tests/test_component_js_e2e.py --ignore=tests/test_dependency_manager_e2e.py --ignore=tests/test_dependency_rendering_e2e.py` (1304 passed, 6 skipped)
- `uv run mypy .` (264 files clean)
- changed Python files pass Ruff formatting and lint checks
- `cd docs_site && uv run pytest tests/test_reference.py -q` (54 passed)
- `cd docs_site && uv run python manage.py docs_build_check` (150 pages, all guards passed)

The browser E2E files require Playwright browser binaries, which are not installed in the local environment.