### PR TITLE
test: cover Django-context slot fallback

### DIFF
--- a/tests/test_templatetags_templating.py
+++ b/tests/test_templatetags_templating.py
@@ -793,6 +793,23 @@ class TestComponentNesting:
         """
         assertHTMLEqual(rendered, expected)
 
+    @djc_test(components_settings={"context_behavior": "django"})
+    def test_unfilled_slot_inside_component_fill_uses_fallback(self):
+        @register("child")
+        class Child(Component):
+            template: types.django_html = '{% slot "content" / %}'
+
+        class Parent(Component):
+            template: types.django_html = """
+                {% component "child" %}
+                    {% fill "content" %}
+                        {% slot "missing" %}fallback{% endslot %}
+                    {% endfill %}
+                {% endcomponent %}
+            """
+
+        assertHTMLEqual(Parent.render(), "fallback")
+
     @djc_test(parametrize=PARAMETRIZE_CONTEXT_BEHAVIOR)
     def test_component_nesting_deep_slot_inside_component_fill(self, components_settings):
         @register("complex_child")


### PR DESCRIPTION
(Generated by GPT 5.6 Sol)

## Summary

- add a minimal regression test for an unfilled slot nested inside a component fill
- exercise the Django-context parent-component lookup fixed in #1235
- verify that the nested slot renders its fallback content

## Tests

- `.venv/bin/pytest -q tests/test_templatetags_templating.py tests/test_templatetags_slot_fill.py`
- `.venv/bin/pytest -q -m "not e2e and not benchmark_snapshot" --ignore=tests/test_templatetags_provide.py`
- `.venv/bin/pytest -q -m "not e2e and not benchmark_snapshot" tests/test_templatetags_provide.py`
- `.venv/bin/mypy .`

Closes #1236